### PR TITLE
Report PR validation results against the PR head, not main

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,9 +1,25 @@
 name: PR Validation
 
+# Runs on `issue_comment`, so GITHUB_SHA / github.ref always point at the default
+# branch, never at the PR being validated. Everything that identifies the PR has to
+# come from `dispatch.outputs.head_sha` — never from the ambient github context —
+# otherwise concurrent validations of different PRs all report against main.
+run-name: >-
+  ${{ github.event_name == 'issue_comment'
+  && format('PR Validation #{0} — {1}', github.event.issue.number, github.event.issue.title)
+  || format('PR Validation — {0}', github.ref_name) }}
+
 on:
   workflow_dispatch:
   issue_comment:
     types: [created]
+
+# Keyed on the PR number so validations of *different* PRs run in parallel, while a
+# second /validate on the same PR supersedes the first instead of racing it to write
+# the commit status.
+concurrency:
+  group: pr-validation-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -129,18 +145,98 @@ jobs:
           $exists = Test-Path 'buildoutput/TestResults.xml'
           "exists=$exists" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      - name: Publish test results
-        uses: dorny/test-reporter@v1
+      # Reduce the JUnit report Pester emits to a small JSON summary. Kept compatible
+      # with Windows PowerShell 5.1, since this job runs under both shells.
+      - name: Summarize test results
         if: always() && steps.test-results.outputs.exists == 'True'
+        run: |
+          [xml]$doc = Get-Content -LiteralPath 'buildoutput/TestResults.xml' -Raw
+
+          $cases = $doc.SelectNodes('//testcase')
+          $failures = @()
+          $skipped = 0
+          foreach ($case in $cases) {
+            $failure = $case.SelectSingleNode('failure')
+            if ($null -ne $failure) {
+              $failures += [PSCustomObject]@{
+                name    = '{0}.{1}' -f $case.GetAttribute('classname'), $case.GetAttribute('name')
+                message = $failure.GetAttribute('message')
+                details = $failure.InnerText
+              }
+              continue
+            }
+            if ($null -ne $case.SelectSingleNode('skipped')) { $skipped++ }
+          }
+
+          $summary = [PSCustomObject]@{
+            total    = $cases.Count
+            failed   = $failures.Count
+            skipped  = $skipped
+            passed   = $cases.Count - $failures.Count - $skipped
+            failures = @($failures | Select-Object -First 50)
+          }
+
+          $json = $summary | ConvertTo-Json -Depth 5
+          [System.IO.File]::WriteAllText("$PWD/buildoutput/TestSummary.json", $json)
+          Write-Host "Tests: $($summary.passed) passed, $($summary.failed) failed, $($summary.skipped) skipped."
+
+      # dorny/test-reporter is deliberately not used here. It has no head-sha input and
+      # resolves the commit as `payload.pull_request?.head.sha ?? github.sha`. An
+      # issue_comment payload carries `issue.pull_request`, not `pull_request`, so it
+      # falls back to github.sha — the tip of main. Every PR's report landed on the same
+      # main commit under the same check name, so no PR showed its own results and
+      # simultaneous validations were indistinguishable. Create the check ourselves,
+      # against the PR head this run actually validated.
+      - name: Publish test results
+        if: always() && steps.test-results.outputs.exists == 'True'
+        uses: actions/github-script@v7
         with:
-          name: Pester Tests (${{ matrix.shell }})
-          path: buildoutput/TestResults.xml
-          reporter: java-junit
+          script: |
+            const fs = require('fs');
+            const raw = fs.readFileSync('buildoutput/TestSummary.json', 'utf8').replace(/^\uFEFF/, '');
+            const result = JSON.parse(raw);
+
+            // ConvertTo-Json collapses a single-element array to a bare object.
+            const failures = Array.isArray(result.failures)
+              ? result.failures
+              : (result.failures ? [result.failures] : []);
+
+            const lines = [
+              `**${result.passed} passed** · **${result.failed} failed** · **${result.skipped} skipped** (${result.total} total)`,
+              '',
+              `Validated \`${{ needs.dispatch.outputs.head_sha }}\` on \`${{ matrix.shell }}\`.`
+            ];
+            for (const failure of failures) {
+              lines.push('', `### ❌ ${failure.name}`, '', '```',
+                `${failure.message || ''}\n${failure.details || ''}`.trim(), '```');
+            }
+            if (result.failed > failures.length) {
+              lines.push('', `_… and ${result.failed - failures.length} more failures._`);
+            }
+            const summary = lines.join('\n').slice(0, 65000);
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Pester Tests (${{ matrix.shell }})',
+              head_sha: '${{ needs.dispatch.outputs.head_sha }}',
+              status: 'completed',
+              conclusion: result.failed > 0 ? 'failure' : 'success',
+              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              output: {
+                title: `${result.passed}/${result.total} passed`,
+                summary
+              }
+            });
+
+            await core.summary.addRaw(summary).write();
 
   report-status:
     name: Report status
     needs: [dispatch, validate]
-    if: always() && needs.dispatch.outputs.should_run == 'true'
+    # `!cancelled()` matters: when a newer /validate supersedes this run, the cancelled
+    # run must not overwrite the status the newer run is already writing for the same SHA.
+    if: always() && !cancelled() && needs.dispatch.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Set final commit status


### PR DESCRIPTION
## Problem

Concurrent PR validations could not be told apart, because every PR's test report was attached to the tip of `main` instead of to the PR being validated.

`PR Validation` triggers on `issue_comment`, so `GITHUB_SHA` and `github.ref` always point at the default branch. The workflow already worked around this for checkout (`ref: head_sha`) and for the commit status — but not for the test reporter.

`dorny/test-reporter` has no `head-sha` input and resolves its target commit as `payload.pull_request?.head.sha ?? github.sha`. An `issue_comment` payload carries `issue.pull_request`, **not** `pull_request`, so it fell through to `github.sha`.

Straight from run [#70](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/31753387618)'s log:

```
HEAD is now at b0398f2                                    ← PR #39's head (correct)
Check runs will be created with SHA=22951843b9cbce09...   ← main's tip (wrong)
```

Confirmed downstream: PR #39's head commit carries only `copilot-pull-request-reviewer` and `.github/dependabot.yml` check runs — no Pester checks at all, despite that run publishing results successfully.

Consequences:

- No PR ever showed its own test results.
- `main`'s tip accumulated red checks belonging to other branches.
- Runs #70 and #71 started 26 seconds apart on two different PRs and dumped four identically-named check runs onto the same commit.

## Changes

- Replace `dorny/test-reporter` with a PowerShell step that reduces Pester's JUnit output to a JSON summary, plus a `github-script` step that creates the check run against `needs.dispatch.outputs.head_sha`. The PowerShell is kept Windows PowerShell 5.1 safe since the matrix runs both shells, and the JS tolerates `ConvertTo-Json` collapsing a single-element array to a bare object.
- Add a `concurrency` group keyed on the PR number. Different PRs still validate in parallel; a second `/validate` on the same PR now supersedes the first instead of racing it to write the commit status.
- Guard `report-status` with `!cancelled()` so a superseded run cannot overwrite the status the newer run is already writing for the same SHA.
- Add `run-name` so each run is labelled with its PR number and title.

`release.yml` deliberately keeps `dorny/test-reporter` — it runs on push to `main`, where `github.sha` is the correct commit.

## Note on runs being listed against `main`

That part is expected and is not changed here. GitHub always executes `issue_comment` workflows from the default branch and labels the run with it — a deliberate security property, since otherwise a PR could edit the workflow and grant itself `checks: write` / `statuses: write`. The code under test was always the feature branch (`HEAD is now at b0398f2`). The new `run-name` makes the owning PR identifiable in the Actions list.

## Testing

Installed PowerShell 7.4 locally and ran the new summarize step against synthetic Pester JUnit XML, then piped its real output through the extracted JS with a stubbed Octokit. Verified counts, conclusion, and target SHA across all-passing, single-failure, and multi-failure fixtures, plus the BOM and array-collapse edge cases. YAML parses and `run-name` folds to a single line.

Not covered locally: the live GitHub API call and Windows PowerShell 5.1 specifically. The first `/validate` on this branch will exercise both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybkujz6WwdmQskueyyTkSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ybkujz6WwdmQskueyyTkSz)_