### PR TITLE
Stop the readiness probe from killing the integration web server

### DIFF
--- a/Tests/Integration/Start-WebServer.ps1
+++ b/Tests/Integration/Start-WebServer.ps1
@@ -146,7 +146,7 @@ catch{{
                 $ProbeStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
                 while ($ProbeStopwatch.Elapsed -lt $ProbeDeadline) {
                     if ($WebServerProcess.HasExited) {
-                        "Web server process exited with code {0} while probing" -f $WebServerProcess.ExitCode | Write-Verbose
+                        "Web server process exited while probing" | Write-Verbose
                         break
                     }
 
@@ -165,11 +165,19 @@ catch{{
                 }
 
                 $ProbeStopwatch.Stop()
-                if ($Result.StatusCode -ne 200) {
+                if ($null -eq $Result -or $Result.StatusCode -ne 200) {
                     $StdOutContent = Get-Content $StdOutLog -Raw -ErrorAction SilentlyContinue
                     $StdErrContent = Get-Content $StdErrLog -Raw -ErrorAction SilentlyContinue
                     if ($WebServerProcess.HasExited) {
-                        $ProcessState = "exited with code {0}" -f $WebServerProcess.ExitCode
+                        # ExitCode is not always available on a Start-Process -PassThru object,
+                        # even once the process has exited, so fall back to a plain statement.
+                        $ExitCode = $WebServerProcess.ExitCode
+                        if ($null -eq $ExitCode) {
+                            $ProcessState = "exited (exit code unavailable)"
+                        }
+                        else {
+                            $ProcessState = "exited with code {0}" -f $ExitCode
+                        }
                     }
                     else {
                         $ProcessState = "still running, but did not answer within {0:N0} seconds" -f $ProbeStopwatch.Elapsed.TotalSeconds

--- a/Tests/Integration/Start-WebServer.ps1
+++ b/Tests/Integration/Start-WebServer.ps1
@@ -93,15 +93,35 @@ try{{
     $Listener.Prefixes.Add($Url)
     $Listener.Start()
     Write-Host "Listening on $Url - Press Ctrl+C to stop"
-    while ($true) {{
-        $Ctx = $Listener.GetContext()
-        $Bytes = [Text.Encoding]::UTF8.GetBytes("OK")
-        $SetCookie = New-SetCookieHeader -Name $Name -Value $Value -Domain $Domain -Path $Path -ExpiresUtc $Expires -HttpOnly:$HttpOnly -Secure:$Secure -SameSite $SameSite
-        $Ctx.Response.Headers.Add("Set-Cookie", $SetCookie)
-        $Ctx.Response.StatusCode = 200
-        $Ctx.Response.OutputStream.Write($Bytes, 0, $Bytes.Length)
-        $Ctx.Response.Close()
+    while ($Listener.IsListening) {{
+        $Ctx = $null
+        try {{
+            $Ctx = $Listener.GetContext()
+            $Bytes = [Text.Encoding]::UTF8.GetBytes("OK")
+            $SetCookie = New-SetCookieHeader -Name $Name -Value $Value -Domain $Domain -Path $Path -ExpiresUtc $Expires -HttpOnly:$HttpOnly -Secure:$Secure -SameSite $SameSite
+            $Ctx.Response.Headers.Add("Set-Cookie", $SetCookie)
+            $Ctx.Response.StatusCode = 200
+            $Ctx.Response.OutputStream.Write($Bytes, 0, $Bytes.Length)
+            $Ctx.Response.Close()
         }}
+        catch {{
+            # A single client that aborted or timed out must never take the listener down.
+            # Only stop serving when the listener itself is gone.
+            if (-not $Listener.IsListening) {{
+                Write-Host "Listener stopped: $($_.Exception.Message)"
+                break
+            }}
+
+            Write-Host "Request failed, continuing to listen: $($_.Exception.Message)"
+            try {{
+                if ($null -ne $Ctx) {{
+                    $Ctx.Response.Abort()
+                }}
+            }}
+            catch {{
+            }}
+        }}
+    }}
 }}
 catch{{
     Throw
@@ -116,25 +136,46 @@ catch{{
 
                 $Arguments = "-NoLogo -NoProfile -ExecutionPolicy Unrestricted -File `"$TempScript`""
                 "Starting web server process: {0} {1}" -f (Get-Command pwsh.exe).Source, $Arguments | Write-Verbose
-                $Global:WebServerPid = (Start-Process (Get-Command pwsh.exe).Source -ArgumentList $Arguments -PassThru -NoNewWindow:$NoNewWindow.IsPresent -RedirectStandardOutput $StdOutLog -RedirectStandardError $StdErrLog).Id
+                $WebServerProcess = Start-Process (Get-Command pwsh.exe).Source -ArgumentList $Arguments -PassThru -NoNewWindow:$NoNewWindow.IsPresent -RedirectStandardOutput $StdOutLog -RedirectStandardError $StdErrLog
+                $Global:WebServerPid = $WebServerProcess.Id
                 "Process started with PID: {0}" -f $Global:WebServerPid | Write-Verbose
 
-                1..30 | ForEach-Object {
-                    try {
-                        "Test web server processes" | Write-Verbose
-                        if ($Null -eq $Result) {
-                            $Result = Invoke-WebRequest $Url  -UseBasicParsing -TimeoutSec 1
-                        }
+                # The script is dot-sourced by the test files, so never trust a leftover $Result.
+                $Result = $null
+                $ProbeDeadline = [TimeSpan]::FromSeconds(60)
+                $ProbeStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                while ($ProbeStopwatch.Elapsed -lt $ProbeDeadline) {
+                    if ($WebServerProcess.HasExited) {
+                        "Web server process exited with code {0} while probing" -f $WebServerProcess.ExitCode | Write-Verbose
+                        break
+                    }
 
+                    try {
+                        "Probing web server at {0}" -f $Url | Write-Verbose
+                        $Result = Invoke-WebRequest $Url -UseBasicParsing -TimeoutSec 5
+                        if ($Result.StatusCode -eq 200) {
+                            break
+                        }
                     }
                     catch {
-                        Start-Sleep 1
+                        "Probe failed: {0}" -f $PSItem.Exception.Message | Write-Verbose
+                        $Result = $null
+                        Start-Sleep -Seconds 1
                     }
                 }
+
+                $ProbeStopwatch.Stop()
                 if ($Result.StatusCode -ne 200) {
                     $StdOutContent = Get-Content $StdOutLog -Raw -ErrorAction SilentlyContinue
                     $StdErrContent = Get-Content $StdErrLog -Raw -ErrorAction SilentlyContinue
-                    throw ("Failed to start web server job. Process stdout:`n{0}`nProcess stderr:`n{1}" -f $StdOutContent, $StdErrContent)
+                    if ($WebServerProcess.HasExited) {
+                        $ProcessState = "exited with code {0}" -f $WebServerProcess.ExitCode
+                    }
+                    else {
+                        $ProcessState = "still running, but did not answer within {0:N0} seconds" -f $ProbeStopwatch.Elapsed.TotalSeconds
+                    }
+
+                    throw ("Failed to start web server job. Process (PID: {0}) {1}. Process stdout:`n{2}`nProcess stderr:`n{3}" -f $Global:WebServerPid, $ProcessState, $StdOutContent, $StdErrContent)
                 }
                 else {
                     "Web server job started: '{0}' (PID: {1})" -f $Url, $Global:WebServerPid | Write-Host


### PR DESCRIPTION
Fixes #45.

## Problem

`Tests/Integration/Start-WebServer.ps1` starts an `HttpListener` in a separate `pwsh.exe` process, then polls it until it answers. The probe used `Invoke-WebRequest $Url -UseBasicParsing -TimeoutSec 1`. On a cold runner the first request exceeds one second, so the **client** aborts the connection. The listener's `while ($true)` loop had no per-request error handling, so `$Ctx.Response.Close()` threw *"An operation was attempted on a nonexistent network connection"*, that reached the outer `catch { Throw }`, and **the listener process exited**.

The probe's `catch { Start-Sleep 1 }` then swallowed every subsequent failure and retried for the remaining 29 iterations against a dead process, ending in `Failed to start web server job` and failing every integration test in that container. Both shells and both integration containers were affected; which one lost was a race.

## Changes

`Tests/Integration/Start-WebServer.ps1` only.

**Listener** — each request is now handled inside its own `try`/`catch`, and the loop runs on `$Listener.IsListening` instead of `$true`. A failed request is logged and serving continues; the loop only breaks when the listener itself is gone. The half-dead context is released with a best-effort `$Ctx.Response.Abort()`.

Type-based filtering (`catch [System.Net.HttpListenerException]`) is deliberately not used: PowerShell unwraps method-invocation exceptions, so an aborted-client `Close()` and a stopped listener surface as the same type. `IsListening` is the reliable discriminator.

**Readiness probe** — the fixed `1..30` loop is replaced by a 60 second deadline (`Stopwatch`) that:

- uses `-TimeoutSec 5`, comfortably above cold-start cost on Windows PowerShell 5.1;
- `break`s immediately on `StatusCode -eq 200`;
- `break`s immediately when the listener process has exited, instead of burning 30 seconds against nothing.

The full process object from `Start-Process -PassThru` is kept so `HasExited`/`ExitCode` are available, and the failure message now reports whether the process died and with which exit code alongside the stdout/stderr it already captured. `$Result` is reset explicitly, since the script is dot-sourced by the test files and a stale value could leak in.

## Verification

**Reproduction, then fix.** A soak that starts the server, aborts a client mid-request (socket closed with `LingerOption(true, 0)` — exactly what the timed-out probe did), then issues a normal request:

| Script | Shell | Result |
| --- | --- | --- |
| unfixed (`main`) | Windows PowerShell 5.1 | **2 of 3 iterations failed** — `Unable to connect to the remote server` |
| this branch | Windows PowerShell 5.1 | 5 of 5 OK, status 200 after aborted client |
| this branch | pwsh 7.6.4 | 5 of 5 OK, status 200 after aborted client |

On this branch the listener logs the original exception and keeps serving:

```
Request failed, continuing to listen: Exception calling "Close" with "0" argument(s): "An operation was attempted on a nonexistent network connection."
```

**Generated script** — parses with 0 errors; the doubled braces in the format string expand correctly.

**Full integration suite** (`Invoke-Pester .\Tests\Integration`, pwsh): 57 passed, 26 failed — all 26 are the pre-existing WebView2 failures on this machine, and no `Failed to start web server job` anywhere. Windows PowerShell 5.1 could not run the Pester suite locally (no Pester 5 installed for 5.1 here), so the harness itself was exercised directly under 5.1, as above.

**PSScriptAnalyzer** — no new rule types; `Build/psakeBuild.ps1` scans the module source only and already excludes `AvoidUsingEmptyCatchBlock`, `AvoidGlobalVars` and `WriteHost`.

## Acceptance criteria

- [x] An aborted or timed-out client request cannot terminate the listener process
- [x] The readiness probe stops early on success and fails fast when the listener process has exited
- [x] The `powershell` (5.1) validation leg passes repeatedly on an unchanged commit — three consecutive `/validate` runs on this PR, both legs green every time (runs [32031946756](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/32031946756), [32032944130](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/32032944130), [32033726082](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/32033726082))

## Review follow-ups

Copilot flagged that `$Result` can stay `$null` when the probe times out or breaks on a dead process. Guard added in e326bac. The claimed null-property *error* does not occur (property access on `$null` returns `$null` here, and `Set-StrictMode` is not in effect for the harness — enabling it makes the pre-existing `$Global:WebServerPid` check at line 19 fail immediately), so the message was never masked, but the explicit guard states the intent.

Chasing it surfaced a real defect alongside: `Start-Process -PassThru` does not always expose `ExitCode` after the process has exited — under Windows PowerShell 5.1 it returns `$null` even after `WaitForExit`, so the new diagnostic rendered as `exited with code ` with nothing after it. Now reported as `exited (exit code unavailable)`; the captured stdout/stderr carries the real reason either way.
