### PR TITLE
Enhance release workflow with testing and WebDriver warmup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
       - 'OmadaWeb.PS/**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  checks: write
+
 jobs:
   build:
     name: Build
@@ -25,6 +29,12 @@ jobs:
         shell: pwsh
         run: ./Build/InstallModules.ps1
 
+      - name: Warm up Selenium/Edge WebDriver
+        shell: pwsh
+        run: |
+          $module = Import-Module ./OmadaWeb.PS/OmadaWeb.PS.psm1 -Force -PassThru
+          & $module { Invoke-WebEdgeDriverFramework | Out-Null }
+
       - name: Generate version number
         id: versioning
         shell: pwsh
@@ -35,10 +45,26 @@ jobs:
           "year=$($date.Year)"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           Write-Host "Version: $version"
 
-      - name: Build module
+      - name: Analyze, test and build
         shell: pwsh
         run: |
-          ./Build/build.ps1 -Task Build -BuildVersion '${{ steps.versioning.outputs.build_version }}'
+          ./Build/build.ps1 -Task TestBuildOnly -BuildVersion '${{ steps.versioning.outputs.build_version }}'
+
+      - name: Check for test results
+        id: test-results
+        if: always()
+        shell: pwsh
+        run: |
+          $exists = Test-Path 'buildoutput/TestResults.xml'
+          "exists=$exists" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always() && steps.test-results.outputs.exists == 'True'
+        with:
+          name: Pester Tests (Release)
+          path: buildoutput/TestResults.xml
+          reporter: java-junit
 
       - name: Upload build output
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
This PR enhances the GitHub Actions release workflow to include comprehensive testing, test result reporting, and WebDriver initialization to improve build reliability and visibility.

## Key Changes
- **Added workflow permissions**: Configured `contents: write` and `checks: write` permissions required for the release workflow
- **WebDriver warmup step**: Added initialization of Selenium/Edge WebDriver before the build process to prevent timeout issues during test execution
- **Enhanced build task**: Changed build task from `Build` to `TestBuildOnly` to include analysis and testing alongside the build
- **Test result detection**: Added a step to check for the existence of test results file (`buildoutput/TestResults.xml`)
- **Test reporting integration**: Integrated `dorny/test-reporter` action to publish Pester test results to GitHub, making test outcomes visible in the PR checks

## Implementation Details
- The WebDriver warmup step imports the OmadaWeb.PS module and invokes the WebEdgeDriverFramework to ensure the driver is ready before tests run
- Test result publishing is conditional and only runs if test results exist, preventing workflow failures when tests are skipped
- The test reporter uses the `java-junit` format to parse Pester XML output for GitHub integration

https://claude.ai/code/session_019svr7DZsdqZCp7cmLYMiRj