### PR TITLE
Publish nightlies to Ps Gallery

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
             -SystemDefaultWorkingDirectory '${{ github.workspace }}' `
             -PsGalleryKey '${{ secrets.PSGALLERY_API_KEY }}' `
             -BuildPath 'OmadaWeb.PS' `
-            -Prerelease 'nightly${{ github.run_number }}'
+            -Prerelease 'nightly${{ github.run_number }}.${{ github.run_attempt }}'
 
       - name: Pack NuGet package
         shell: pwsh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,15 @@ jobs:
           name: BuildOutput
           path: buildoutput/
 
+      - name: Publish to PSGallery (pre-release)
+        shell: pwsh
+        run: |
+          ./Build/PushToPsGallery.ps1 `
+            -SystemDefaultWorkingDirectory '${{ github.workspace }}' `
+            -PsGalleryKey '${{ secrets.PSGALLERY_API_KEY }}' `
+            -BuildPath 'OmadaWeb.PS' `
+            -Prerelease 'nightly${{ github.run_number }}'
+
       - name: Pack NuGet package
         shell: pwsh
         run: |

--- a/Build/PushToPsGallery.ps1
+++ b/Build/PushToPsGallery.ps1
@@ -20,23 +20,27 @@ try {
     $SourcePath = "{0}/buildoutput/{1}" -f $SystemDefaultWorkingDirectory, $BuildPath.TrimStart('/')
 
     if (-not [string]::IsNullOrWhiteSpace($Prerelease)) {
-        $Manifest = Get-ChildItem -Path $SourcePath -Filter '*.psd1' | Select-Object -First 1
-        if ($null -eq $Manifest) {
-            throw "No .psd1 manifest found in '$SourcePath'."
+        $ManifestPath = Join-Path -Path $SourcePath -ChildPath ("{0}.psd1" -f (Split-Path -Leaf $BuildPath))
+        if (-not (Test-Path -LiteralPath $ManifestPath)) {
+            throw "Module manifest '$ManifestPath' not found."
         }
 
+        $ManifestData = Import-PowerShellDataFile -Path $ManifestPath -ErrorAction Stop
         # PSGallery requires exactly 3-part version for pre-release packages (SemVer).
         # Drop the 4th part (run number) — it is already encoded in the Prerelease string
         # (e.g. 'nightly15'), giving a final version like 2026.7.3-nightly15.
-        $Parts = ($ManifestData = Import-PowerShellDataFile -Path $Manifest.FullName).ModuleVersion -split '\.'
+        $Parts = "$($ManifestData.ModuleVersion)" -split '\.'
         if ($Parts.Count -eq 4) {
             $ThreePartVersion = '{0}.{1}.{2}' -f $Parts[0], $Parts[1], $Parts[2]
             "Converting version $($ManifestData.ModuleVersion) to 3-part prerelease version $ThreePartVersion" | Write-Host
-            Update-ModuleManifest -Path $Manifest.FullName -ModuleVersion $ThreePartVersion -Prerelease $Prerelease
+            Update-ModuleManifest -Path $ManifestPath -ModuleVersion $ThreePartVersion -Prerelease $Prerelease -ErrorAction Stop
+        }
+        elseif ($Parts.Count -eq 3) {
+            "Setting prerelease string '$Prerelease' on $(Split-Path -Leaf $ManifestPath)" | Write-Host
+            Update-ModuleManifest -Path $ManifestPath -Prerelease $Prerelease -ErrorAction Stop
         }
         else {
-            "Setting prerelease string '$Prerelease' on $($Manifest.Name)" | Write-Host
-            Update-ModuleManifest -Path $Manifest.FullName -Prerelease $Prerelease
+            throw "Unexpected ModuleVersion '$($ManifestData.ModuleVersion)' in '$ManifestPath'."
         }
     }
 

--- a/Build/PushToPsGallery.ps1
+++ b/Build/PushToPsGallery.ps1
@@ -1,7 +1,8 @@
 ﻿PARAM(
     [string]$SystemDefaultWorkingDirectory,
     [string]$PsGalleryKey,
-    [string]$BuildPath
+    [string]$BuildPath,
+    [string]$Prerelease = ""
 )
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls13
@@ -16,7 +17,29 @@ catch {
 
 try {
     "Publish-Module to PSGallery" | Write-Host
-    $SourcePath = "{0}/buildoutput/{1}" -f $SystemDefaultWorkingDirectory,$BuildPath.TrimStart('/')
+    $SourcePath = "{0}/buildoutput/{1}" -f $SystemDefaultWorkingDirectory, $BuildPath.TrimStart('/')
+
+    if (-not [string]::IsNullOrWhiteSpace($Prerelease)) {
+        $Manifest = Get-ChildItem -Path $SourcePath -Filter '*.psd1' | Select-Object -First 1
+        if ($null -eq $Manifest) {
+            throw "No .psd1 manifest found in '$SourcePath'."
+        }
+
+        # PSGallery requires exactly 3-part version for pre-release packages (SemVer).
+        # Drop the 4th part (run number) — it is already encoded in the Prerelease string
+        # (e.g. 'nightly15'), giving a final version like 2026.7.3-nightly15.
+        $Parts = ($ManifestData = Import-PowerShellDataFile -Path $Manifest.FullName).ModuleVersion -split '\.'
+        if ($Parts.Count -eq 4) {
+            $ThreePartVersion = '{0}.{1}.{2}' -f $Parts[0], $Parts[1], $Parts[2]
+            "Converting version $($ManifestData.ModuleVersion) to 3-part prerelease version $ThreePartVersion" | Write-Host
+            Update-ModuleManifest -Path $Manifest.FullName -ModuleVersion $ThreePartVersion -Prerelease $Prerelease
+        }
+        else {
+            "Setting prerelease string '$Prerelease' on $($Manifest.Name)" | Write-Host
+            Update-ModuleManifest -Path $Manifest.FullName -Prerelease $Prerelease
+        }
+    }
+
     Publish-Module -Path $SourcePath -NuGetApiKey "$PsGalleryKey" -Verbose
 }
 catch {


### PR DESCRIPTION
This pull request adds a new step to the nightly GitHub Actions workflow to publish a pre-release version of the package to the PowerShell Gallery. This will help automate the distribution of nightly builds for testing and early feedback.

**CI/CD pipeline improvements:**

* [`.github/workflows/nightly.yml`](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6R103-R111): Added a `Publish to PSGallery (pre-release)` step that runs the `PushToPsGallery.ps1` script with appropriate parameters, enabling automated publishing of nightly pre-releases to the PowerShell Gallery.