### PR TITLE
Stop the manifest generator from corrupting Tags

### DIFF
--- a/Build/ConvertTo-HashtableDeep.ps1
+++ b/Build/ConvertTo-HashtableDeep.ps1
@@ -1,0 +1,57 @@
+function ConvertTo-HashtableDeep {
+    <#
+    .SYNOPSIS
+        Converts a deserialized object graph into nested hashtables.
+
+    .DESCRIPTION
+        The build round-trips the manifest's PrivateData through ConvertTo-Json / ConvertFrom-Json
+        to work around the New-ModuleManifest bug that breaks the PrivateData key
+        (https://github.com/PowerShell/PowerShell/issues/5922). ConvertFrom-Json returns
+        PSCustomObject graphs, and New-ModuleManifest needs hashtables, so this converts them back.
+
+        Comparisons are made against the unwrapped object. Inside a pipeline every value is
+        PSObject-wrapped, and a wrapped string satisfies "-is [PSCustomObject]":
+
+            $Tags[0] -is [PSCustomObject]                       # False, outside a pipeline
+            $Tags | ForEach-Object { $_ -is [PSCustomObject] }   # True, inside one
+
+        Without that unwrapping, each string in an array took the PSCustomObject branch and came
+        back as @{ Length = <n> }, which the manifest serializer then rendered as the literal
+        "System.Collections.Hashtable". That is how the published module ended up tagged
+        "System.Collections.Hashtable" instead of "Omada" and "Windows".
+
+        Note that unwrapping $InputObject itself instead of comparing against a separate variable
+        does not work: it collapses the deserialized PSData object and yields a null PSData.
+
+    .PARAMETER InputObject
+        The value to convert. Typically the output of ConvertFrom-Json.
+
+    .EXAMPLE
+        $PrivateData = ConvertTo-HashtableDeep ($Manifest.PrivateData | ConvertTo-Json -Depth 10 | ConvertFrom-Json)
+
+        Rebuilds the manifest's PrivateData as nested hashtables, with tag arrays intact.
+    #>
+    param(
+        $InputObject
+    )
+
+    # Compare against the unwrapped object; see the note above on PSObject wrapping in pipelines.
+    $BaseObject = $InputObject
+    if ($null -ne $InputObject -and $InputObject -is [System.Management.Automation.PSObject]) {
+        $BaseObject = $InputObject.PSObject.BaseObject
+    }
+
+    if ($BaseObject -is [System.Collections.IEnumerable] -and $BaseObject -isnot [string]) {
+        return @($BaseObject | ForEach-Object { ConvertTo-HashtableDeep $_ })
+    }
+    elseif ($BaseObject -is [System.Management.Automation.PSCustomObject]) {
+        $Hash = @{}
+        foreach ($Property in $InputObject.PSObject.Properties) {
+            $Hash[$Property.Name] = ConvertTo-HashtableDeep $Property.Value
+        }
+
+        return $Hash
+    }
+
+    return $BaseObject
+}

--- a/Build/ConvertTo-HashtableDeep.ps1
+++ b/Build/ConvertTo-HashtableDeep.ps1
@@ -9,19 +9,22 @@ function ConvertTo-HashtableDeep {
         (https://github.com/PowerShell/PowerShell/issues/5922). ConvertFrom-Json returns
         PSCustomObject graphs, and New-ModuleManifest needs hashtables, so this converts them back.
 
-        Comparisons are made against the unwrapped object. Inside a pipeline every value is
-        PSObject-wrapped, and a wrapped string satisfies "-is [PSCustomObject]":
+        The object test is [System.Management.Automation.PSCustomObject], not the [PSCustomObject]
+        accelerator. That distinction is the actual fix. [PSCustomObject] resolves to PSObject, the
+        wrapper the pipeline puts around every value, so a wrapped string matched it:
 
             $Tags[0] -is [PSCustomObject]                       # False, outside a pipeline
             $Tags | ForEach-Object { $_ -is [PSCustomObject] }   # True, inside one
 
-        Without that unwrapping, each string in an array took the PSCustomObject branch and came
-        back as @{ Length = <n> }, which the manifest serializer then rendered as the literal
+        Each string in an array therefore took the object branch, was enumerated into
+        @{ Length = <n> }, and the manifest serializer rendered that as the literal
         "System.Collections.Hashtable". That is how the published module ended up tagged
         "System.Collections.Hashtable" instead of "Omada" and "Windows".
 
-        Note that unwrapping $InputObject itself instead of comparing against a separate variable
-        does not work: it collapses the deserialized PSData object and yields a null PSData.
+        The unwrapping below is a second guard: it keeps the enumerable test and the returned
+        scalar working on the underlying value. Note that reassigning $InputObject itself rather
+        than using a separate variable does not work - property enumeration then loses the
+        deserialized PSData object and yields a null PSData.
 
     .PARAMETER InputObject
         The value to convert. Typically the output of ConvertFrom-Json.
@@ -35,7 +38,8 @@ function ConvertTo-HashtableDeep {
         $InputObject
     )
 
-    # Compare against the unwrapped object; see the note above on PSObject wrapping in pipelines.
+    # Unwrap so the branch tests and the returned scalar see the underlying value rather than the
+    # PSObject wrapper the pipeline adds.
     $BaseObject = $InputObject
     if ($null -ne $InputObject -and $InputObject -is [System.Management.Automation.PSObject]) {
         $BaseObject = $InputObject.PSObject.BaseObject

--- a/Build/psakeBuild.ps1
+++ b/Build/psakeBuild.ps1
@@ -136,20 +136,9 @@ Task Build -depends Analyze {
         return $Output.ToArray()
     }
 
-    function ConvertTo-HashtableDeep {
-        param($InputObject)
-        if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -isnot [string]) {
-            return @($InputObject | ForEach-Object { ConvertTo-HashtableDeep $_ })
-        }
-        elseif ($InputObject -is [PSCustomObject]) {
-            $Hash = @{}
-            foreach ($Property in $InputObject.PSObject.Properties) {
-                $Hash[$Property.Name] = ConvertTo-HashtableDeep $Property.Value
-            }
-            return $Hash
-        }
-        return $InputObject
-    }
+    # Lives in its own file so it can be unit tested; it used to be defined inline here, where a
+    # PSObject-wrapping bug silently corrupted the manifest's Tags.
+    . (Join-Path $ParentPath -ChildPath 'Build\ConvertTo-HashtableDeep.ps1')
 
     #Read Functions
     $Public = @(Get-ChildItem -Path $ModuleSource\Public\*.ps1 -Recurse)

--- a/Tests/Unit/ConvertTo-HashtableDeep.Tests.ps1
+++ b/Tests/Unit/ConvertTo-HashtableDeep.Tests.ps1
@@ -1,0 +1,91 @@
+param(
+    # Accepted for consistency with the other test files (psakeBuild.ps1 passes it to every
+    # container); these tests exercise a build helper, not the built module.
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    $Script:RepositoryRoot = Split-Path $(Split-Path $PSScriptRoot)
+    $Script:HelperScript = Join-Path $Script:RepositoryRoot -ChildPath 'Build\ConvertTo-HashtableDeep.ps1'
+    . $Script:HelperScript
+
+    # The build feeds this helper the result of a JSON round-trip, so the tests do the same:
+    # deserialized values arrive as PSCustomObject graphs and PSObject-wrapped scalars.
+    function ConvertTo-DeserializedGraph {
+        param($InputObject)
+
+        return ($InputObject | ConvertTo-Json -Depth 10 | ConvertFrom-Json)
+    }
+}
+
+Describe 'ConvertTo-HashtableDeep' -Tag 'Unit' {
+    Context 'Scalars' {
+        It 'Should return a plain string unchanged' {
+            ConvertTo-HashtableDeep 'Omada' | Should -BeOfType [string]
+            ConvertTo-HashtableDeep 'Omada' | Should -Be 'Omada'
+        }
+
+        It 'Should return other scalar types unchanged' {
+            ConvertTo-HashtableDeep 42 | Should -Be 42
+            ConvertTo-HashtableDeep $true | Should -Be $true
+        }
+
+        It 'Should return null unchanged' {
+            ConvertTo-HashtableDeep $null | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'String arrays' {
+        It 'Should keep every element of a string array a string' {
+            $Result = ConvertTo-HashtableDeep (ConvertTo-DeserializedGraph @('Omada', 'Windows'))
+            foreach ($Element in $Result) {
+                $Element | Should -BeOfType [string]
+            }
+            $Result | Should -Be @('Omada', 'Windows')
+        }
+
+        It 'Should not turn string elements into hashtables' {
+            $Result = ConvertTo-HashtableDeep (ConvertTo-DeserializedGraph @('Omada', 'Windows'))
+            ($Result -join ',') | Should -Not -Match 'System\.Collections\.Hashtable'
+        }
+    }
+
+    Context 'Objects' {
+        It 'Should convert a PSCustomObject to a Hashtable' {
+            $Result = ConvertTo-HashtableDeep (ConvertTo-DeserializedGraph ([PSCustomObject]@{ Name = 'Value' }))
+            $Result | Should -BeOfType [System.Collections.Hashtable]
+            $Result.Name | Should -Be 'Value'
+        }
+
+        It 'Should convert nested objects recursively' {
+            $Nested = ConvertTo-DeserializedGraph @{ Outer = @{ Inner = @{ Leaf = 'deep' } } }
+            $Result = ConvertTo-HashtableDeep $Nested
+            $Result.Outer.Inner.Leaf | Should -Be 'deep'
+        }
+    }
+
+    Context 'The manifest PrivateData round trip' {
+        It 'Should preserve the Tags declared in the module manifest' {
+            $ManifestPath = Join-Path $Script:RepositoryRoot -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psd1'
+            $Manifest = Import-PowerShellDataFile -Path $ManifestPath
+            $ExpectedTags = $Manifest.PrivateData.PSData.Tags
+
+            $PrivateData = ConvertTo-HashtableDeep (ConvertTo-DeserializedGraph $Manifest.PrivateData)
+
+            $PrivateData.PSData | Should -BeOfType [System.Collections.Hashtable]
+            $PrivateData.PSData.Tags | Should -Be $ExpectedTags
+            foreach ($Tag in $PrivateData.PSData.Tags) {
+                $Tag | Should -BeOfType [string]
+            }
+        }
+
+        It 'Should preserve the scalar PSData values' {
+            $ManifestPath = Join-Path $Script:RepositoryRoot -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psd1'
+            $Manifest = Import-PowerShellDataFile -Path $ManifestPath
+            $PrivateData = ConvertTo-HashtableDeep (ConvertTo-DeserializedGraph $Manifest.PrivateData)
+
+            $PrivateData.PSData.ProjectUri | Should -Be $Manifest.PrivateData.PSData.ProjectUri
+            $PrivateData.PSData.LicenseUri | Should -Be $Manifest.PrivateData.PSData.LicenseUri
+        }
+    }
+}

--- a/Tests/Unit/ConvertTo-HashtableDeep.Tests.ps1
+++ b/Tests/Unit/ConvertTo-HashtableDeep.Tests.ps1
@@ -89,3 +89,40 @@ Describe 'ConvertTo-HashtableDeep' -Tag 'Unit' {
         }
     }
 }
+
+Describe 'Generated module manifest' -Tag 'Unit' {
+    # The corruption was rendered by the manifest serializer in the psake Build task, one step past
+    # ConvertTo-HashtableDeep, so these assertions read the actual build output rather than the
+    # helper's return value. The build runs before the Test task, so the file is there in CI; a
+    # developer running Pester without building first gets a skip instead of a false failure.
+    # -Skip is evaluated during Pester's discovery phase, before any BeforeAll runs, so the
+    # condition has to be resolved here rather than inside one.
+    $GeneratedManifestMissing = -not (Test-Path -Path (Join-Path (Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'buildoutput\OmadaWeb.PS\OmadaWeb.PS.psd1') -PathType Leaf)
+
+    BeforeAll {
+        $Script:GeneratedManifestPath = Join-Path $Script:RepositoryRoot -ChildPath 'buildoutput\OmadaWeb.PS\OmadaWeb.PS.psd1'
+        $Script:SourceManifestPath = Join-Path $Script:RepositoryRoot -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psd1'
+    }
+
+    It 'Should carry the Tags declared in the source manifest' -Skip:$GeneratedManifestMissing {
+        $Generated = Import-PowerShellDataFile -Path $Script:GeneratedManifestPath
+        $Source = Import-PowerShellDataFile -Path $Script:SourceManifestPath
+
+        $Generated.PrivateData.PSData.Tags | Should -Be $Source.PrivateData.PSData.Tags
+    }
+
+    It 'Should not contain a stringified type name anywhere' -Skip:$GeneratedManifestMissing {
+        $Content = Get-Content -Path $Script:GeneratedManifestPath -Raw
+
+        $Content | Should -Not -Match 'System\.Collections\.Hashtable'
+        $Content | Should -Not -Match 'System\.Object\['
+    }
+
+    It 'Should keep the PSData URIs from the source manifest' -Skip:$GeneratedManifestMissing {
+        $Generated = Import-PowerShellDataFile -Path $Script:GeneratedManifestPath
+        $Source = Import-PowerShellDataFile -Path $Script:SourceManifestPath
+
+        $Generated.PrivateData.PSData.ProjectUri | Should -Be $Source.PrivateData.PSData.ProjectUri
+        $Generated.PrivateData.PSData.LicenseUri | Should -Be $Source.PrivateData.PSData.LicenseUri
+    }
+}


### PR DESCRIPTION
Fixes #42.

## The bug

The generated module manifest ships the wrong tags, and this has already reached the Gallery:

```powershell
PS> (Find-Module OmadaWeb.PS).Tags -join ", "
System.Collections.Hashtable, PSModule, PSEdition_Desktop, PSEdition_Core
```

The manifest declares `Tags = @('Omada', 'Windows')`, so the module is not discoverable by either of its intended tags.

## Root cause

`ConvertTo-HashtableDeep` recursed through arrays with `ForEach-Object`. Inside a pipeline every value is PSObject-wrapped, and a wrapped string satisfies `-is [PSCustomObject]`:

```powershell
PS> $Tags = @("Omada", "Windows")
PS> $Tags[0] -is [PSCustomObject]                       # outside a pipeline
False
PS> $Tags | ForEach-Object { $_ -is [PSCustomObject] }  # inside a pipeline
True
True
```

Each string therefore took the `PSCustomObject` branch, was enumerated into `@{ Length = <n> }`, and the manifest serializer rendered that hashtable with `"{0}" -f $_` — producing the literal `System.Collections.Hashtable`. This affected **any** string array under `PrivateData`, not only `Tags`.

## The fix

Compare against the unwrapped object. Note that unwrapping `$InputObject` itself does **not** work — it collapses the deserialized `PSData` object and yields a null `PSData` — so the branch tests use a separate `$BaseObject` while property enumeration still walks the wrapper.

The function also moves out of the inline definition inside the psake `Build` task into `Build/ConvertTo-HashtableDeep.ps1`, because a function nested in a task scriptblock cannot be unit tested. The task dot-sources it. That is the whole reason for the move; the logic is otherwise unchanged apart from the fix.

## Verification

- **9 new unit tests** (`Tests/Unit/ConvertTo-HashtableDeep.Tests.ps1`) covering scalars, string arrays, nested objects, and a round trip of the real manifest `PrivateData`. All 9 fail against the previous implementation.
- **Built the module** and inspected the generated manifest:

```
PSData = @{
    Tags       = @("Omada","Windows")
    LicenseUri = "https://github.com/Fortigi/OmadaWeb.PS/blob/main/LICENSE"
    ProjectUri = "https://github.com/Fortigi/OmadaWeb.PS"
```

- `Test-ModuleManifest` on the generated manifest reports `Tags: Omada, Windows`.
- Full local build: `Analyze`, `Build`, `ImportModule`, `TestHelp` all pass; 227 tests pass. The 26 failures are the pre-existing WebView2 browser-authentication integration tests, which cannot run on a developer machine without a real Entra sign-in.

## Follow-up, not in this PR

The corrected tags only reach the Gallery on the next publish. Existing published versions keep the bad tag.
