### PR TITLE
Require manual trigger for release.yml's publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'OmadaWeb.PS/**'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -49,6 +50,12 @@ jobs:
     name: Package and Release
     runs-on: windows-latest
     needs: build
+    # Requires the "release" GitHub Environment with required reviewers configured
+    # (Settings > Environments) for the approval gate to take effect. Until that
+    # is set up, this job-level condition is the actual gate: it only runs when
+    # someone manually triggers this workflow (Run workflow), never on a plain
+    # push to main, so publishing always needs a deliberate human action.
+    if: github.event_name == 'workflow_dispatch'
     environment: release
 
     env:


### PR DESCRIPTION
## Summary
- `environment: release` on the `release` job only blocks execution if the "release" GitHub Environment exists with required reviewers configured in repo Settings → Environments. That was never set up, so GitHub auto-created an unprotected environment on first use and the job ran straight through on the push from merging #2 (run cancelled manually after noticing it didn't pause: https://github.com/Fortigi/OmadaWeb.PS/actions/runs/28191452149).
- Added `workflow_dispatch` as a trigger and gated the `release` job on `if: github.event_name == 'workflow_dispatch'`, so publishing always requires someone to explicitly run the workflow — independent of whether the Environment protection rule is configured. `environment: release` is left in place as a second layer for once required reviewers are added.

## Still needed (manual, can't be done via available tools)
- Settings → Environments → create "release" → add required reviewer(s), so the approval prompt also shows up on manual runs.

## Test plan
- [ ] Merge, then manually run `release.yml` via `workflow_dispatch` and confirm a plain push to `main` no longer triggers the `release` job


---
_Generated by [Claude Code](https://claude.ai/code/session_017Nihdq7GfRkhny6yPb1MrP)_