### PR TITLE
Fix silently-succeeding build on Analyze task failure

### DIFF
--- a/Build/build.ps1
+++ b/Build/build.ps1
@@ -16,6 +16,10 @@ try {
 
 
     Invoke-psake -buildFile "$PSScriptRoot\psakeBuild.ps1" -taskList $Task -Verbose:$VerbosePreference -parameters @{"BuildVersion" = $BuildVersion }
+
+    if (!$psake.build_success) {
+        throw "psake build failed, see output above for details."
+    }
 }
 catch {
     $PSCmdlet.ThrowTerminatingError($PSItem)

--- a/Build/psakeBuild.ps1
+++ b/Build/psakeBuild.ps1
@@ -19,7 +19,7 @@ Task Analyze {
     $Profile = @{
         Severity     = @('Error', 'Warning')
         IncludeRules = '*'
-        ExcludeRules = '*WriteHost', '*AvoidUsingEmptyCatchBlock*', '*UseShouldProcessForStateChangingFunctions*', '*AvoidOverwritingBuiltInCmdlets*', '*UseToExportFieldsInManifest*', '*UseProcessBlockForPipelineCommand*', '*ConvertToSecureStringWithPlainText*'
+        ExcludeRules = '*WriteHost', '*AvoidUsingEmptyCatchBlock*', '*UseShouldProcessForStateChangingFunctions*', '*AvoidOverwritingBuiltInCmdlets*', '*UseToExportFieldsInManifest*', '*UseProcessBlockForPipelineCommand*', '*ConvertToSecureStringWithPlainText*', '*AvoidGlobalVars*'
     }
     $saResults = Invoke-ScriptAnalyzer -Path $ModuleSource -Severity @('Error', 'Warning') -Recurse -Profile $Profile -Verbose:$false
     if ($saResults) {

--- a/OmadaWeb.PS/Private/Get-EdgeProfile.ps1
+++ b/OmadaWeb.PS/Private/Get-EdgeProfile.ps1
@@ -11,19 +11,19 @@ function Get-EdgeProfile {
             $_.Name -match "^Default$|^Profile \d+$"
         }
 
-        $ProfileInfo = foreach ($Profile in $Profiles) {
-            $PreferencesFile = Join-Path -Path $Profile.FullName -ChildPath "Preferences"
+        $ProfileInfo = foreach ($EdgeProfile in $Profiles) {
+            $PreferencesFile = Join-Path -Path $EdgeProfile.FullName -ChildPath "Preferences"
             if (Test-Path $PreferencesFile) {
 
                 $Preferences = Get-Content -Path $PreferencesFile -Raw | ConvertFrom-Json
                 [PSCustomObject]@{
-                    Folder = $Profile.Name
+                    Folder = $EdgeProfile.Name
                     Name   = $Preferences.profile.name
                 }
             }
             else {
                 [PSCustomObject]@{
-                    Folder = $Profile.Name
+                    Folder = $EdgeProfile.Name
                     Name   = "Default"
                 }
             }


### PR DESCRIPTION
## Summary
- `Invoke-psake` records task failures in `$psake.build_success` without throwing, so `Build/build.ps1`'s catch block never fired and the GitHub Actions Build step reported success despite producing no output, breaking the nightly artifact download (https://github.com/Fortigi/OmadaWeb.PS/actions/runs/28176928675). `build.ps1` now checks `$psake.build_success` explicitly and fails the build when it's false.
- Fixes the underlying PSScriptAnalyzer findings that were causing the `Analyze` task to fail: renames the loop variable in `Get-EdgeProfile.ps1` that shadowed the automatic `$Profile` variable, and excludes `AvoidGlobalVars` for the intentionally exported `$Global:OmadaWebPSCurrentBaseUrl`.

## Test plan
- [ ] Merge and re-run `nightly.yml` via `workflow_dispatch`
- [ ] Confirm the Build job's "Upload build output" step actually has files this time
- [ ] Confirm "Package and Nightly Release" succeeds end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_017Nihdq7GfRkhny6yPb1MrP)_