### PR TITLE
Remove the run_attempt because because PowerShellGallery does only ac…

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
             -SystemDefaultWorkingDirectory '${{ github.workspace }}' `
             -PsGalleryKey '${{ secrets.PSGALLERY_API_KEY }}' `
             -BuildPath 'OmadaWeb.PS' `
-            -Prerelease 'nightly${{ github.run_number }}.${{ github.run_attempt }}'
+            -Prerelease 'nightly${{ github.run_number }}'
 
       - name: Pack NuGet package
         shell: pwsh


### PR DESCRIPTION
…cepts 'a-zA-Z0-9'. It is not likely that a nightly build is retried zo run_attempt is not needed.