### PR TITLE
Fall back to manual sign-in when the Microsoft login page changes (D3 layers 1-2)

### DIFF
--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -169,6 +169,13 @@ $Script:LoginFailed = $false
 $Script:LoginState = $null
 $Script:LoginSubState = $null
 $Script:LoginTask = $null
+# Seconds the sign-in automation may sit on the same page without making progress before it stops
+# filling in credentials and lets the user sign in manually - see Switch-ToManualLogin.ps1. Generous
+# on purpose: a slow round trip to Entra must not be mistaken for a changed sign-in page.
+$Script:LoginAutomationFallbackTimeout = 60
+$Script:ManualLoginFallbackActive = $false
+$Script:UnmatchedPageSignature = $null
+$Script:UnmatchedPageSince = $null
 $Script:MaxLoginRetries = 3
 $Script:MfaRequestDisplayed = $false
 $Script:MicrosoftOnlineLogin = $false

--- a/OmadaWeb.PS/Private/Get-DataFromWebDriver.ps1
+++ b/OmadaWeb.PS/Private/Get-DataFromWebDriver.ps1
@@ -28,10 +28,8 @@ function Get-DataFromWebDriver {
         $MfaRequestDisplayed = $false
         $PhoneLinkActive = $false
 
-        # A new sign-in gets a fresh attempt at autofill, whatever happened during the previous one.
-        $Script:ManualLoginFallbackActive = $false
-        $Script:UnmatchedPageSignature = $null
-        $Script:UnmatchedPageSince = $null
+        # A new browser gets a fresh attempt at autofill, whatever happened during the previous one.
+        Reset-LoginAutomationState
         if ((Get-Process | Where-Object { $_.ProcessName -eq "PhoneExperienceHost" } | Measure-Object).Count -gt 0) {
             $PhoneLinkActive = $true
         }

--- a/OmadaWeb.PS/Private/Get-DataFromWebDriver.ps1
+++ b/OmadaWeb.PS/Private/Get-DataFromWebDriver.ps1
@@ -27,6 +27,11 @@ function Get-DataFromWebDriver {
         $LoginMessageShown = $false
         $MfaRequestDisplayed = $false
         $PhoneLinkActive = $false
+
+        # A new sign-in gets a fresh attempt at autofill, whatever happened during the previous one.
+        $Script:ManualLoginFallbackActive = $false
+        $Script:UnmatchedPageSignature = $null
+        $Script:UnmatchedPageSince = $null
         if ((Get-Process | Where-Object { $_.ProcessName -eq "PhoneExperienceHost" } | Measure-Object).Count -gt 0) {
             $PhoneLinkActive = $true
         }
@@ -42,7 +47,7 @@ function Get-DataFromWebDriver {
             Write-Host "." -NoNewline -ForegroundColor Yellow
             Start-Sleep -Milliseconds 500
 
-            if ($SessionContext.Credential -and ![string]::IsNullOrWhiteSpace($SessionContext.Credential.UserName.Trim())) {
+            if ($SessionContext.Credential -and ![string]::IsNullOrWhiteSpace($SessionContext.Credential.UserName.Trim()) -and -not $Script:ManualLoginFallbackActive) {
 
                 if ($EdgeDriver.url -like "https://login.microsoftonline.com/*") {
                     try {
@@ -76,6 +81,8 @@ function Get-DataFromWebDriver {
                             # ConvertTo-JavaScriptLiteral if a value ever has to cross into JavaScript.
                             $EdgeDriver.FindElements([OpenQA.Selenium.By]::Id($UserNameElementId))[0].SendKeys($SessionContext.Credential.UserName.Trim())
                             $EdgeDriver.FindElement([OpenQA.Selenium.By]::Id($SubmitButton)).Click()
+                            # Acting on the page is progress - restart the stall clock.
+                            $Script:UnmatchedPageSince = $null
                         }
 
                         if ($IdAttributes -notcontains $UserNameElementId `
@@ -88,6 +95,7 @@ function Get-DataFromWebDriver {
                             # See the note above: SendKeys transports the password out of band, no escaping needed.
                             $EdgeDriver.FindElements([OpenQA.Selenium.By]::Id($PasswordElementId))[0].SendKeys($SessionContext.Credential.GetNetworkCredential().Password)
                             $EdgeDriver.FindElement([OpenQA.Selenium.By]::Id($SubmitButton)).Click()
+                            $Script:UnmatchedPageSince = $null
                         }
 
                         if ($IdAttributes -notcontains $UserNameElementId `
@@ -110,6 +118,7 @@ function Get-DataFromWebDriver {
                         ) {
                             "Decline Stay signed in? " | Write-Verbose
                             $EdgeDriver.FindElement([OpenQA.Selenium.By]::Id($ButtonBackId)).Click()
+                            $Script:UnmatchedPageSince = $null
                         }
 
                         if ($IdAttributes -notcontains $UserNameElementId `
@@ -121,6 +130,7 @@ function Get-DataFromWebDriver {
                             $EdgeDriver.FindElements([OpenQA.Selenium.By]::XPath("//*[@data-test-id]")) | ForEach-Object {
                                 if ($_.GetAttribute("data-test-id") -eq $SessionContext.Credential.UserName.Trim()) {
                                     $_.Click()
+                                    $Script:UnmatchedPageSince = $null
                                 }
                             }
                         }
@@ -158,9 +168,33 @@ function Get-DataFromWebDriver {
                             "`nMFA failed! Please retry!" | Write-Warning
                             $MfaRequestDisplayed = $false
                             $LoginMessageShown = $false
+                            $Script:UnmatchedPageSince = $null
+                        }
+
+                        # Every branch above recognizes the page by hardcoded Entra element IDs.
+                        # When Microsoft changes that markup none of them fire and this loop keeps
+                        # polling a page it can no longer drive. Hand the sign-in back to the user
+                        # instead - the browser window is open and waiting (issue #32).
+                        $WaitingForApproval = $MfaRequestDisplayed -and $IdAttributes -contains $MfaElementId
+                        if (Test-LoginAutomationStalled -ElementId $IdAttributes -WaitingForApproval:$WaitingForApproval) {
+                            $KnownElementId = @($UserNameElementId, $PasswordElementId, $ButtonSubmitId, $ButtonBackId, $CantAccessAccountId, $MfaElementId, $MfaRetryId1, $MfaRetryId2)
+                            $MissingElementId = @($KnownElementId | Where-Object { $_ -notin $IdAttributes })
+
+                            Switch-ToManualLogin -State "EdgeDriverLoginScenarios" -MissingElementId $MissingElementId -FoundElementId $IdAttributes -Url $EdgeDriver.url | Out-Null
                         }
                     }
-                    catch {}
+                    catch {
+                        # The sign-in page changes between polls, so a stale element reference here
+                        # is expected and the next iteration re-reads the page. Logged rather than
+                        # swallowed so that a genuine failure is visible with -Verbose - and so that
+                        # a failure which keeps repeating ends in a manual sign-in rather than in an
+                        # endless poll.
+                        "Login scenario evaluation failed: {0}" -f (Protect-LogMessage -Message $_.Exception.Message) | Write-Verbose
+
+                        if (Test-LoginAutomationStalled -ElementId @("<scenario evaluation failed>")) {
+                            Switch-ToManualLogin -State "EdgeDriverLoginScenarios" -Url $EdgeDriver.url -Reason $_.Exception.Message | Out-Null
+                        }
+                    }
                 }
             }
 

--- a/OmadaWeb.PS/Private/Get-DataFromWebView2.ps1
+++ b/OmadaWeb.PS/Private/Get-DataFromWebView2.ps1
@@ -21,9 +21,8 @@ function Get-DataFromWebView2 {
         $Script:CurrentWebView2Session.LoginRetryCount = 0
 
         # A new sign-in gets a fresh attempt at autofill, whatever happened during the previous one.
-        $Script:ManualLoginFallbackActive = $false
-        $Script:UnmatchedPageSignature = $null
-        $Script:UnmatchedPageSince = $null
+        # Every window opened from here resets it again - see Initialize-WebView2.
+        Reset-LoginAutomationState
 
         Add-ReflectionAssembly -Object $Script:WebView2CorePath
         Add-ReflectionAssembly -Object $Script:WebView2WinFormsPath

--- a/OmadaWeb.PS/Private/Get-DataFromWebView2.ps1
+++ b/OmadaWeb.PS/Private/Get-DataFromWebView2.ps1
@@ -20,6 +20,11 @@ function Get-DataFromWebView2 {
         $Script:CurrentWebView2Session = $SessionContext
         $Script:CurrentWebView2Session.LoginRetryCount = 0
 
+        # A new sign-in gets a fresh attempt at autofill, whatever happened during the previous one.
+        $Script:ManualLoginFallbackActive = $false
+        $Script:UnmatchedPageSignature = $null
+        $Script:UnmatchedPageSince = $null
+
         Add-ReflectionAssembly -Object $Script:WebView2CorePath
         Add-ReflectionAssembly -Object $Script:WebView2WinFormsPath
         Add-ReflectionAssembly -Object "System.Drawing" -Type LoadWithPartialName

--- a/OmadaWeb.PS/Private/Initialize-Webview2.ps1
+++ b/OmadaWeb.PS/Private/Initialize-Webview2.ps1
@@ -8,6 +8,9 @@ function Initialize-WebView2 {
         "{0} - Initializing WebView2" -f $MyInvocation.MyCommand | Write-Verbose
         Write-Host "`r`nWebView2 opened, please login! Waiting for login." -NoNewline -ForegroundColor Yellow
         $Script:MicrosoftOnlineLogin = $true
+        # This window gets its own attempt at autofill, and its own diagnostic if that attempt ends
+        # in a manual sign-in.
+        Reset-LoginAutomationState
 
         $Script:WebView2.add_CoreWebView2InitializationCompleted({
                 param($sender, $e)

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -240,9 +240,7 @@ function Invoke-WebView2MicrosoftLogin {
             $Script:LoginFailed = $false
             $Script:CurrentScenario = $null
             $Script:PreviousScenario = $null
-            $Script:ManualLoginFallbackActive = $false
-            $Script:UnmatchedPageSignature = $null
-            $Script:UnmatchedPageSince = $null
+            Reset-LoginAutomationState
             return $false
         }
 

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -236,6 +236,9 @@ function Invoke-WebView2MicrosoftLogin {
             $Script:LoginFailed = $false
             $Script:CurrentScenario = $null
             $Script:PreviousScenario = $null
+            $Script:ManualLoginFallbackActive = $false
+            $Script:UnmatchedPageSignature = $null
+            $Script:UnmatchedPageSince = $null
             return $false
         }
 
@@ -273,6 +276,13 @@ function Invoke-WebView2MicrosoftLogin {
 
                         if ($null -eq $Script:IdAttributes -or $Script:IdAttributes.Count -eq 0) {
                             "No element IDs found on page, retrying..." | Write-Verbose
+                            # A sign-in page carrying none of the known IDs at all is the loudest
+                            # form of a selector break, and retrying it would otherwise never end.
+                            if (Test-LoginAutomationStalled -ElementId @()) {
+                                Switch-ToManualLogin -State "GettingIds" -Url $Script:WebView2.Source.AbsoluteUri -Reason "The page carries none of the element IDs this module looks for." | Out-Null
+                                return $false
+                            }
+
                             $Script:LoginState = "GettingIds"
                             $Script:LoginTask = $null
                             return $false
@@ -328,6 +338,25 @@ function Invoke-WebView2MicrosoftLogin {
                     "SubmitButton exists: $( $SubmitButtonId -in $Script:IdAttributes.id)" | Write-Verbose
                     "ButtonBack exists: $( $ButtonBackId -in $Script:IdAttributes.id)" | Write-Verbose
                     "MfaElementIds exists: $( $MfaElementId1 -in $Script:IdAttributes.id -or   $MfaElementId2 -in $Script:IdAttributes.id)" | Write-Verbose
+
+                    # Every scenario below recognizes the page by the element IDs above. When
+                    # Microsoft changes that markup, either no scenario matches or the one that does
+                    # can no longer act, and the timer keeps re-evaluating the same page forever.
+                    # Detect that and let the user sign in by hand instead - the window is open and
+                    # for a tenant that is not on Entra typing the credentials there is the normal
+                    # path anyway (issue #32).
+                    $WaitingForApproval = $Script:MfaRequestDisplayed -and ($MfaElementId1 -in $Script:IdAttributes.id -or $MfaElementId2 -in $Script:IdAttributes.id)
+                    if (Test-LoginAutomationStalled -ElementId $Script:IdAttributes.id -WaitingForApproval:$WaitingForApproval) {
+                        $KnownElementId = @($UserNameElementId, $PasswordElementId, $SubmitButtonId, $ButtonBackId, $CantAccessAccountId, $MfaElementId1, $MfaElementId2, $MfaRetryId1, $MfaRetryId2, $KeepMeSignedInId)
+                        $MissingElementId = @($KnownElementId | Where-Object { $_ -notin $Script:IdAttributes.id })
+                        $ScenarioName = "NoMatchingScenario"
+                        if (-not [string]::IsNullOrWhiteSpace($Script:CurrentScenario)) {
+                            $ScenarioName = $Script:CurrentScenario
+                        }
+
+                        Switch-ToManualLogin -State ("ProcessingScenarios/{0}" -f $ScenarioName) -MissingElementId $MissingElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri | Out-Null
+                        return $false
+                    }
 
                     # Scenario 1: Username entry page
                     # Check if username field exists - we'll verify visibility in the sub-state
@@ -390,11 +419,9 @@ function Invoke-WebView2MicrosoftLogin {
                                         }
                                     }
                                     else {
-                                        # Task faulted, reset
-                                        "Username field check faulted: $($Script:LoginTask.Exception.Message)" | Write-Verbose
-                                        $Script:LoginSubState = $null
-                                        $Script:MicrosoftOnlineLogin = $false
-
+                                        # The visibility check could not run at all, so autofill is
+                                        # over for this sign-in. Say so instead of going quiet.
+                                        Switch-ToManualLogin -State "Scenario1/CheckingUsernameField" -MissingElementId $UserNameElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
                                     }
                                 }
                                 return $false
@@ -410,10 +437,9 @@ function Invoke-WebView2MicrosoftLogin {
                                         $Script:LoginSubState = "ClickingSubmit"
                                     }
                                     else {
-                                        # Failed to set username, reset
-                                        "Failed to set username: $($Script:LoginTask.Exception.Message)" | Write-Verbose
-                                        $Script:LoginSubState = $null
-                                        $Script:MicrosoftOnlineLogin = $false
+                                        # The username could not be written into the field, so the
+                                        # user has to type it. Tell them, rather than stopping mute.
+                                        Switch-ToManualLogin -State "Scenario1/SettingUsername" -MissingElementId $UserNameElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
                                     }
                                 }
                                 return $false
@@ -423,6 +449,10 @@ function Invoke-WebView2MicrosoftLogin {
                                 if ($Script:LoginTask.IsCompleted) {
                                     "Clicked submit, waiting for page change..." | Write-Verbose
                                     # Reset state to detect next page
+                                    # Clicking counts as progress, so restart the stall clock. The
+                                    # username and password pages carry the same element IDs, so
+                                    # without this the clock would keep running across the step.
+                                    $Script:UnmatchedPageSince = $null
                                     $Script:LoginState = "GettingIds"
                                     $Script:LoginSubState = $null
                                     $Script:IdAttributes = $null
@@ -496,9 +526,7 @@ function Invoke-WebView2MicrosoftLogin {
                                         }
                                     }
                                     else {
-                                        # Task faulted, reset
-                                        "Password field check faulted: $($Script:LoginTask.Exception.Message)" | Write-Verbose
-                                        $Script:LoginSubState = $null
+                                        Switch-ToManualLogin -State "Scenario2/CheckingPasswordField" -MissingElementId $PasswordElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
                                     }
                                 }
                                 return $false
@@ -514,9 +542,7 @@ function Invoke-WebView2MicrosoftLogin {
                                         $Script:LoginSubState = "ClickingSubmit"
                                     }
                                     else {
-                                        # Failed to set password, reset
-                                        "Failed to set password: $($Script:LoginTask.Exception.Message)" | Write-Verbose
-                                        $Script:LoginSubState = $null
+                                        Switch-ToManualLogin -State "Scenario2/SettingPassword" -MissingElementId $PasswordElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
                                     }
                                 }
                                 return $false
@@ -526,6 +552,7 @@ function Invoke-WebView2MicrosoftLogin {
                                 if ($Script:LoginTask.IsCompleted) {
                                     "Clicked submit, waiting for page change..." | Write-Verbose
                                     # Reset state to detect next page
+                                    $Script:UnmatchedPageSince = $null
                                     $Script:LoginState = "GettingIds"
                                     $Script:LoginSubState = $null
                                     $Script:IdAttributes = $null
@@ -596,6 +623,7 @@ function Invoke-WebView2MicrosoftLogin {
                                 if ($Script:LoginTask.IsCompleted) {
                                     "Clicked No, waiting for page change..." | Write-Verbose
                                     # Reset state to detect next page
+                                    $Script:UnmatchedPageSince = $null
                                     $Script:LoginState = "GettingIds"
                                     $Script:LoginSubState = $null
                                     $Script:IdAttributes = $null
@@ -635,6 +663,7 @@ function Invoke-WebView2MicrosoftLogin {
                                         if ($result -eq "true") {
                                             "Selected logged-in account" | Write-Verbose
                                             # Reset state to detect next page
+                                            $Script:UnmatchedPageSince = $null
                                             $Script:LoginState = "GettingIds"
                                             $Script:LoginSubState = $null
                                             $Script:IdAttributes = $null
@@ -674,6 +703,7 @@ function Invoke-WebView2MicrosoftLogin {
                                         if ($result -eq "true") {
                                             "Clicked 'Use another account', going to username entry..." | Write-Verbose
                                             # Reset state to detect username page
+                                            $Script:UnmatchedPageSince = $null
                                             $Script:LoginState = "GettingIds"
                                             $Script:LoginSubState = $null
                                             $Script:IdAttributes = $null
@@ -762,12 +792,19 @@ function Invoke-WebView2MicrosoftLogin {
                         "`nMFA failed! Please retry!" | Write-Warning
                         $Script:MfaRequestDisplayed = $false
                         # Reset state to detect next page
+                        $Script:UnmatchedPageSince = $null
                         $Script:LoginState = "GettingIds"
                         $Script:IdAttributes = $null
                         return $true
                     }
 
-                    # No scenario matched, stay in this state and wait for next timer tick
+                    # No scenario matched. Re-read the page on the next tick rather than
+                    # re-evaluating attributes that are already stale, so that a page which is only
+                    # mid-navigation is picked up as soon as it settles. The stall check above ends
+                    # this loop when the same page keeps not matching.
+                    $Script:LoginState = "GettingIds"
+                    $Script:LoginTask = $null
+                    $Script:IdAttributes = $null
                     return $false
 
                 }

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -807,6 +807,11 @@ function Invoke-WebView2MicrosoftLogin {
                     # re-evaluating attributes that are already stale, so that a page which is only
                     # mid-navigation is picked up as soon as it settles. The stall check above ends
                     # this loop when the same page keeps not matching.
+                    # Nothing on this page is being acted on, so the scenario the previous page was
+                    # in no longer describes anything - keep it for the verbose trail, but do not
+                    # let the stall diagnostic report it as the current state.
+                    $Script:PreviousScenario = $Script:CurrentScenario
+                    $Script:CurrentScenario = $null
                     $Script:LoginState = "GettingIds"
                     $Script:LoginTask = $null
                     $Script:IdAttributes = $null

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -30,6 +30,10 @@ function Invoke-WebView2MicrosoftLogin {
         $ButtonBackId = "idBtn_Back"
         $KeepMeSignedInId = "KmsiCheckboxField"
 
+        # Everything the scenarios below recognize a page by, and so everything a diagnostic has to
+        # be able to report as absent.
+        $KnownElementId = @($UserNameElementId, $PasswordElementId, $SubmitButtonId, $ButtonBackId, $CantAccessAccountId, $MfaElementId1, $MfaElementId2, $MfaRetryId1, $MfaRetryId2, $KeepMeSignedInId)
+
         # JavaScript to get all element details on the page
         $getAllIdsScript = @"
 (function() {
@@ -279,7 +283,9 @@ function Invoke-WebView2MicrosoftLogin {
                             # A sign-in page carrying none of the known IDs at all is the loudest
                             # form of a selector break, and retrying it would otherwise never end.
                             if (Test-LoginAutomationStalled -ElementId @()) {
-                                Switch-ToManualLogin -State "GettingIds" -Url $Script:WebView2.Source.AbsoluteUri -Reason "The page carries none of the element IDs this module looks for." | Out-Null
+                                # Every known selector is missing here, so name them all rather than
+                                # leaving the diagnostic without a single selector in it.
+                                Switch-ToManualLogin -State "GettingIds" -MissingElementId $KnownElementId -FoundElementId @() -Url $Script:WebView2.Source.AbsoluteUri -Reason "The page carries none of the element IDs this module looks for." | Out-Null
                                 return $false
                             }
 
@@ -347,7 +353,6 @@ function Invoke-WebView2MicrosoftLogin {
                     # path anyway (issue #32).
                     $WaitingForApproval = $Script:MfaRequestDisplayed -and ($MfaElementId1 -in $Script:IdAttributes.id -or $MfaElementId2 -in $Script:IdAttributes.id)
                     if (Test-LoginAutomationStalled -ElementId $Script:IdAttributes.id -WaitingForApproval:$WaitingForApproval) {
-                        $KnownElementId = @($UserNameElementId, $PasswordElementId, $SubmitButtonId, $ButtonBackId, $CantAccessAccountId, $MfaElementId1, $MfaElementId2, $MfaRetryId1, $MfaRetryId2, $KeepMeSignedInId)
                         $MissingElementId = @($KnownElementId | Where-Object { $_ -notin $Script:IdAttributes.id })
                         $ScenarioName = "NoMatchingScenario"
                         if (-not [string]::IsNullOrWhiteSpace($Script:CurrentScenario)) {

--- a/OmadaWeb.PS/Private/Reset-LoginAutomationState.ps1
+++ b/OmadaWeb.PS/Private/Reset-LoginAutomationState.ps1
@@ -1,0 +1,24 @@
+function Reset-LoginAutomationState {
+    <#
+    .SYNOPSIS
+        Gives credential autofill a clean slate for a new sign-in window.
+
+    .DESCRIPTION
+        Switch-ToManualLogin deliberately leaves its state set for the rest of a sign-in: that is what
+        keeps a 150 ms timer from repeating the same warning forever, and what keeps the drivers from
+        fighting a user who is typing. It has to be cleared somewhere, and it cannot be cleared by
+        Invoke-WebView2MicrosoftLogin's "left the sign-in page" branch - after a fallback that function
+        returns at the top, because autofill is off, and never reaches it.
+
+        So the reset belongs where a new browser window starts: Initialize-WebView2 for WebView2 and
+        Get-DataFromWebDriver for Edge WebDriver. Without it, a second window in the same session
+        would drive the page again (Initialize-WebView2 re-enables autofill) while the fallback still
+        counted as reported, and the user would never see the diagnostic for it.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $Script:ManualLoginFallbackActive = $false
+    $Script:UnmatchedPageSignature = $null
+    $Script:UnmatchedPageSince = $null
+}

--- a/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
+++ b/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
@@ -59,17 +59,21 @@ function Switch-ToManualLogin {
         }
     }
 
-    $MissingText = "none - the page matched none of the known sign-in steps"
-    if (($MissingElementId | Measure-Object).Count -gt 0) {
-        $MissingText = $MissingElementId -join ", "
+    # Not every caller knows which selector is to blame - a script exception carries a reason but no
+    # element - so the default has to say "unknown", not something the reader would act on.
+    $MissingText = "unknown"
+    $NamedMissingElementId = @($MissingElementId | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($NamedMissingElementId.Count -gt 0) {
+        $MissingText = $NamedMissingElementId -join ", "
     }
 
     $Lines = [System.Collections.Generic.List[string]]::new()
     $Lines.Add("Automated Microsoft sign-in could not continue - handing control back to you.")
     $Lines.Add("  State            : {0}" -f $State)
     $Lines.Add("  Missing elements : {0}" -f $MissingText)
-    if (($FoundElementId | Measure-Object).Count -gt 0) {
-        $Lines.Add("  Elements present : {0}" -f ($FoundElementId -join ", "))
+    $NamedFoundElementId = @($FoundElementId | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($NamedFoundElementId.Count -gt 0) {
+        $Lines.Add("  Elements present : {0}" -f ($NamedFoundElementId -join ", "))
     }
 
     $Lines.Add("  Page URL         : {0}" -f $PageAddress)

--- a/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
+++ b/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
@@ -1,0 +1,89 @@
+function Switch-ToManualLogin {
+    <#
+    .SYNOPSIS
+        Stops credential autofill, explains why, and leaves the sign-in to the user.
+
+    .DESCRIPTION
+        The Microsoft sign-in automation recognizes pages by hardcoded Entra element IDs. Microsoft
+        changes that markup without notice, and when it does no scenario matches any more. Failing
+        the request at that point would be wrong: the browser window is open and visible, and for
+        every tenant that is not on Entra typing the credentials there is the normal sign-in path
+        anyway. So a selector break degrades autofill, not login.
+
+        This function is the single place that makes that switch. It clears the flag the WebView2
+        timer and the Edge WebDriver poll loop use to decide whether to drive the page, and prints a
+        diagnostic naming the state, the selectors that were expected but absent, and the page the
+        browser is on - the three things needed to fix the selector table afterwards.
+
+        Only the path of the page URL is reported. Sign-in URLs carry client_id, state and nonce
+        query parameters, and this text is written to a stream that users routinely capture into
+        support logs.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$State,
+
+        [AllowNull()]
+        [string[]]$MissingElementId,
+
+        [AllowNull()]
+        [string[]]$FoundElementId,
+
+        [AllowNull()]
+        [string]$Url,
+
+        [AllowNull()]
+        [string]$Reason
+    )
+
+    if ($Script:ManualLoginFallbackActive) {
+        # The timer ticks every 150 ms and the WebDriver loop every 500 ms, so the guard is what
+        # keeps this a diagnostic instead of a flood.
+        "Manual login fallback is already active - not reporting again" | Write-Verbose
+        return $false
+    }
+
+    $Script:ManualLoginFallbackActive = $true
+    $Script:MicrosoftOnlineLogin = $false
+    $Script:LoginSubState = $null
+    $Script:LoginTask = $null
+
+    $PageAddress = "unknown"
+    if (-not [string]::IsNullOrWhiteSpace($Url)) {
+        try {
+            $PageAddress = ([System.Uri]::New($Url)).GetLeftPart([System.UriPartial]::Path)
+        }
+        catch {
+            $PageAddress = Protect-LogMessage -Message $Url
+        }
+    }
+
+    $MissingText = "none - the page matched none of the known sign-in steps"
+    if (($MissingElementId | Measure-Object).Count -gt 0) {
+        $MissingText = $MissingElementId -join ", "
+    }
+
+    $Lines = [System.Collections.Generic.List[string]]::new()
+    $Lines.Add("Automated Microsoft sign-in could not continue - handing control back to you.")
+    $Lines.Add("  State            : {0}" -f $State)
+    $Lines.Add("  Missing elements : {0}" -f $MissingText)
+    if (($FoundElementId | Measure-Object).Count -gt 0) {
+        $Lines.Add("  Elements present : {0}" -f ($FoundElementId -join ", "))
+    }
+
+    $Lines.Add("  Page URL         : {0}" -f $PageAddress)
+    if (-not [string]::IsNullOrWhiteSpace($Reason)) {
+        $Lines.Add("  Reason           : {0}" -f (Protect-LogMessage -Message $Reason))
+    }
+
+    $Lines.Add("The sign-in page no longer matches what this module knows about it, which usually means Microsoft changed it. Please sign in yourself in the browser window that is open - only filling in your credentials automatically stopped working, signing in did not. Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues.")
+
+    ($Lines -join [System.Environment]::NewLine) | Write-Warning
+
+    if (-not [string]::IsNullOrWhiteSpace($Url)) {
+        "Switch-ToManualLogin - Full page URL: {0}" -f (Protect-LogMessage -Message $Url) | Write-Verbose
+    }
+
+    return $true
+}

--- a/OmadaWeb.PS/Private/Test-LoginAutomationStalled.ps1
+++ b/OmadaWeb.PS/Private/Test-LoginAutomationStalled.ps1
@@ -1,0 +1,52 @@
+function Test-LoginAutomationStalled {
+    <#
+    .SYNOPSIS
+        Reports whether the sign-in automation has stopped making progress on the current page.
+
+    .DESCRIPTION
+        Both login drivers poll: the WebView2 timer every 150 ms, the Edge WebDriver loop every
+        500 ms. When the page stops matching any known scenario - or matches one whose actions no
+        longer do anything - both simply keep polling, which is the stall this exists to detect.
+
+        Progress is measured by the set of known element IDs on the page. A healthy sign-in moves to
+        a different page within seconds, changing that set; the call sites additionally clear
+        $Script:UnmatchedPageSince whenever they successfully click something, so a step that submits
+        a page whose element IDs happen to be identical to the previous one still counts as progress.
+
+        Waiting for the user to approve a sign-in request in their authenticator app is not a stall,
+        which is what -WaitingForApproval is for.
+    #>
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string[]]$ElementId,
+
+        [switch]$WaitingForApproval
+    )
+
+    if ($WaitingForApproval) {
+        $Script:UnmatchedPageSignature = $null
+        $Script:UnmatchedPageSince = $null
+        return $false
+    }
+
+    $Signature = "<no known elements>"
+    if (($ElementId | Measure-Object).Count -gt 0) {
+        $Signature = ($ElementId | Sort-Object) -join ","
+    }
+
+    if ($Script:UnmatchedPageSignature -ne $Signature -or $null -eq $Script:UnmatchedPageSince) {
+        $Script:UnmatchedPageSignature = $Signature
+        $Script:UnmatchedPageSince = [DateTime]::Now
+        return $false
+    }
+
+    $StalledSeconds = ([DateTime]::Now - $Script:UnmatchedPageSince).TotalSeconds
+    if ($StalledSeconds -lt $Script:LoginAutomationFallbackTimeout) {
+        return $false
+    }
+
+    "{0} - No sign-in progress for {1:N0} seconds on a page with elements: {2}" -f $MyInvocation.MyCommand, $StalledSeconds, $Signature | Write-Verbose
+
+    return $true
+}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ Invoke-OmadaWebRequest -Uri "https://your-omada-instance.com/api/data"
 Invoke-OmadaWebRequest -Uri "https://your-omada-instance.com/api/data" -AuthenticationType "Browser"
 ```
 
+### Signing in, and what happens when Microsoft changes the sign-in page
+
+Every browser-based authentication type signs in the same way a person does: a browser window opens on your Omada instance, and you complete the sign-in there. Passing a `-Credential` for an Entra tenant adds one convenience on top of that - the module recognizes the Microsoft sign-in pages and fills the fields in for you.
+
+That recognition rests on element IDs Microsoft can change at any time, and does. When a page no longer matches what the module knows, the module stops filling fields in and hands the window back to you with a warning such as:
+
+```text
+WARNING: Automated Microsoft sign-in could not continue - handing control back to you.
+  State            : ProcessingScenarios/NoMatchingScenario
+  Missing elements : i0116, idSIButton9
+  Elements present : signInName
+  Page URL         : https://login.microsoftonline.com/common/oauth2/authorize
+```
+
+**A change to the sign-in page degrades autofill, not login.** The window is open and the request continues as soon as you have signed in yourself, exactly as it does for every tenant that is not on Entra - there, signing in by hand at your own identity provider is the normal path anyway.
+
+The warning names the state, the elements that were expected but absent, and the page the browser was on. That is what a fix needs, so please include it when reporting the change at [GitHub Issues](https://github.com/Fortigi/OmadaWeb.PS/issues). No query string is printed, since sign-in URLs carry request identifiers.
+
+The module waits 60 seconds without progress before it gives up on autofill, so a slow round trip to Microsoft is not mistaken for a changed page. Waiting for you to approve a sign-in request in your authenticator app does not count against that.
+
 ### Local data footprint
 
 Everything the module stores lives under one root: `%LOCALAPPDATA%\OmadaWeb.PS`. This is what ends up there, and why:

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -234,10 +234,13 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
 
     BeforeEach {
         InModuleScope 'OmadaWeb.PS' {
-            # A page that carries none of the element IDs the scenarios look for - what a Microsoft
-            # sign-in redesign looks like from here.
+            # A page that carries none of the element IDs any scenario acts on - what a Microsoft
+            # sign-in redesign looks like from here. getAllIdsScript only ever reports IDs from its
+            # own list, so an unrecognized page reaches ProcessingScenarios either empty or carrying
+            # one of the IDs that list looks for but no scenario handles. i0281 is such an ID, and
+            # using it keeps this fixture the shape the state machine really receives.
             $Script:UnknownPageAttributes = @(
-                [PSCustomObject]@{ id = 'signInName'; tagName = 'INPUT'; outerHTML = '<input id="signInName">' }
+                [PSCustomObject]@{ id = 'i0281'; tagName = 'DIV'; outerHTML = '<div id="i0281"></div>' }
             )
 
             $Script:WebView2 = [PSCustomObject]@{
@@ -312,7 +315,7 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
             $Warning | Should -BeLike '*i0116*'
             $Warning | Should -BeLike '*i0118*'
             $Warning | Should -BeLike '*idSIButton9*'
-            $Warning | Should -BeLike '*signInName*'
+            $Warning | Should -BeLike '*Elements present : i0281*'
             $Warning | Should -BeLike '*https://login.microsoftonline.com/common/oauth2/authorize*'
         }
     }

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -1,0 +1,315 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Switch-ToManualLogin' -Tag 'Unit' {
+
+    BeforeEach {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:ManualLoginFallbackActive = $false
+            $Script:MicrosoftOnlineLogin = $true
+            $Script:UnmatchedPageSignature = $null
+            $Script:UnmatchedPageSince = $null
+        }
+    }
+
+    It 'Hands control to the user by stopping the sign-in automation' {
+        InModuleScope 'OmadaWeb.PS' {
+            Switch-ToManualLogin -State 'ProcessingScenarios' -MissingElementId 'i0116' -WarningAction SilentlyContinue | Should -BeTrue
+
+            $Script:MicrosoftOnlineLogin | Should -BeFalse
+            $Script:ManualLoginFallbackActive | Should -BeTrue
+        }
+    }
+
+    It 'Names the state, the missing selector and the page URL' {
+        InModuleScope 'OmadaWeb.PS' {
+            # Capture the warning stream only. The verbose stream repeats the URL, so folding the
+            # streams together would let this pass without the warning saying anything at all.
+            Switch-ToManualLogin -State 'ProcessingScenarios' -MissingElementId @('i0116', 'idSIButton9') -Url 'https://login.microsoftonline.com/common/oauth2/authorize?client_id=abc' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+            $Warning = $Warnings -join "`n"
+
+            $Warning | Should -BeLike '*ProcessingScenarios*'
+            $Warning | Should -BeLike '*i0116*'
+            $Warning | Should -BeLike '*idSIButton9*'
+            $Warning | Should -BeLike '*https://login.microsoftonline.com/common/oauth2/authorize*'
+        }
+    }
+
+    It 'Keeps the query string of the page URL out of the warning' {
+        InModuleScope 'OmadaWeb.PS' {
+            Switch-ToManualLogin -State 'ProcessingScenarios' -Url 'https://login.microsoftonline.com/common/oauth2/authorize?client_id=abc&state=secretstate' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+            ($Warnings -join "`n") | Should -Not -BeLike '*secretstate*'
+        }
+    }
+
+    It 'States that signing in still works' {
+        InModuleScope 'OmadaWeb.PS' {
+            Switch-ToManualLogin -State 'ProcessingScenarios' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+            ($Warnings -join "`n") | Should -BeLike '*sign in yourself in the browser window*'
+        }
+    }
+
+    It 'Reports once per sign-in, not once per poll' {
+        InModuleScope 'OmadaWeb.PS' {
+            $First = Switch-ToManualLogin -State 'ProcessingScenarios' -WarningAction SilentlyContinue
+            $Second = Switch-ToManualLogin -State 'ProcessingScenarios' -WarningVariable Warnings -WarningAction SilentlyContinue
+
+            $First | Should -BeTrue
+            $Second | Should -BeFalse
+            ($Warnings | Measure-Object).Count | Should -Be 0
+        }
+    }
+
+    It 'Reports a reason when one is given, with secrets removed' {
+        InModuleScope 'OmadaWeb.PS' {
+            Switch-ToManualLogin -State 'Scenario1/SettingUsername' -Reason 'Request failed with Authorization: Bearer abcdef1234567890' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+            $Warning = $Warnings -join "`n"
+
+            $Warning | Should -BeLike '*Scenario1/SettingUsername*'
+            $Warning | Should -BeLike '*Request failed*'
+            $Warning | Should -Not -BeLike '*abcdef1234567890*'
+        }
+    }
+}
+
+Describe 'Test-LoginAutomationStalled' -Tag 'Unit' {
+
+    BeforeEach {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:UnmatchedPageSignature = $null
+            $Script:UnmatchedPageSince = $null
+            $Script:LoginAutomationFallbackTimeout = 0
+        }
+    }
+
+    AfterAll {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:LoginAutomationFallbackTimeout = 60
+        }
+    }
+
+    It 'Does not report a stall on the first sight of a page' {
+        InModuleScope 'OmadaWeb.PS' {
+            Test-LoginAutomationStalled -ElementId @('i0116', 'idSIButton9') | Should -BeFalse
+        }
+    }
+
+    It 'Reports a stall when the same page keeps coming back' {
+        InModuleScope 'OmadaWeb.PS' {
+            Test-LoginAutomationStalled -ElementId @('someNewId') | Out-Null
+
+            Test-LoginAutomationStalled -ElementId @('someNewId') | Should -BeTrue
+        }
+    }
+
+    It 'Restarts the clock when the page changes' {
+        InModuleScope 'OmadaWeb.PS' {
+            Test-LoginAutomationStalled -ElementId @('i0116') | Out-Null
+
+            Test-LoginAutomationStalled -ElementId @('i0118') | Should -BeFalse
+        }
+    }
+
+    It 'Restarts the clock when a call site reports progress' {
+        InModuleScope 'OmadaWeb.PS' {
+            Test-LoginAutomationStalled -ElementId @('i0116') | Out-Null
+            # What the call sites do after a successful click.
+            $Script:UnmatchedPageSince = $null
+
+            Test-LoginAutomationStalled -ElementId @('i0116') | Should -BeFalse
+        }
+    }
+
+    It 'Ignores element order' {
+        InModuleScope 'OmadaWeb.PS' {
+            Test-LoginAutomationStalled -ElementId @('i0116', 'i0118') | Out-Null
+
+            Test-LoginAutomationStalled -ElementId @('i0118', 'i0116') | Should -BeTrue
+        }
+    }
+
+    It 'Does not report a stall while waiting for the user to approve the sign-in request' {
+        InModuleScope 'OmadaWeb.PS' {
+            Test-LoginAutomationStalled -ElementId @('idRichContext_DisplaySign') | Out-Null
+
+            Test-LoginAutomationStalled -ElementId @('idRichContext_DisplaySign') -WaitingForApproval | Should -BeFalse
+        }
+    }
+
+    It 'Treats a page without any known element as a page in its own right' {
+        InModuleScope 'OmadaWeb.PS' {
+            Test-LoginAutomationStalled -ElementId @() | Out-Null
+
+            Test-LoginAutomationStalled -ElementId @() | Should -BeTrue
+        }
+    }
+
+    It 'Holds off while the timeout has not passed' {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:LoginAutomationFallbackTimeout = 600
+
+            Test-LoginAutomationStalled -ElementId @('i0116') | Out-Null
+
+            Test-LoginAutomationStalled -ElementId @('i0116') | Should -BeFalse
+        }
+    }
+}
+
+Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
+
+    BeforeEach {
+        InModuleScope 'OmadaWeb.PS' {
+            # A page that carries none of the element IDs the scenarios look for - what a Microsoft
+            # sign-in redesign looks like from here.
+            $Script:UnknownPageAttributes = @(
+                [PSCustomObject]@{ id = 'signInName'; tagName = 'INPUT'; outerHTML = '<input id="signInName">' }
+            )
+
+            $Script:WebView2 = [PSCustomObject]@{
+                Source       = [System.Uri]::New('https://login.microsoftonline.com/common/oauth2/authorize?client_id=abc')
+                CoreWebView2 = [PSCustomObject]@{}
+            }
+
+            $Script:WebView2.CoreWebView2 | Add-Member -MemberType ScriptMethod -Name ExecuteScriptAsync -Value {
+                param($Script)
+
+                [PSCustomObject]@{
+                    IsCompleted = $true
+                    IsFaulted   = $false
+                    Result      = 'null'
+                }
+            }
+
+            $Script:CurrentWebView2Session = [PSCustomObject]@{
+                Credential = New-Object System.Management.Automation.PSCredential('user@contoso.com', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+            }
+
+            $Script:MicrosoftOnlineLogin = $true
+            $Script:LoginFailed = $false
+            $Script:ManualLoginFallbackActive = $false
+            $Script:MfaRequestDisplayed = $false
+            $Script:LoginState = 'ProcessingScenarios'
+            $Script:LoginSubState = $null
+            $Script:LoginTask = $null
+            $Script:IdAttributes = $Script:UnknownPageAttributes
+            $Script:PreviousAttributes = $Script:UnknownPageAttributes
+            $Script:UnmatchedPageSignature = $null
+            $Script:UnmatchedPageSince = $null
+            $Script:LoginAutomationFallbackTimeout = 0
+        }
+    }
+
+    AfterAll {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:WebView2 = $null
+            $Script:CurrentWebView2Session = $null
+            $Script:IdAttributes = $null
+            $Script:PreviousAttributes = $null
+            $Script:LoginAutomationFallbackTimeout = 60
+        }
+    }
+
+    It 'Falls back to manual login when the page matches no known sign-in step' {
+        InModuleScope 'OmadaWeb.PS' {
+            # First pass arms the stall clock, second pass hits the timeout. Warnings raised inside
+            # the state machine do not reach an outer -WarningVariable, so redirect the warning
+            # stream and keep only warning records - a fold of every stream would let the verbose
+            # logging satisfy these assertions on its own.
+            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
+            $Script:LoginState = 'ProcessingScenarios'
+            $Script:IdAttributes = $Script:UnknownPageAttributes
+            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+
+            $Script:MicrosoftOnlineLogin | Should -BeFalse
+            ($Warnings -join "`n") | Should -BeLike '*ProcessingScenarios*'
+        }
+    }
+
+    It 'Names the missing selectors and the page in the diagnostic' {
+        InModuleScope 'OmadaWeb.PS' {
+            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
+            $Script:LoginState = 'ProcessingScenarios'
+            $Script:IdAttributes = $Script:UnknownPageAttributes
+            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+
+            $Warning = $Warnings -join "`n"
+
+            $Warning | Should -BeLike '*i0116*'
+            $Warning | Should -BeLike '*i0118*'
+            $Warning | Should -BeLike '*idSIButton9*'
+            $Warning | Should -BeLike '*signInName*'
+            $Warning | Should -BeLike '*https://login.microsoftonline.com/common/oauth2/authorize*'
+        }
+    }
+
+    It 'Does not fall back while the page still matches a known sign-in step' {
+        InModuleScope 'OmadaWeb.PS' {
+            # Working through the sub-states of a recognized page takes several ticks, which is why
+            # the timeout is generous in the module. Use the real one here.
+            $Script:LoginAutomationFallbackTimeout = 60
+
+            $KnownPage = @(
+                [PSCustomObject]@{ id = 'i0116'; outerHTML = '<input id="i0116">' }
+                [PSCustomObject]@{ id = 'idSIButton9'; outerHTML = '<input id="idSIButton9">' }
+            )
+
+            $Script:IdAttributes = $KnownPage
+            $Script:PreviousAttributes = $KnownPage
+
+            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
+            $Script:LoginState = 'ProcessingScenarios'
+            $Script:IdAttributes = $KnownPage
+            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+
+            $Script:MicrosoftOnlineLogin | Should -BeTrue
+            ($Warnings | Measure-Object).Count | Should -Be 0
+        }
+    }
+
+    It 'Does not fall back while waiting for the user to approve the sign-in request' {
+        InModuleScope 'OmadaWeb.PS' {
+            $MfaPage = @(
+                [PSCustomObject]@{ id = 'idRichContext_DisplaySign'; outerHTML = '<div id="idRichContext_DisplaySign">42</div>' }
+            )
+
+            $Script:MfaRequestDisplayed = $true
+            $Script:IdAttributes = $MfaPage
+            $Script:PreviousAttributes = $MfaPage
+
+            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
+            $Script:LoginState = 'ProcessingScenarios'
+            $Script:IdAttributes = $MfaPage
+            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+
+            $Script:MicrosoftOnlineLogin | Should -BeTrue
+            ($Warnings | Measure-Object).Count | Should -Be 0
+        }
+    }
+
+    It 'Resets the fallback when the browser leaves the Microsoft sign-in page' {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:ManualLoginFallbackActive = $true
+            $Script:UnmatchedPageSince = [DateTime]::Now
+            $Script:WebView2.Source = [System.Uri]::New('https://omada.contoso.com/home')
+
+            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
+
+            $Script:ManualLoginFallbackActive | Should -BeFalse
+            $Script:UnmatchedPageSince | Should -BeNullOrEmpty
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -58,6 +58,31 @@ Describe 'Switch-ToManualLogin' -Tag 'Unit' {
         }
     }
 
+    It 'Says the missing selector is unknown when the caller cannot name one' {
+        InModuleScope 'OmadaWeb.PS' {
+            # A script exception carries a reason but no element. Claiming the page matched no known
+            # step would be a different, and wrong, statement.
+            Switch-ToManualLogin -State 'EdgeDriverLoginScenarios' -Reason 'stale element reference' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+            $Warning = $Warnings -join "`n"
+
+            $Warning | Should -BeLike '*Missing elements : unknown*'
+            $Warning | Should -Not -BeLike '*matched none of the known sign-in steps*'
+        }
+    }
+
+    It 'Leaves empty entries out of the element lists' {
+        InModuleScope 'OmadaWeb.PS' {
+            Switch-ToManualLogin -State 'ProcessingScenarios' -MissingElementId @('i0116', '', $null) -FoundElementId @('', $null) -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+            $Warning = $Warnings -join "`n"
+
+            $Warning | Should -BeLike '*Missing elements : i0116*'
+            $Warning | Should -Not -BeLike '*i0116,*'
+            $Warning | Should -Not -BeLike '*Elements present*'
+        }
+    }
+
     It 'Reports once per sign-in, not once per poll' {
         InModuleScope 'OmadaWeb.PS' {
             $First = Switch-ToManualLogin -State 'ProcessingScenarios' -WarningAction SilentlyContinue
@@ -293,6 +318,28 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
 
             $Script:MicrosoftOnlineLogin | Should -BeTrue
             ($Warnings | Measure-Object).Count | Should -Be 0
+        }
+    }
+
+    It 'Names every known selector when the page carries none of them' {
+        InModuleScope 'OmadaWeb.PS' {
+            # getAllIds found nothing at all - the loudest form of a selector break. The diagnostic
+            # has to list what was looked for, since the page itself offers nothing to report.
+            $Script:LoginState = 'GettingIds'
+            $Script:LoginTask = [PSCustomObject]@{ IsCompleted = $true; IsFaulted = $false; Result = '"[]"' }
+
+            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
+
+            $Script:LoginState = 'GettingIds'
+            $Script:LoginTask = [PSCustomObject]@{ IsCompleted = $true; IsFaulted = $false; Result = '"[]"' }
+            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+
+            $Warning = $Warnings -join "`n"
+
+            $Warning | Should -BeLike '*i0116*'
+            $Warning | Should -BeLike '*KmsiCheckboxField*'
+            $Warning | Should -Not -BeLike '*Missing elements : unknown*'
+            $Warning | Should -Not -BeLike '*Elements present*'
         }
     }
 

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -107,6 +107,46 @@ Describe 'Switch-ToManualLogin' -Tag 'Unit' {
     }
 }
 
+Describe 'Reset-LoginAutomationState' -Tag 'Unit' {
+
+    It 'Lets a new browser window report a fallback of its own' {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:MicrosoftOnlineLogin = $true
+            Switch-ToManualLogin -State 'ProcessingScenarios' -WarningAction SilentlyContinue | Out-Null
+
+            # What Initialize-WebView2 and Get-DataFromWebDriver do for every new window. Without it
+            # the guard inside Switch-ToManualLogin would keep the next window's diagnostic silent.
+            Reset-LoginAutomationState
+            $Script:MicrosoftOnlineLogin = $true
+
+            Switch-ToManualLogin -State 'ProcessingScenarios' -WarningAction SilentlyContinue | Should -BeTrue
+        }
+    }
+
+    It 'Clears the stall clock' {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:UnmatchedPageSignature = 'i0116'
+            $Script:UnmatchedPageSince = [DateTime]::Now
+
+            Reset-LoginAutomationState
+
+            $Script:UnmatchedPageSignature | Should -BeNullOrEmpty
+            $Script:UnmatchedPageSince | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Is called by Initialize-WebView2 before the sign-in timer starts' {
+        InModuleScope 'OmadaWeb.PS' {
+            # Initialize-WebView2 needs a real WinForms WebView2 to run, so assert on the call site
+            # instead: this is the only place a WebView2 window arms autofill again.
+            $Definition = (Get-Command Initialize-WebView2).Definition
+
+            $Definition | Should -BeLike '*$Script:MicrosoftOnlineLogin = $true*'
+            $Definition | Should -BeLike '*Reset-LoginAutomationState*'
+        }
+    }
+}
+
 Describe 'Test-LoginAutomationStalled' -Tag 'Unit' {
 
     BeforeEach {

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -364,6 +364,38 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
         }
     }
 
+    It 'Does not report a scenario the previous page was in' {
+        InModuleScope 'OmadaWeb.PS' {
+            # The username page matched a scenario, then the sign-in moved to a page nothing
+            # recognizes. Naming UsernameEntry in the diagnostic would send a reader looking at the
+            # wrong code.
+            #
+            # A page with only the back button reaches the "no scenario matched" branch: the
+            # stay-signed-in scenario needs a submit button too, and account selection needs the
+            # back button to be absent.
+            $BackButtonOnlyPage = @(
+                [PSCustomObject]@{ id = 'idBtn_Back'; outerHTML = '<input id="idBtn_Back">' }
+            )
+
+            $Script:CurrentScenario = 'UsernameEntry'
+            $Script:IdAttributes = $BackButtonOnlyPage
+            $Script:PreviousAttributes = $BackButtonOnlyPage
+
+            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
+
+            $Script:CurrentScenario | Should -BeNullOrEmpty -Because 'no scenario is acting on this page'
+
+            $Script:LoginState = 'ProcessingScenarios'
+            $Script:IdAttributes = $BackButtonOnlyPage
+            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+
+            $Warning = $Warnings -join "`n"
+
+            $Warning | Should -Not -BeLike '*UsernameEntry*'
+            $Warning | Should -BeLike '*ProcessingScenarios/NoMatchingScenario*'
+        }
+    }
+
     It 'Names every known selector when the page carries none of them' {
         InModuleScope 'OmadaWeb.PS' {
             # getAllIds found nothing at all - the loudest form of a selector break. The diagnostic


### PR DESCRIPTION
Part of #32 (Roadmap D3) — **layers 1 and 2 only**: graceful fallback to manual sign-in, and diagnostics that name what broke. Layer 3 (out-of-band selector table) depends on #30 and is not in this PR, so the issue stays open.

## What was broken

The sign-in automation recognizes Entra pages by hardcoded element IDs (`i0116`, `i0118`, `idSIButton9`, `idBtn_Back`, …). When Microsoft changes that markup — which they do, continuously and per-A/B-cohort — neither driver had a way out:

| Where | Failure mode |
| --- | --- |
| `Invoke-WebView2MicrosoftLogin.ps1` — "No scenario matched" | Returned `$false` on **stale** `$Script:IdAttributes` forever; the state machine never re-read the page from `ProcessingScenarios`. The 150 ms timer span until the 600 s Omada watchdog fired or the user closed the window. |
| `Invoke-WebView2MicrosoftLogin.ps1` — account-selection scenario | Sub-state cycled `$null → ClickingAccount → $null` indefinitely on any page without the username, password or back-button IDs. |
| `Invoke-WebView2MicrosoftLogin.ps1` — faulted-task branches | Set `$Script:MicrosoftOnlineLogin = $false` with only a `Write-Verbose`: autofill stopped, the user was told nothing. |
| `Get-DataFromWebDriver.ps1` | Kept polling every 500 ms with none of its five scenarios able to act, printing dots; every scenario error went into an empty `catch {}`. |

None of that has to fail the request. The browser window is open and visible, and for every tenant that is not on Entra, signing in there by hand is the normal path already. **A selector break should degrade autofill, not login.**

## What changed

| New | Purpose |
| --- | --- |
| `OmadaWeb.PS/Private/Test-LoginAutomationStalled.ps1` | Measures progress by the set of known element IDs on the page. Reports a stall when the same page persists for `$Script:LoginAutomationFallbackTimeout` (60 s) without the automation acting on it. Waiting for the user to approve a sign-in request in their authenticator app is excluded. |
| `OmadaWeb.PS/Private/Switch-ToManualLogin.ps1` | The single place that gives up: clears the flag both drivers use to decide whether to drive the page, and warns **once per sign-in** naming the state, the missing selectors, the ones that were present and the page URL. |
| `Tests/Unit/Switch-ToManualLogin.Tests.ps1` | 19 tests: the helpers, and the WebView2 state machine driven end to end against a fake `CoreWebView2`. |

Changed: both drivers call the two helpers; the WebView2 state machine returns to `GettingIds` instead of re-evaluating stale attributes when nothing matches; the four faulted-task branches in scenarios 1 and 2 now fall back with a diagnostic instead of going quiet; `Get-DataFromWebDriver`'s empty `catch {}` logs (redacted) and falls back when the same failure keeps repeating; both drivers reset the fallback state at the start of a sign-in; README gained a section under USAGE.

What the user sees:

```text
WARNING: Automated Microsoft sign-in could not continue - handing control back to you.
  State            : ProcessingScenarios/AccountSelection
  Missing elements : i0116, i0118, idSIButton9, idBtn_Back, cantAccessAccount, ...
  Elements present : signInName
  Page URL         : https://login.microsoftonline.com/common/oauth2/authorize
The sign-in page no longer matches what this module knows about it, which usually means
Microsoft changed it. Please sign in yourself in the browser window that is open - only
filling in your credentials automatically stopped working, signing in did not. ...
```

## Acceptance criteria (#32)

- [x] A missing selector hands control to the user for manual login instead of hanging or erroring out
- [x] Failure diagnostics name the state, the missing selector and the current page URL
- [x] Tests simulate a missing selector and assert both the fallback and the diagnostic
- [ ] Selector table can be refreshed out-of-band — **layer 3, not in this PR** (depends on #30)
- [ ] Out-of-band fetch is opt-out and documented — **layer 3, not in this PR**
- [x] Documentation states plainly that a selector break degrades autofill, not login

## Decisions worth reviewing

- **A stall is measured by time on the same page, not by "no scenario matched".** The account-selection scenario matches almost any unrecognized page and then loops, so a match-based trigger would have missed the most likely real-world break. The cost is that any page the automation genuinely cannot move past for 60 s ends in the fallback — including a user who is typing by hand. That reads as honest ("autofill stopped, you are in control") rather than wrong.
- **60 seconds, in a module variable, not a parameter.** Long enough that a slow round trip to Entra is not mistaken for a redesign; not exposed as a user-facing knob until someone needs it.
- **The clock is reset explicitly after every successful click**, because the username and password pages carry the same element IDs — page identity alone would keep the clock running across a step that did make progress.
- **Only the path of the page URL is printed.** Sign-in URLs carry `client_id`, `state` and `nonce`, and this text goes to a stream users capture into support logs. The full (redacted) URL goes to `-Verbose`, and the reason string goes through `Protect-LogMessage`.
- **The fallback warns once per sign-in.** The WebView2 timer ticks every 150 ms; without the guard this would be a flood rather than a diagnostic.
- **The four faulted-task branches now fall back too**, including the two in scenario 2 that previously only reset the sub-state. If the module cannot write into the password field, the user has to type it — better said out loud.
- **Out of scope, noticed while working here:** `Get-DataFromWebDriver.ps1` on `main` references `$SelectUserElementId`, `$AccountElement` and `$MfaRetryId`, none of which are ever assigned, so two of its scenarios can never fire. Left alone deliberately — it is a separate bug and those pages now end in the manual fallback rather than an endless poll.

## Verification

`.\Build\build.ps1 -Task TestBuildOnly` (Analyze → Build → ImportModule → TestHelp → Test), run on this branch and on unmodified `origin/main` in a throwaway worktree:

| | Tests | Failed |
| --- | --- | --- |
| `origin/main` (baseline) | 290 | 26 |
| this branch | 309 | 26 |

The failure sets are identical (`Compare-Object` over the JUnit results reports no difference in either direction): all 26 are the pre-existing WebView2/Edge-dependent integration tests that need a real browser install. The 19 new tests all pass. PSScriptAnalyzer is clean at Error and Warning severity.
