### PR TITLE
Central log-redaction layer: stop serializing credentials, tokens and cookies into verbose output

### DIFF
--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -113,10 +113,6 @@ try {
 }
 catch {}
 
-# Diagnostics only: an explicit shallow depth keeps the log readable and avoids walking deep
-# object graphs, which happens on every load because the string is built before Write-Verbose.
-"PsBoundParameters = {0}" -f ($PsBoundParameters | ConvertTo-Json -Depth 5) | Write-Verbose
-
 # Initialize script-level variables
 $Global:OmadaWebPSCurrentBaseUrl = $null
 [bool]$Script:EnvironmentSuspended = $false
@@ -310,6 +306,12 @@ foreach ($Import in @($Public + $Private)) {
 # Export all the functions
 Export-ModuleMember -Function $Public.Basename -Alias *
 #endregion
+
+# Import-Module -ArgumentList can carry an OmadaWebAuthCookie, so this goes through the redaction
+# walker like every other object that reaches the verbose stream. It has to be logged from here
+# rather than from where the parameters are processed further up: the walker is one of the functions
+# the loop above dot-sources, so it does not exist yet at that point.
+"PsBoundParameters = {0}" -f (ConvertTo-RedactedLogString -InputObject $PsBoundParameters) | Write-Verbose
 
 "Validate version" | Write-Verbose
 try {

--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -114,6 +114,20 @@ try {
 catch {}
 
 # Initialize script-level variables
+# Redaction constants for ConvertTo-RedactedLogString. They live here, initialized once per import,
+# because the walker recurses once per property of every object logged and builds its string on every
+# request whether or not -Verbose is on - rebuilding a 16-element array per recursive call is exactly
+# the kind of cost that does not belong on that path. The patterns are matched as case-insensitive
+# substrings, so composites such as X-CSRF-Token, RefreshToken and SessionCookie are covered too.
+$Script:RedactedLogToken = "***REDACTED***"
+$Script:SensitiveLogNamePatterns = @(
+    "authorization", "cookie", "credential", "password", "pwd", "secret", "token",
+    "apikey", "api_key", "clientsecret", "sessionkey", "bearer", "csrf", "assertion",
+    "privatekey", "connectionstring"
+)
+# Used only inside an object that pairs a Name member with a Value member - a cookie or a header,
+# where the value is the secret. Precomputed for the same reason as the list above.
+$Script:SensitiveLogNamePatternsWithValue = $Script:SensitiveLogNamePatterns + "value"
 $Global:OmadaWebPSCurrentBaseUrl = $null
 [bool]$Script:EnvironmentSuspended = $false
 # The suspended status is cached in $Script:EnvironmentSuspended for the current base URL only

--- a/OmadaWeb.PS/Private/ConvertTo-RedactedLogString.ps1
+++ b/OmadaWeb.PS/Private/ConvertTo-RedactedLogString.ps1
@@ -37,8 +37,10 @@ function ConvertTo-RedactedLogString {
         return ($Redacted | ConvertTo-Json -Depth 20 -WarningAction SilentlyContinue)
     }
     catch {
-        # Failing open would leak the very thing this function exists to hide.
-        return "<redaction failed: {0}>" -f $_.Exception.Message
+        # Failing open would leak the very thing this function exists to hide - and that includes the
+        # exception message, which for a failure mid-walk can quote the value being walked. The
+        # exception type is enough to debug this from and carries nothing.
+        return "<redaction failed: {0}>" -f $_.Exception.GetType().Name
     }
 }
 
@@ -98,6 +100,11 @@ function ConvertTo-RedactedLogValue {
         return "CookieCollection(Count={0})" -f $Value.Count
     }
 
+    if ($Value -is [System.Net.Cookie]) {
+        # A cookie's value IS the session secret. Its name and domain are what you need to see.
+        return "Cookie(Name={0}, Domain={1})" -f $Value.Name, $Value.Domain
+    }
+
     if ($Value -is [Microsoft.PowerShell.Commands.WebRequestSession]) {
         # $BoundParams.WebSession carries the authentication cookie, and the member name "WebSession"
         # matches none of the patterns above - so this needs a type rule rather than a name rule.
@@ -154,9 +161,19 @@ function ConvertTo-RedactedLogValue {
     $Visited.Add($Value)
 
     if ($Value -is [System.Collections.IDictionary]) {
+        # See the note further down on name/value pairs - a cookie or header can arrive as a
+        # hashtable just as easily as an object, and the same reasoning applies.
+        $Keys = @($Value.Keys)
+        $KeyNames = @($Keys | ForEach-Object { [string]$_ })
+        $DictionaryPatterns = $SensitiveNamePatterns
+        # -contains is case-insensitive for strings, so this catches name/value as well as Name/Value.
+        if ($KeyNames -contains "name" -and $KeyNames -contains "value") {
+            $DictionaryPatterns = $SensitiveNamePatterns + "value"
+        }
+
         $Result = [ordered]@{}
-        foreach ($Key in @($Value.Keys)) {
-            $Result[[string]$Key] = Get-RedactedMemberValue -Name ([string]$Key) -MemberValue $Value[$Key] -Depth $Depth -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues -SensitiveNamePatterns $SensitiveNamePatterns -RedactedToken $RedactedToken
+        foreach ($Key in $Keys) {
+            $Result[[string]$Key] = Get-RedactedMemberValue -Name ([string]$Key) -MemberValue $Value[$Key] -Depth $Depth -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues -SensitiveNamePatterns $DictionaryPatterns -RedactedToken $RedactedToken
         }
 
         return $Result
@@ -183,12 +200,23 @@ function ConvertTo-RedactedLogValue {
         return $Result
     }
 
+    # An object exposing both a Name and a Value member is a name/value pair, and in this module that
+    # is almost always a cookie or a header: $SessionContext.AuthCookie is a PSCustomObject with
+    # lowercase name/value/domain members (see Get-WebView2Cookie), so no type rule reaches it and
+    # "value" names nothing secret on its own. Within such an object, though, the value is the secret -
+    # so mask it there and nowhere else. The rest of the members (domain, path, expiry, httpOnly) are
+    # the diagnostics worth keeping.
+    $MemberSensitiveNamePatterns = $SensitiveNamePatterns
+    if ($null -ne $Value.PSObject.Properties['Name'] -and $null -ne $Value.PSObject.Properties['Value']) {
+        $MemberSensitiveNamePatterns = $SensitiveNamePatterns + "value"
+    }
+
     # Anything else: walk its properties, tolerating members that throw when read.
     $Result = [ordered]@{}
     try {
         foreach ($Property in $Value.PSObject.Properties) {
             try {
-                $Result[$Property.Name] = Get-RedactedMemberValue -Name $Property.Name -MemberValue $Property.Value -Depth $Depth -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues -SensitiveNamePatterns $SensitiveNamePatterns -RedactedToken $RedactedToken
+                $Result[$Property.Name] = Get-RedactedMemberValue -Name $Property.Name -MemberValue $Property.Value -Depth $Depth -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues -SensitiveNamePatterns $MemberSensitiveNamePatterns -RedactedToken $RedactedToken
             }
             catch {
                 $Result[$Property.Name] = "<unreadable>"

--- a/OmadaWeb.PS/Private/ConvertTo-RedactedLogString.ps1
+++ b/OmadaWeb.PS/Private/ConvertTo-RedactedLogString.ps1
@@ -60,15 +60,12 @@ function ConvertTo-RedactedLogValue {
         [bool]$MaskValues
     )
 
-    $RedactedToken = "***REDACTED***"
-
-    # Property names that identify secret material. Matched as a case-insensitive substring so
-    # composites such as X-CSRF-Token, RefreshToken and SessionCookie are covered too.
-    $SensitiveNamePatterns = @(
-        "authorization", "cookie", "credential", "password", "pwd", "secret", "token",
-        "apikey", "api_key", "clientsecret", "sessionkey", "bearer", "csrf", "assertion",
-        "privatekey", "connectionstring"
-    )
+    # Read from module scope rather than rebuilt here: this function recurses once per property of
+    # every object logged, and the string it feeds is built on every request whether or not -Verbose
+    # is on, so a per-call array allocation is not free. The pattern list and its name/value variant
+    # are defined in OmadaWeb.PS.psm1 alongside the module's other script state.
+    $RedactedToken = $Script:RedactedLogToken
+    $SensitiveNamePatterns = $Script:SensitiveLogNamePatterns
 
     if ($null -eq $Value) {
         return $null
@@ -168,7 +165,7 @@ function ConvertTo-RedactedLogValue {
         $DictionaryPatterns = $SensitiveNamePatterns
         # -contains is case-insensitive for strings, so this catches name/value as well as Name/Value.
         if ($KeyNames -contains "name" -and $KeyNames -contains "value") {
-            $DictionaryPatterns = $SensitiveNamePatterns + "value"
+            $DictionaryPatterns = $Script:SensitiveLogNamePatternsWithValue
         }
 
         $Result = [ordered]@{}
@@ -208,7 +205,7 @@ function ConvertTo-RedactedLogValue {
     # the diagnostics worth keeping.
     $MemberSensitiveNamePatterns = $SensitiveNamePatterns
     if ($null -ne $Value.PSObject.Properties['Name'] -and $null -ne $Value.PSObject.Properties['Value']) {
-        $MemberSensitiveNamePatterns = $SensitiveNamePatterns + "value"
+        $MemberSensitiveNamePatterns = $Script:SensitiveLogNamePatternsWithValue
     }
 
     # Anything else: walk its properties, tolerating members that throw when read.

--- a/OmadaWeb.PS/Private/ConvertTo-RedactedLogString.ps1
+++ b/OmadaWeb.PS/Private/ConvertTo-RedactedLogString.ps1
@@ -1,0 +1,248 @@
+function ConvertTo-RedactedLogString {
+    <#
+    .SYNOPSIS
+        Serializes an object to JSON for the verbose stream with all secret material removed.
+
+    .DESCRIPTION
+        The single path by which request parameters, sessions, cookies and configuration objects are
+        allowed to reach the verbose stream. Sensitive properties are masked by name, credentials and
+        secure strings by type, and bulk data is reduced to a shape summary.
+
+        This matters beyond -Verbose on a console: consumers of this module capture the verbose
+        stream into their own logs. OmadaSqlTroubleshooter, for instance, has an "Export Log File"
+        button, so anything written here can end up in a file a user attaches to a support ticket.
+
+        NOTE: none of the functions in this file may log anything themselves - every logging call
+        site in the module routes through this one, so writing to the verbose stream from here would
+        recurse.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+        [AllowNull()]
+        $InputObject,
+        [int]$MaxDepth = 6,
+        [int]$MaxStringLength = 512,
+        # Keep keys and value shapes but no values at all. Used where the object being logged IS a
+        # request body, rather than a parameter set containing one.
+        [switch]$ShapeOnly
+    )
+
+    try {
+        $Redacted = ConvertTo-RedactedLogValue -Value $InputObject -Depth 0 -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited ([System.Collections.Generic.List[object]]::new()) -MaskValues ([bool]$ShapeOnly)
+        if ($null -eq $Redacted) {
+            return "null"
+        }
+
+        return ($Redacted | ConvertTo-Json -Depth 20 -WarningAction SilentlyContinue)
+    }
+    catch {
+        # Failing open would leak the very thing this function exists to hide.
+        return "<redaction failed: {0}>" -f $_.Exception.Message
+    }
+}
+
+function ConvertTo-RedactedLogValue {
+    <#
+    .SYNOPSIS
+        Recursive walker behind ConvertTo-RedactedLogString. Returns a redacted clone, not a string.
+    #>
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Value,
+        [int]$Depth,
+        [int]$MaxDepth,
+        [int]$MaxStringLength,
+        [System.Collections.Generic.List[object]]$Visited,
+        [bool]$MaskValues
+    )
+
+    $RedactedToken = "***REDACTED***"
+
+    # Property names that identify secret material. Matched as a case-insensitive substring so
+    # composites such as X-CSRF-Token, RefreshToken and SessionCookie are covered too.
+    $SensitiveNamePatterns = @(
+        "authorization", "cookie", "credential", "password", "pwd", "secret", "token",
+        "apikey", "api_key", "clientsecret", "sessionkey", "bearer", "csrf", "assertion",
+        "privatekey", "connectionstring"
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    # Type rules first - these hold regardless of the property name the value arrived under.
+    if ($Value -is [System.Security.SecureString]) {
+        return $RedactedToken
+    }
+
+    if ($Value -is [System.Management.Automation.PSCredential]) {
+        # The user name is diagnostic and not secret; the password never leaves the SecureString.
+        return "PSCredential(UserName={0})" -f $Value.UserName
+    }
+
+    if ($Value -is [System.Net.NetworkCredential]) {
+        return "NetworkCredential(UserName={0})" -f $Value.UserName
+    }
+
+    if ($Value -is [byte[]]) {
+        return "Byte[{0}]" -f $Value.Length
+    }
+
+    if ($Value -is [System.Net.CookieContainer]) {
+        return "CookieContainer(Count={0})" -f $Value.Count
+    }
+
+    if ($Value -is [System.Net.CookieCollection]) {
+        return "CookieCollection(Count={0})" -f $Value.Count
+    }
+
+    if ($Value -is [Microsoft.PowerShell.Commands.WebRequestSession]) {
+        # $BoundParams.WebSession carries the authentication cookie, and the member name "WebSession"
+        # matches none of the patterns above - so this needs a type rule rather than a name rule.
+        # The cookie count and user agent are the diagnostic parts; nothing else here is.
+        return "WebRequestSession(Cookies={0}, UserAgent={1})" -f $Value.Cookies.Count, $Value.UserAgent
+    }
+
+    if ($Value -is [string]) {
+        if ($MaskValues) {
+            return "String({0})" -f $Value.Length
+        }
+
+        # The name rules above only fire on members whose name gives the secret away. A token that
+        # arrives under a name nobody anticipated is still a token, so every string value that is
+        # about to be logged also passes the regex net.
+        $Value = Protect-LogMessage -Message $Value
+
+        if ($Value.Length -gt $MaxStringLength) {
+            return "{0}...(truncated, {1} chars)" -f $Value.Substring(0, $MaxStringLength), $Value.Length
+        }
+
+        return $Value
+    }
+
+    if ($Value -is [uri]) {
+        if ($MaskValues) {
+            return $Value.GetType().Name
+        }
+
+        # Serialized as its string form rather than walked: a Uri's property graph is large and
+        # uninteresting in a log, and an OAuth2/login redirect can carry a token in its query
+        # string - which the regex net masks, but only on text.
+        return (Protect-LogMessage -Message $Value.AbsoluteUri)
+    }
+
+    if ($Value -is [ValueType] -or $Value -is [System.Management.Automation.SwitchParameter]) {
+        if ($MaskValues) {
+            return $Value.GetType().Name
+        }
+
+        return $Value
+    }
+
+    if ($Depth -ge $MaxDepth) {
+        return "<max depth {0} reached: {1}>" -f $MaxDepth, $Value.GetType().Name
+    }
+
+    # Live session and response objects are cyclic - without this the walker never returns.
+    foreach ($Seen in $Visited) {
+        if ([object]::ReferenceEquals($Seen, $Value)) {
+            return "<circular reference: {0}>" -f $Value.GetType().Name
+        }
+    }
+    $Visited.Add($Value)
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        $Result = [ordered]@{}
+        foreach ($Key in @($Value.Keys)) {
+            $Result[[string]$Key] = Get-RedactedMemberValue -Name ([string]$Key) -MemberValue $Value[$Key] -Depth $Depth -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues -SensitiveNamePatterns $SensitiveNamePatterns -RedactedToken $RedactedToken
+        }
+
+        return $Result
+    }
+
+    if ($Value -isnot [string] -and $Value -is [System.Collections.IEnumerable]) {
+        $Items = @($Value)
+        $ItemCount = ($Items | Measure-Object).Count
+        if ($ItemCount -gt 3) {
+            # Bulk data - response collections, cookie lists. Log the shape, never the contents.
+            $ElementType = "Object"
+            if ($null -ne $Items[0]) {
+                $ElementType = $Items[0].GetType().Name
+            }
+
+            return "Array[{0}] of {1}" -f $ItemCount, $ElementType
+        }
+
+        $Result = @()
+        foreach ($Item in $Items) {
+            $Result += , (ConvertTo-RedactedLogValue -Value $Item -Depth ($Depth + 1) -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues)
+        }
+
+        return $Result
+    }
+
+    # Anything else: walk its properties, tolerating members that throw when read.
+    $Result = [ordered]@{}
+    try {
+        foreach ($Property in $Value.PSObject.Properties) {
+            try {
+                $Result[$Property.Name] = Get-RedactedMemberValue -Name $Property.Name -MemberValue $Property.Value -Depth $Depth -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues -SensitiveNamePatterns $SensitiveNamePatterns -RedactedToken $RedactedToken
+            }
+            catch {
+                $Result[$Property.Name] = "<unreadable>"
+            }
+        }
+    }
+    catch {
+        return "<{0}>" -f $Value.GetType().Name
+    }
+
+    if ($Result.Count -le 0) {
+        return $Value.ToString()
+    }
+
+    return $Result
+}
+
+function Get-RedactedMemberValue {
+    <#
+    .SYNOPSIS
+        Applies the name-based rules for a single member, then hands off to the recursive walker.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$Name,
+        [AllowNull()]
+        $MemberValue,
+        [int]$Depth,
+        [int]$MaxDepth,
+        [int]$MaxStringLength,
+        [System.Collections.Generic.List[object]]$Visited,
+        [bool]$MaskValues,
+        [string[]]$SensitiveNamePatterns,
+        [string]$RedactedToken
+    )
+
+    # Credential objects are handled by the type rules in the walker, which keep the user name -
+    # knowing which account authenticated is the first thing you need for a 401 - while the password
+    # stays in its SecureString. Applying the name rule here instead would throw that away for no gain.
+    $HandledByTypeRule = $MemberValue -is [System.Management.Automation.PSCredential] -or $MemberValue -is [System.Net.NetworkCredential] -or $MemberValue -is [System.Security.SecureString]
+
+    if (-not $HandledByTypeRule) {
+        foreach ($Pattern in $SensitiveNamePatterns) {
+            if ($Name -like "*$Pattern*") {
+                return $RedactedToken
+            }
+        }
+    }
+
+    # Request bodies keep their keys and value shapes - enough to tell what was sent - but no values.
+    $ChildMaskValues = $MaskValues
+    if ($Name -eq "Body") {
+        $ChildMaskValues = $true
+    }
+
+    return ConvertTo-RedactedLogValue -Value $MemberValue -Depth ($Depth + 1) -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $ChildMaskValues
+}

--- a/OmadaWeb.PS/Private/Get-WebView2Cookie.ps1
+++ b/OmadaWeb.PS/Private/Get-WebView2Cookie.ps1
@@ -4,9 +4,10 @@ function Get-WebView2Cookie {
     try {
 
         if ( $Script:LastCheckedHost -ne $Script:WebView2.Source.Host) {
-            # Diagnostics only: a shallow depth is enough for the Uri and avoids walking the
-            # WebView2 object graph.
-            "{0} - {1}" -f $MyInvocation.MyCommand, ($Script:WebView2.Source | ConvertTo-Json -Depth 5) | Write-Verbose
+            # Diagnostics only: a login redirect URI can carry a token in its query string, so this
+            # goes through the redaction walker. A shallow depth is enough for the Uri and avoids
+            # walking the WebView2 object graph.
+            "{0} - {1}" -f $MyInvocation.MyCommand, (ConvertTo-RedactedLogString -InputObject $Script:WebView2.Source -MaxDepth 3) | Write-Verbose
         }
 
         if ($null -eq $Script:WebView2.CoreWebView2.CookieManager) {

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -96,9 +96,10 @@ function Invoke-OmadaRequest {
                 else {
                     try {
                         $SessionContext.AuthCookie = (Import-Clixml $CookiePath).OmadaWebAuthCookie
-                        # Diagnostics only: depth is kept shallow on purpose so a verbose log does not
-                        # expand the whole cookie object graph.
-                        "{0} - Cookie:`r{1}" -f $MyInvocation.MyCommand, ($SessionContext.AuthCookie | ConvertTo-Json -Depth 3) | Write-Verbose
+                        # Diagnostics only: the cookie's own value is the session secret, so this goes
+                        # through the redaction walker. Depth is kept shallow on purpose so a verbose
+                        # log does not expand the whole cookie object graph.
+                        "{0} - Cookie:`r{1}" -f $MyInvocation.MyCommand, (ConvertTo-RedactedLogString -InputObject $SessionContext.AuthCookie -MaxDepth 3) | Write-Verbose
                     }
                     catch {
                         $SessionContext.AuthCookie = $null
@@ -114,9 +115,10 @@ function Invoke-OmadaRequest {
                         $SessionContext.AuthCookie = ([System.Management.Automation.PSSerializer]::Deserialize([System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
                                     [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR((Import-Clixml $SessionContext.CookieCacheFilePath))
                                 ))).OmadaWebAuthCookie
-                        # Diagnostics only: depth is kept shallow on purpose so a verbose log does not
-                        # expand the whole cookie object graph.
-                        "{0} - Cookie:`r{1}" -f $MyInvocation.MyCommand, ($SessionContext.AuthCookie | ConvertTo-Json -Depth 3) | Write-Verbose
+                        # Diagnostics only: the cookie's own value is the session secret, so this goes
+                        # through the redaction walker. Depth is kept shallow on purpose so a verbose
+                        # log does not expand the whole cookie object graph.
+                        "{0} - Cookie:`r{1}" -f $MyInvocation.MyCommand, (ConvertTo-RedactedLogString -InputObject $SessionContext.AuthCookie -MaxDepth 3) | Write-Verbose
                     }
                     catch {
                         "Failure loading cookie, try to create a new one." | Write-Verbose
@@ -179,9 +181,11 @@ function Invoke-OmadaRequest {
                 $Paged = $true
             }
 
-            # Diagnostics only: $BoundParams holds rich objects (credential, session, cookie), and this
-            # string is built on every request even without -Verbose, so the depth stays deliberately low.
-            "{0} - {1}" -f $MyInvocation.MyCommand, ($BoundParams | ConvertTo-Json -Depth 5) | Write-Verbose
+            # Diagnostics only: $BoundParams holds the Authorization header, the credential and the
+            # session carrying the auth cookie, so it only ever reaches the verbose stream through the
+            # redaction walker. The string is built on every request even without -Verbose, which is
+            # why the walker's depth cap matters as much as its masking.
+            "{0} - {1}" -f $MyInvocation.MyCommand, (ConvertTo-RedactedLogString -InputObject $BoundParams) | Write-Verbose
             try {
                 $CustomErrorTrigger = "Login failed - {0}" -f (New-Guid).Guid.ToString()
                 $FullyQualifiedModule = @{
@@ -193,8 +197,10 @@ function Invoke-OmadaRequest {
                     $FullyQualifiedModule.ModuleVersion = [Version]"3.1.0.0"
                 }
 
-                # Diagnostics only: the hashtable above is flat, depth 5 is ample.
-                "{0} - Using Microsoft.PowerShell.Utility module: {1}" -f $MyInvocation.MyCommand, ($FullyQualifiedModule | ConvertTo-Json -Depth 5) | Write-Verbose
+                # The hashtable above holds no secrets, but it goes through the walker anyway so that
+                # "no ConvertTo-Json reaches Write-Verbose in this module" stays true as a rule - a
+                # rule is what survives future edits; a per-site judgement is not.
+                "{0} - Using Microsoft.PowerShell.Utility module: {1}" -f $MyInvocation.MyCommand, (ConvertTo-RedactedLogString -InputObject $FullyQualifiedModule) | Write-Verbose
 
                 switch ($Script:FunctionName) {
                     "Invoke-RestMethod" {
@@ -316,7 +322,10 @@ function Invoke-OmadaRequest {
                 }
                 if (($BoundParams.AuthenticationType) -in ("Browser", "WebView2") -and ($StatusCode -eq 401 -or $_.Exception.Message -eq $CustomErrorTrigger)) {
 
-                    "{0} - Re-Authentication - Error message: {1}" -f $MyInvocation.MyCommand, $_.Exception.Message | Write-Verbose
+                    # The exception comes from Invoke-RestMethod/Invoke-WebRequest or the browser stack
+                    # and routinely quotes the request that failed, headers included. There is no
+                    # object left to walk here, so the regex safety net is what applies.
+                    "{0} - Re-Authentication - Error message: {1}" -f $MyInvocation.MyCommand, (Protect-LogMessage -Message $_.Exception.Message) | Write-Verbose
                     $SessionContext.AuthCookie = $null
                     if (![string]::IsNullOrWhiteSpace($SessionContext.CookieCacheFilePath) -and (Test-Path $SessionContext.CookieCacheFilePath -PathType Leaf)) {
                         $SessionContext.CookieCacheFilePath | Remove-Item -ErrorAction SilentlyContinue

--- a/OmadaWeb.PS/Private/Protect-LogMessage.ps1
+++ b/OmadaWeb.PS/Private/Protect-LogMessage.ps1
@@ -1,0 +1,56 @@
+function Protect-LogMessage {
+    <#
+    .SYNOPSIS
+        Masks secret material in an already-flattened log line.
+
+    .DESCRIPTION
+        Structure-aware redaction happens in ConvertTo-RedactedLogString, which needs an object to
+        walk. This function is the safety net for text that never was an object: exception messages
+        raised by Invoke-RestMethod/Invoke-WebRequest and the browser stack, which routinely quote the
+        request that failed - headers included.
+
+        NOTE: this function must not log anything itself - the call sites that use it are logging
+        call sites, so writing to the verbose stream from here would recurse.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    if ([string]::IsNullOrEmpty($Message)) {
+        return $Message
+    }
+
+    try {
+        $Redacted = "***REDACTED***"
+        $Result = $Message
+
+        # Auth scheme followed by a token. The token is required, so a bare "AuthenticationType: Basic"
+        # - which is useful diagnostic information - survives untouched.
+        $Result = $Result -replace '(?i)\b(Basic|Bearer|Negotiate|NTLM|Digest)\s+([A-Za-z0-9+/=._\-]{8,})', ('$1 {0}' -f $Redacted)
+
+        # Bare JWTs, which turn up in OAuth2 responses and cached-token messages without a scheme prefix.
+        $Result = $Result -replace '\beyJ[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]*', '***REDACTED-JWT***'
+
+        # JSON-style pairs whose key names a secret, e.g. {"Password": "..."} or {"X-CSRF-Token": "..."}.
+        # The lookahead spares the one value ConvertTo-RedactedLogString deliberately emits for a
+        # credential - "PSCredential(UserName=...)" - which carries no password and answers the first
+        # question you ask of a 401. Without it the safety net would undo that upstream decision.
+        $Result = $Result -replace '(?i)("[^"]*(?:authorization|cookie|credential|password|pwd|secret|token|apikey|api_key|clientsecret|sessionkey|csrf|assertion|privatekey|connectionstring)[^"]*"\s*:\s*)"(?!(?:PS|Network)Credential\(UserName=)[^"]*"', ('$1"{0}"' -f $Redacted)
+
+        # Query-string, form and cookie style pairs, e.g. password=..., oisauthtoken=...
+        $Result = $Result -replace '(?i)\b([\w.\-]*(?:password|pwd|secret|token|apikey|api_key|sessionid|sessionkey|auth|csrf)[\w.\-]*)\s*=\s*([^\s;,&"'']+)', ('$1={0}' -f $Redacted)
+
+        # Any Set-Cookie header, whatever the cookie is called.
+        $Result = $Result -replace '(?i)(Set-Cookie:\s*)([^\s=;]+)=([^;\s]+)', ('$1$2={0}' -f $Redacted)
+
+        return $Result
+    }
+    catch {
+        # Failing open would leak the very thing this function exists to hide.
+        return "***REDACTION FAILED - MESSAGE SUPPRESSED***"
+    }
+}

--- a/OmadaWeb.PS/Private/Protect-LogMessage.ps1
+++ b/OmadaWeb.PS/Private/Protect-LogMessage.ps1
@@ -41,7 +41,9 @@ function Protect-LogMessage {
         # question you ask of a 401. Without it the safety net would undo that upstream decision.
         $Result = $Result -replace '(?i)("[^"]*(?:authorization|cookie|credential|password|pwd|secret|token|apikey|api_key|clientsecret|sessionkey|csrf|assertion|privatekey|connectionstring)[^"]*"\s*:\s*)"(?!(?:PS|Network)Credential\(UserName=)[^"]*"', ('$1"{0}"' -f $Redacted)
 
-        # Query-string, form and cookie style pairs, e.g. password=..., oisauthtoken=...
+        # Query-string, form and cookie style pairs: the key names the secret and the value follows an
+        # "=" up to the next separator. Matches "client_secret=abc123", "oisauthtoken=abc123" and
+        # "X-CSRF-Token=abc123"; leaves "grant_type=client_credentials" alone.
         $Result = $Result -replace '(?i)\b([\w.\-]*(?:password|pwd|secret|token|apikey|api_key|sessionid|sessionkey|auth|csrf)[\w.\-]*)\s*=\s*([^\s;,&"'']+)', ('$1={0}' -f $Redacted)
 
         # Any Set-Cookie header, whatever the cookie is called.

--- a/OmadaWeb.PS/Private/Set-RequestParameter.ps1
+++ b/OmadaWeb.PS/Private/Set-RequestParameter.ps1
@@ -27,8 +27,9 @@
     }
 
     "Parameters" | Write-Verbose
-    # Diagnostics only: the parameter set holds rich objects (credential, session, body), so the
-    # depth stays deliberately low - this string is built on every request, even without -Verbose.
-    $Parameters | ConvertTo-Json -Depth 5 | Write-Verbose
+    # Diagnostics only: the parameter set is what goes on the wire - Authorization header, credential,
+    # session and body - so it only reaches the verbose stream through the redaction walker. The string
+    # is built on every request, even without -Verbose, which is why the depth cap matters too.
+    ConvertTo-RedactedLogString -InputObject $Parameters | Write-Verbose
     return $Parameters
 }

--- a/Tests/Integration/Invoke-OmadaRestMethod.Tests.ps1
+++ b/Tests/Integration/Invoke-OmadaRestMethod.Tests.ps1
@@ -118,6 +118,27 @@ Describe 'Invoke-TestOmadaRestMethod' -Tag 'Integration' {
             $Result | Should -Be "OK"
         }
 
+        It 'Should not write the credential, the Basic header or the session cookie to the verbose stream' {
+            # The acceptance criterion of Fortigi/OmadaWeb.PS#43, end to end: consumers of this module
+            # capture the verbose stream into logs they export and attach to support tickets, so a
+            # full request has to be able to run at maximum verbosity without emitting anything secret.
+            $Password = "Pa55word-{0}" -f (New-Guid).Guid
+            $Credential = (New-Object System.Management.Automation.PSCredential("svc_sql", (ConvertTo-SecureString $Password -AsPlainText -Force)))
+            $BasicBlob = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f "svc_sql", $Password)))
+
+            # Keep the verbose records only, so the response object itself cannot satisfy or spoil
+            # an assertion about what was logged.
+            $VerboseOutput = ((Invoke-TestOmadaRestMethod -Uri $Uri -AuthenticationType Basic -Credential $Credential @AllowUnencryptedAuthParams -Verbose 4>&1) | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }) | Out-String
+
+            $VerboseOutput | Should -Not -BeNullOrEmpty
+            $VerboseOutput | Should -Not -Match ([regex]::Escape($Password))
+            $VerboseOutput | Should -Not -Match ([regex]::Escape($BasicBlob))
+
+            # Still useful: which account, which endpoint.
+            $VerboseOutput | Should -Match 'svc_sql'
+            $VerboseOutput | Should -Match ([regex]::Escape($Uri))
+        }
+
         It 'Should return result from Invoke-(Test)OmadaRestMethod using Windows Authentication' {
             $Credential = (New-Object System.Management.Automation.PSCredential("user", (ConvertTo-SecureString "password" -AsPlainText -Force)))
             $Result = Invoke-TestOmadaRestMethod -Uri $Uri -AuthenticationType Windows -Credential $Credential @AllowUnencryptedAuthParams

--- a/Tests/Unit/ConvertTo-RedactedLogString.Tests.ps1
+++ b/Tests/Unit/ConvertTo-RedactedLogString.Tests.ps1
@@ -78,6 +78,53 @@ Describe 'ConvertTo-RedactedLogString' -Tag 'Unit' {
             }
         }
 
+        It 'Should mask the value of an OmadaWebAuthCookie-shaped object while keeping its diagnostics' {
+            InModuleScope 'OmadaWeb.PS' {
+                # This is the exact shape Get-WebView2Cookie builds and Invoke-OmadaRequest logs from
+                # $SessionContext.AuthCookie. No type rule reaches it and "value" names nothing secret
+                # on its own, so without the name/value-pair rule the session token would be logged.
+                $AuthCookie = [pscustomobject]@{
+                    name     = 'oisauthtoken'
+                    value    = 'cookie-secret-value'
+                    domain   = 'tenant.omada.cloud'
+                    path     = '/'
+                    expires  = $null
+                    httpOnly = $true
+                    secure   = $true
+                    sameSite = 'Lax'
+                }
+                $Result = ConvertTo-RedactedLogString -InputObject $AuthCookie
+                $Result | Should -Not -Match 'cookie-secret-value'
+                $Result | Should -Match 'oisauthtoken'
+                $Result | Should -Match 'tenant\.omada\.cloud'
+            }
+        }
+
+        It 'Should mask the value of a name/value pair arriving as a hashtable too' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ name = 'oisauthtoken'; value = 'cookie-secret-value' }
+                $Result | Should -Not -Match 'cookie-secret-value'
+                $Result | Should -Match 'oisauthtoken'
+            }
+        }
+
+        It 'Should keep a Value member that is not part of a name/value pair' {
+            InModuleScope 'OmadaWeb.PS' {
+                # The rule has to stay narrow: "Value" on its own is an ordinary member name.
+                $Result = ConvertTo-RedactedLogString -InputObject ([pscustomobject]@{ Value = 42; Unit = 'seconds' })
+                $Result | Should -Match '42'
+            }
+        }
+
+        It 'Should reduce a System.Net.Cookie to its name and domain' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Cookie = New-Object System.Net.Cookie('oisauthtoken', 'cookie-secret-value', '/', 'tenant.omada.cloud')
+                $Result = ConvertTo-RedactedLogString -InputObject $Cookie
+                $Result | Should -Not -Match 'cookie-secret-value'
+                $Result | Should -Match 'Cookie\(Name=oisauthtoken, Domain=tenant\.omada\.cloud\)'
+            }
+        }
+
         It 'Should mask a token carried in a Uri query string' {
             InModuleScope 'OmadaWeb.PS' {
                 $Result = ConvertTo-RedactedLogString -InputObject ([System.Uri]::new('https://login.microsoftonline.com/common/callback?id_token=header.payload.signature'))
@@ -157,11 +204,14 @@ Describe 'ConvertTo-RedactedLogString' -Tag 'Unit' {
             }
         }
 
-        It 'Should report a failure instead of returning the unredacted object' {
+        It 'Should report a failure by exception type, never by exception message' {
             InModuleScope 'OmadaWeb.PS' {
-                Mock ConvertTo-RedactedLogValue { throw 'walker exploded' }
+                # A failure mid-walk can raise a message quoting the value being walked, so the
+                # message is exactly as untrustworthy as the object. The type is enough to debug from.
+                Mock ConvertTo-RedactedLogValue { throw 'walker exploded on Sup3rSecret!' }
                 $Result = ConvertTo-RedactedLogString -InputObject @{ Password = 'Sup3rSecret!' }
                 $Result | Should -Not -Match 'Sup3rSecret'
+                $Result | Should -Not -Match 'walker exploded'
                 $Result | Should -Match 'redaction failed'
             }
         }

--- a/Tests/Unit/ConvertTo-RedactedLogString.Tests.ps1
+++ b/Tests/Unit/ConvertTo-RedactedLogString.Tests.ps1
@@ -1,0 +1,173 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'ConvertTo-RedactedLogString' -Tag 'Unit' {
+    Context 'Name-based masking' {
+        It 'Should mask a value whose key names a secret' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Authorization = 'Basic dXNlcjpwYXNzd29yZA==' }
+                $Result | Should -Not -Match 'dXNlcjpwYXNzd29yZA'
+                $Result | Should -Match '\*\*\*REDACTED\*\*\*'
+            }
+        }
+
+        It 'Should match the key as a case-insensitive substring so composite names are covered' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{
+                    'X-CSRF-Token'  = 'csrf-secret-value'
+                    'RefreshToken'  = 'refresh-secret-value'
+                    'oisauthtoken'  = 'cookie-secret-value'
+                    'ClientSecret'  = 'client-secret-value'
+                }
+                $Result | Should -Not -Match 'csrf-secret-value'
+                $Result | Should -Not -Match 'refresh-secret-value'
+                $Result | Should -Not -Match 'cookie-secret-value'
+                $Result | Should -Not -Match 'client-secret-value'
+            }
+        }
+
+        It 'Should keep values whose key names nothing secret' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Method = 'POST'; Uri = 'https://tenant.omada.cloud/OData' }
+                $Result | Should -Match 'POST'
+                $Result | Should -Match 'tenant\.omada\.cloud'
+            }
+        }
+    }
+
+    Context 'Type-based masking' {
+        It 'Should keep the credential user name and never the password' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Credential = New-Object System.Management.Automation.PSCredential('omada\svc_sql', (ConvertTo-SecureString 'Sup3rSecret!' -AsPlainText -Force))
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Credential = $Credential }
+                $Result | Should -Match 'svc_sql'
+                $Result | Should -Not -Match 'Sup3rSecret'
+            }
+        }
+
+        It 'Should mask a SecureString' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Anything = (ConvertTo-SecureString 'Sup3rSecret!' -AsPlainText -Force) }
+                $Result | Should -Not -Match 'Sup3rSecret'
+                $Result | Should -Match '\*\*\*REDACTED\*\*\*'
+            }
+        }
+
+        It 'Should reduce a byte array to its length' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Raw = [byte[]]@(1, 2, 3, 4, 5) }
+                $Result | Should -Match 'Byte\[5\]'
+            }
+        }
+
+        It 'Should reduce a WebRequestSession to its cookie count and user agent' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Session.UserAgent = 'OmadaWeb.PS/1.0'
+                $Session.Cookies.Add((New-Object System.Net.Cookie('oisauthtoken', 'cookie-secret-value', '/', 'tenant.omada.cloud')))
+                $Result = ConvertTo-RedactedLogString -InputObject @{ WebSession = $Session }
+                $Result | Should -Not -Match 'cookie-secret-value'
+                $Result | Should -Match 'WebRequestSession\(Cookies=1'
+                $Result | Should -Match 'OmadaWeb.PS/1.0'
+            }
+        }
+
+        It 'Should mask a token carried in a Uri query string' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject ([System.Uri]::new('https://login.microsoftonline.com/common/callback?id_token=header.payload.signature'))
+                $Result | Should -Not -Match 'header\.payload\.signature'
+                $Result | Should -Match 'login\.microsoftonline\.com'
+            }
+        }
+    }
+
+    Context 'Free-form values the name rules cannot see' {
+        It 'Should mask an auth scheme and token arriving under an unremarkable key' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Note = 'retrying with Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature' }
+                $Result | Should -Not -Match 'eyJhbGciOiJIUzI1NiJ9'
+            }
+        }
+    }
+
+    Context 'Bounds' {
+        It 'Should collapse an array of more than three elements to a shape summary' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Rows = @('a', 'b', 'c', 'd', 'e') }
+                $Result | Should -Match 'Array\[5\] of String'
+            }
+        }
+
+        It 'Should stop at the requested depth' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Deep = @{ L1 = @{ L2 = @{ L3 = @{ L4 = 'bottom' } } } }
+                $Result = ConvertTo-RedactedLogString -InputObject $Deep -MaxDepth 2
+                $Result | Should -Not -Match 'bottom'
+                $Result | Should -Match 'max depth 2 reached'
+            }
+        }
+
+        It 'Should truncate a long string' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Text = ('x' * 40) } -MaxStringLength 10
+                $Result | Should -Match 'truncated, 40 chars'
+            }
+        }
+
+        It 'Should not loop on a circular reference' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Outer = [PSCustomObject]@{ Name = 'outer'; Child = $null }
+                $Inner = [PSCustomObject]@{ Name = 'inner'; Parent = $Outer }
+                $Outer.Child = $Inner
+                $Result = ConvertTo-RedactedLogString -InputObject $Outer
+                $Result | Should -Match 'circular reference'
+            }
+        }
+    }
+
+    Context 'Bodies and -ShapeOnly' {
+        It 'Should keep body keys and value shapes but no body values' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Body = @{ C_QUERY = 'SELECT * FROM dbo.Person' } }
+                $Result | Should -Match 'C_QUERY'
+                $Result | Should -Not -Match 'dbo\.Person'
+                $Result | Should -Match 'String\(24\)'
+            }
+        }
+
+        It 'Should keep keys and shapes only when -ShapeOnly is used' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Name = 'Omada' } -ShapeOnly
+                $Result | Should -Match 'Name'
+                $Result | Should -Not -Match 'Omada'
+            }
+        }
+    }
+
+    Context 'Edge cases' {
+        It 'Should render a null input as the literal null' {
+            InModuleScope 'OmadaWeb.PS' {
+                ConvertTo-RedactedLogString -InputObject $null | Should -Be 'null'
+            }
+        }
+
+        It 'Should report a failure instead of returning the unredacted object' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock ConvertTo-RedactedLogValue { throw 'walker exploded' }
+                $Result = ConvertTo-RedactedLogString -InputObject @{ Password = 'Sup3rSecret!' }
+                $Result | Should -Not -Match 'Sup3rSecret'
+                $Result | Should -Match 'redaction failed'
+            }
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Protect-LogMessage.Tests.ps1
+++ b/Tests/Unit/Protect-LogMessage.Tests.ps1
@@ -1,0 +1,103 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Protect-LogMessage' -Tag 'Unit' {
+    Context 'Authentication schemes' {
+        It 'Should mask the token after a Basic scheme' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = Protect-LogMessage -Message 'Authorization: Basic dXNlcjpwYXNzd29yZA=='
+                $Result | Should -Not -Match 'dXNlcjpwYXNzd29yZA'
+                $Result | Should -Match 'Basic \*\*\*REDACTED\*\*\*'
+            }
+        }
+
+        It 'Should mask the token after a Bearer scheme' {
+            InModuleScope 'OmadaWeb.PS' {
+                Protect-LogMessage -Message 'Authorization: Bearer abcdefgh12345678' | Should -Not -Match 'abcdefgh12345678'
+            }
+        }
+
+        It 'Should leave a bare scheme name alone, since it is diagnostic and not secret' {
+            InModuleScope 'OmadaWeb.PS' {
+                Protect-LogMessage -Message 'AuthenticationType: Basic' | Should -Be 'AuthenticationType: Basic'
+            }
+        }
+    }
+
+    Context 'Tokens without a scheme prefix' {
+        It 'Should mask a bare JWT' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = Protect-LogMessage -Message 'cached token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.Xy_Z1 for tenant'
+                $Result | Should -Not -Match 'eyJhbGciOiJIUzI1NiJ9'
+                $Result | Should -Match 'REDACTED-JWT'
+                $Result | Should -Match 'for tenant'
+            }
+        }
+    }
+
+    Context 'Key/value pairs' {
+        It 'Should mask a JSON pair whose key names a secret' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = Protect-LogMessage -Message '{"Password": "Sup3rSecret!", "Method": "POST"}'
+                $Result | Should -Not -Match 'Sup3rSecret'
+                $Result | Should -Match 'POST'
+            }
+        }
+
+        It 'Should mask a query-string or form pair whose key names a secret' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = Protect-LogMessage -Message 'grant_type=client_credentials&client_secret=Sup3rSecret!'
+                $Result | Should -Not -Match 'Sup3rSecret'
+                $Result | Should -Match 'grant_type=client_credentials'
+            }
+        }
+
+        It 'Should mask a Set-Cookie header whatever the cookie is called' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Result = Protect-LogMessage -Message 'Set-Cookie: oisauthtoken=cookie-secret-value; Path=/; HttpOnly'
+                $Result | Should -Not -Match 'cookie-secret-value'
+                $Result | Should -Match 'oisauthtoken=\*\*\*REDACTED\*\*\*'
+            }
+        }
+
+        It 'Should spare the credential user name that ConvertTo-RedactedLogString deliberately emits' {
+            InModuleScope 'OmadaWeb.PS' {
+                # The walker keeps the account name on purpose - it is the first thing you need for a
+                # 401 - so the two layers must not silently disagree about it.
+                $Result = Protect-LogMessage -Message '{"Credential": "PSCredential(UserName=omada\\svc_sql)"}'
+                $Result | Should -Match 'svc_sql'
+            }
+        }
+    }
+
+    Context 'Edge cases' {
+        It 'Should return an empty message unchanged' {
+            InModuleScope 'OmadaWeb.PS' {
+                Protect-LogMessage -Message '' | Should -Be ''
+            }
+        }
+
+        It 'Should return a null message unchanged' {
+            InModuleScope 'OmadaWeb.PS' {
+                Protect-LogMessage -Message $null | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Should leave text without secrets untouched' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Message = 'Invoke-OmadaRequest - BaseUrl: https://tenant.omada.cloud'
+                Protect-LogMessage -Message $Message | Should -Be $Message
+            }
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Set-RequestParameter.Tests.ps1
+++ b/Tests/Unit/Set-RequestParameter.Tests.ps1
@@ -67,6 +67,39 @@ Describe 'Set-RequestParameter' -Tag 'Unit' {
             }
         }
     }
+
+    Context 'Verbose output' {
+        It 'Should log the parameter set without the Basic header, the session cookie or the password' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Session.Cookies.Add((New-Object System.Net.Cookie('oisauthtoken', 'cookie-secret-value', '/', 'example.omada.cloud')))
+                $BoundParams = @{
+                    Uri        = 'https://example.omada.cloud/OData'
+                    Method     = 'POST'
+                    Headers    = @{ Authorization = 'Basic dXNlcjpTdXAzclNlY3JldCE=' }
+                    WebSession = $Session
+                    Credential = New-Object System.Management.Automation.PSCredential('omada\svc_sql', (ConvertTo-SecureString 'Sup3rSecret!' -AsPlainText -Force))
+                    Body       = '{"C_QUERY":"SELECT * FROM dbo.Person"}'
+                }
+
+                # Keep the verbose records only. The function also returns the parameter hashtable,
+                # and formatting that for comparison would print the very values under test - a
+                # property of this test, not of the log line it is checking.
+                $VerboseOutput = ((Set-RequestParameter -Verbose 4>&1) | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }) | Out-String
+
+                # Nothing secret.
+                $VerboseOutput | Should -Not -Match 'dXNlcjpTdXAzclNlY3JldCE'
+                $VerboseOutput | Should -Not -Match 'cookie-secret-value'
+                $VerboseOutput | Should -Not -Match 'Sup3rSecret'
+                $VerboseOutput | Should -Not -Match 'dbo\.Person'
+
+                # Still useful: which account, which endpoint, which method.
+                $VerboseOutput | Should -Match 'svc_sql'
+                $VerboseOutput | Should -Match 'example\.omada\.cloud'
+                $VerboseOutput | Should -Match 'POST'
+            }
+        }
+    }
 }
 
 AfterAll {


### PR DESCRIPTION
Closes #43.

The OmadaWeb.PS half of roadmap item A2. The application half shipped as
Fortigi/OmadaSqlTroubleshooter#51; this mirrors its design rather than inventing a second one.

Verbose logging serialised live objects straight into the verbose stream, secrets included.
`Invoke-OmadaRequest.ps1:184` dumped the whole bound-parameter set as JSON *after* the
`Authorization` header, the `WebSession` and the `Credential` had been added; `:101`/`:119` dumped
the auth cookie; `Set-RequestParameter.ps1:32` dumped the assembled parameter set; and
`OmadaWeb.PS.psm1` dumped `PsBoundParameters` on import, which can carry an `OmadaWebAuthCookie`.
Two further sites leaked less obviously: `Get-WebView2Cookie.ps1:9` dumped a WebView2 source Uri —
a login redirect can carry a token in its query string — and the re-authentication path logged an
exception message verbatim, and those messages routinely quote the failing request, headers included.

This matters beyond `-Verbose` on a console. OmadaSqlTroubleshooter captures this stream into its
application log and has an **Export Log File** button, so anything written here can reach a file a
user attaches to a support ticket.

## What changed

Two new private helpers:

| Function | Role |
| --- | --- |
| `ConvertTo-RedactedLogString` | Structure-aware walker. Masks by property name (`authorization`, `cookie`, `token`, `password`, … as a case-insensitive substring, so `X-CSRF-Token` and `RefreshToken` are covered), by type (`PSCredential` → user name only, `SecureString` → masked, `byte[]` → length, cookie containers → count, `System.Net.Cookie` → name and domain, `WebRequestSession` → cookie count and user agent, `Uri` → its string form with query-string secrets masked) and by shape (an object or hashtable exposing both a `Name` and a `Value` member is a name/value pair — a cookie or a header — so its value is masked there and nowhere else). Arrays over 3 elements collapse to `Array[n] of T`. Request bodies keep their keys and value shapes, never their values. Capped on depth, string length and circular references, and reports its own failures by exception type, never by message. |
| `Protect-LogMessage` | Regex net over already-flattened text — scheme+token, bare JWTs, JSON secret pairs, query/form/cookie pairs, `Set-Cookie`. The walker calls it on every string it is about to emit, so a token arriving under a property name nobody anticipated is still masked. |

All seven serialisation call sites are converted. No `ConvertTo-Json` reaches `Write-Verbose`
anywhere in `OmadaWeb.PS/` any more; the two that remain build the wire payload (`Set-Body.ps1`) and
escape JavaScript (`ConvertTo-JavaScriptLiteral.ps1`), which is not logging.

A representative log line now reads:

```
Invoke-OmadaRequest - {
  "Uri": "https://tenant.omada.cloud/OData/BuiltIn/C_P_SQLTROUBLESHOOTING",
  "Credential": "PSCredential(UserName=omada\\svc_sql)",
  "Headers": { "Authorization": "***REDACTED***" },
  "WebSession": "WebRequestSession(Cookies=1, UserAgent=OmadaWeb.PS/1.0)",
  "Body": "String(38)",
  "Method": "POST"
}
```

## Acceptance criteria

- [x] A single redaction helper is the only path by which request/response objects reach the verbose stream
- [x] `Authorization` headers, cookies, `PSCredential`/`SecureString` values and request bodies are masked
- [x] All call sites listed in the issue are converted — plus three the issue did not list (see above)
- [x] Unit tests assert that a request carrying a Basic header, a bearer cookie and a credential produces verbose output containing none of those values
- [x] Whether to export the helper is decided: **kept internal** — see below

## Decisions worth reviewing

**The helpers stay private, one copy per repo.** #51 already settled this: OmadaWeb.PS ships from
the PowerShell Gallery and its source is not in the application's tree, so the application cannot
consume a helper that lives only here without taking a hard dependency on an internal function. Two
copies is the lesser cost. If you would rather export `ConvertTo-RedactedLogString` and have
OmadaSqlTroubleshooter drop its own, that is a one-line change here plus a deletion there — say so
and I will do it.

**`FullyQualifiedModule` goes through the walker even though it holds no secrets.** The point is the
rule, not the site: "no `ConvertTo-Json` reaches `Write-Verbose` in this module" is greppable and
survives future edits, where a per-site judgement quietly does not.

**The cookie and WebView2 sites keep a shallow depth (`-MaxDepth 3`).** That preserves the existing
`-Depth 3` intent — those objects are large and the string is built whether or not `-Verbose` is on.

**The name/value shape rule is deliberately narrow.** `$SessionContext.AuthCookie` is a
`PSCustomObject` with lowercase `name`/`value`/`domain` members, so no type rule reaches it and
`value` names nothing secret on its own — the first version of this PR leaked the session token
there, which Copilot caught. Masking `Value` unconditionally would over-mask ordinary objects, so
the rule fires only when a `Name` member sits alongside it, and a negative test pins that boundary
down. The cookie's domain, path, expiry and `httpOnly` still survive, so the log says which cookie
for which host.

**The credential user name is kept** (`PSCredential(UserName=omada\svc_sql)`), the password never.
Knowing which account hit a 401 is the first thing you need. This required a lookahead in
`Protect-LogMessage` so the regex net does not strip what the walker deliberately emits — the two
layers can otherwise silently disagree.

**`Uri` values are logged as strings, not walked.** A `Uri`'s property graph is large and
uninteresting in a log, and `ConvertTo-Json` on one previously expanded all of it. The string form
goes through the regex net, which is what masks a token in a login redirect's query string.

## Verification

`./Build/build.ps1 -Task TestBuildOnly` — PSScriptAnalyzer clean, comment-based help clean.

Pester, compared against a clean `origin/main` worktree on the same machine:

| | Passed | Failed |
| --- | --- | --- |
| `origin/main` (baseline) | 230 | 26 |
| this branch | 264 | 26 |

The 26 failures are identical in both runs (`diff` of the failing test names is empty) — they are
the WebView2/Selenium browser-login tests, which need an interactive Edge/WebView2 this machine does
not provide and which CI mocks out. 34 new tests, no regressions.

The acceptance criterion is asserted at two levels: a unit test over `Set-RequestParameter` with a
Basic header, a `WebSession` holding an `oisauthtoken` cookie and a `PSCredential`, and an
integration test end to end through `Invoke-OmadaRestMethod` against the local test web server with
a random password. Both assert the secrets are absent *and* that the account, endpoint and method
are still there — a redactor that logs nothing would pass the first half alone.

## Notes for the reviewer

- The `psm1`'s `PsBoundParameters` line had to move below the loop that dot-sources
  `Private\*.ps1`. The walker is one of the functions that loop defines, so at the point the
  parameters are processed it does not exist yet. It now sits just after `Export-ModuleMember`,
  which is also where the build inlines the functions, so it behaves the same in source and in the
  assembled `.psm1`.
- Both test captures filter down to verbose records. Without that, the function's own return value
  gets formatted into the comparison string and prints the very values under test — a property of
  the test, not of the log line it checks.
