### PR TITLE
Bundle inside the Build task, so the nightly package is complete

### DIFF
--- a/Build/Confirm-PackageFileList.ps1
+++ b/Build/Confirm-PackageFileList.ps1
@@ -1,0 +1,71 @@
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Checks that every file the module manifest declares is actually in the built package.
+.DESCRIPTION
+    The manifest's FileList is a promise about what the package contains, and several things later in
+    the pipeline believe it. Update-ModuleManifest - which PushToPsGallery.ps1 runs to stamp a
+    prerelease version - validates each entry against the file system and refuses to write the
+    manifest when one is missing. nuget pack fails on a <file> pattern that matches nothing.
+
+    Both of those happen minutes after the package was produced, in a different job, with an error
+    that describes the manifest rather than the build step that left the file out. This script moves
+    that discovery to the moment the package is created.
+
+    It is not a substitute for the tests: it is deliberately cheap and dependency-free so it can run
+    at the end of every build, including the ones that skip the test suite.
+.PARAMETER PackagePath
+    The built module folder to check. Defaults to buildoutput\OmadaWeb.PS next to this script.
+.PARAMETER ManifestPath
+    The manifest to read FileList from. Defaults to the .psd1 inside PackagePath.
+.EXAMPLE
+    ./Build/Confirm-PackageFileList.ps1
+
+    Verifies the package in buildoutput and fails when anything the manifest declares is absent.
+#>
+[CmdletBinding()]
+param(
+    [parameter(Mandatory = $false)]
+    [string]$PackagePath = (Join-Path $PSScriptRoot ".." | Join-Path -ChildPath "buildoutput" | Join-Path -ChildPath "OmadaWeb.PS"),
+    [parameter(Mandatory = $false)]
+    [string]$ManifestPath
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $PackagePath -PathType Container)) {
+    "Package folder '{0}' does not exist, so there is nothing to verify. Run the Build task first." -f $PackagePath | Write-Error -ErrorAction Stop
+}
+
+if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
+    $ManifestPath = Join-Path $PackagePath "OmadaWeb.PS.psd1"
+}
+
+if (-not (Test-Path $ManifestPath -PathType Leaf)) {
+    "Module manifest '{0}' does not exist." -f $ManifestPath | Write-Error -ErrorAction Stop
+}
+
+$Manifest = Import-PowerShellDataFile -Path $ManifestPath
+# A manifest without a FileList key yields a single $null entry rather than an empty array, which
+# would otherwise be reported as one missing file with a blank name.
+$Declared = @($Manifest.FileList | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+if ($Declared.Count -eq 0) {
+    # An empty FileList would make this check pass while proving nothing.
+    "Module manifest '{0}' declares no FileList, so the package contents cannot be verified." -f $ManifestPath | Write-Error -ErrorAction Stop
+}
+
+$Missing = [System.Collections.Generic.List[string]]::new()
+foreach ($Entry in $Declared) {
+    # FileList entries are relative to the module root, which is the package folder.
+    if (-not (Test-Path (Join-Path $PackagePath $Entry) -PathType Leaf)) {
+        $Missing.Add($Entry)
+    }
+}
+
+if ($Missing.Count -gt 0) {
+    "The built package '{0}' is missing {1} file(s) its manifest declares in FileList:`r`n  {2}`r`nPublishing this package would fail in Update-ModuleManifest and nuget pack, so the build stops here instead. If these are the bundled WebView2 assemblies, the build step that fetches them did not run or did not complete." -f $PackagePath, $Missing.Count, ($Missing -join "`r`n  ") | Write-Error -ErrorAction Stop
+}
+
+"Package contents match the manifest: {0} file(s) declared and present." -f $Declared.Count | Write-Host -ForegroundColor Green

--- a/Build/psakeBuild.ps1
+++ b/Build/psakeBuild.ps1
@@ -10,9 +10,12 @@ Properties {
 }
 
 
-Task default -depends Analyze, Build, BundleDependencies, ImportModule, TestHelp, Test
-Task DeployOnly -depends Build, BundleDependencies, Deploy
-Task TestBuildOnly -depends Analyze, Build, BundleDependencies, ImportModule, TestHelp, Test
+# Build produces a complete package on its own - assemblies bundled, contents verified against the
+# manifest - so every task list below and every caller of `build.ps1 -Task Build` gets the same
+# thing.
+Task default -depends Analyze, Build, ImportModule, TestHelp, Test
+Task DeployOnly -depends Build, Deploy
+Task TestBuildOnly -depends Analyze, Build, ImportModule, TestHelp, Test
 
 Task Analyze {
 
@@ -282,20 +285,28 @@ Task Build -depends Analyze {
     "Copy dependency lock file" | Write-Host -ForegroundColor Magenta
     Copy-Item -Path "$ModuleSource\DependencyLock.psd1" -Destination "$OutputDir" -Force
 
-}
-
-# Puts the WebView2 assemblies inside the package, fetched from the pinned URL and verified against
-# the pinned SHA-256 by the module's own download code. It runs between Build and ImportModule so
-# every workflow that builds - release, PR validation and nightly - bundles without a workflow edit,
-# and so the tests below see the same layout a user installs.
-#
-# A failure here fails the build on purpose. A package that quietly shipped without these assemblies
-# would look healthy and then break the first sign-in of every user without egress to nuget.org.
-Task BundleDependencies -depends Build {
+    # Puts the WebView2 assemblies inside the package, fetched from the pinned URL and verified
+    # against the pinned SHA-256 by the module's own download code.
+    #
+    # This belongs to building the module rather than to a task alongside it. The manifest written
+    # above declares these files in its FileList unconditionally, so a package without them is not a
+    # cheaper build - it is a broken one, and it fails much later, in whatever job tries to publish
+    # it. It used to be a separate BundleDependencies task pulled in by the aggregate task lists,
+    # which meant `build.ps1 -Task Build` - what nightly.yml runs - produced exactly that.
+    #
+    # A failure here fails the build on purpose. A package that quietly shipped without these
+    # assemblies would look healthy and then break the first sign-in of every user without egress to
+    # nuget.org.
+    "Bundle runtime dependencies" | Write-Host -ForegroundColor Magenta
     & (Join-Path $PSScriptRoot -ChildPath "Get-BundledDependency.ps1") -PackagePath $OutputDir -RepositoryRoot $ParentPath
+
+    # Everything the manifest promises has to be on disk before anything downstream believes it.
+    "Verify package contents against the manifest" | Write-Host -ForegroundColor Magenta
+    & (Join-Path $PSScriptRoot -ChildPath "Confirm-PackageFileList.ps1") -PackagePath $OutputDir
+
 }
 
-Task ImportModule -depends Build, BundleDependencies {
+Task ImportModule -depends Build {
 
     try {
         $ScriptBlock = {

--- a/Tests/Unit/Confirm-PackageFileList.Tests.ps1
+++ b/Tests/Unit/Confirm-PackageFileList.Tests.ps1
@@ -101,7 +101,10 @@ Describe 'psakeBuild.ps1 packaging' -Tag 'Unit' {
         # declares, and the failure surfaced at publish time.
         $Content = Get-Content -Path $Script:PsakeBuild -Raw
 
-        $BuildTask = [regex]::Match($Content, '(?s)Task Build -depends Analyze \{.*?\r?\n\}')
+        # Matched without pinning the -depends clause: what matters is that the work happens inside
+        # the Build task, not what that task depends on. Anchored to the start of a line so a
+        # comment mentioning `-Task Build` is not mistaken for the declaration.
+        $BuildTask = [regex]::Match($Content, '(?sm)^Task\s+Build\b[^\{]*\{.*?\r?\n\}')
         $BuildTask.Success | Should -BeTrue
 
         $BuildTask.Value | Should -BeLike '*Get-BundledDependency.ps1*' -Because 'a build that does not bundle produces a package its own manifest contradicts'

--- a/Tests/Unit/Confirm-PackageFileList.Tests.ps1
+++ b/Tests/Unit/Confirm-PackageFileList.Tests.ps1
@@ -1,0 +1,121 @@
+param(
+    # Accepted for consistency with the other test files (psakeBuild.ps1 passes it to every
+    # container); these tests exercise the build scripts, not the built module.
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    $Script:RepositoryRoot = Split-Path $(Split-Path $PSScriptRoot)
+    $Script:ConfirmScript = Join-Path $Script:RepositoryRoot -ChildPath 'Build\Confirm-PackageFileList.ps1'
+    $Script:PsakeBuild = Join-Path $Script:RepositoryRoot -ChildPath 'Build\psakeBuild.ps1'
+
+    $Script:WorkFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("OmadaWebPackageTests_{0}" -f ([System.Guid]::NewGuid().ToString('N')))
+    $null = New-Item -Path $Script:WorkFolder -ItemType Directory -Force
+
+    function New-TestPackage {
+        # A miniature built package: a manifest declaring a FileList, and whichever of those files
+        # the test wants to exist.
+        param(
+            [string]$Name,
+            [string[]]$Declared,
+            [string[]]$Present
+        )
+
+        $PackagePath = Join-Path $Script:WorkFolder -ChildPath $Name
+        $null = New-Item -Path $PackagePath -ItemType Directory -Force
+
+        foreach ($File in $Present) {
+            $FullPath = Join-Path $PackagePath $File
+            $null = New-Item -Path (Split-Path $FullPath) -ItemType Directory -Force
+            Set-Content -Path $FullPath -Value 'stub' -NoNewline
+        }
+
+        $FileListLiteral = ($Declared | ForEach-Object { "'{0}'" -f $_ }) -join ', '
+        $ManifestContent = "@{{ ModuleVersion = '1.0'; FileList = @({0}) }}" -f $FileListLiteral
+        Set-Content -Path (Join-Path $PackagePath 'OmadaWeb.PS.psd1') -Value $ManifestContent
+
+        return $PackagePath
+    }
+}
+
+Describe 'Confirm-PackageFileList.ps1' -Tag 'Unit' {
+    It 'Should pass when every declared file is in the package' {
+        $PackagePath = New-TestPackage -Name 'complete' `
+            -Declared @('OmadaWeb.PS.psd1', 'ThirdPartyNotices.txt', 'lib\Core\win-x64\WebView2Loader.dll') `
+            -Present @('ThirdPartyNotices.txt', 'lib\Core\win-x64\WebView2Loader.dll')
+
+        { & $Script:ConfirmScript -PackagePath $PackagePath -ErrorAction Stop } | Should -Not -Throw
+    }
+
+    It 'Should fail when a declared file is missing, and name it' {
+        # Exactly what nightly shipped: a manifest promising the bundle, and a package without it.
+        # Update-ModuleManifest refused it minutes later, in another job, with an error about the
+        # manifest rather than about the missing build step.
+        $PackagePath = New-TestPackage -Name 'missing-bundle' `
+            -Declared @('OmadaWeb.PS.psd1', 'ThirdPartyNotices.txt', 'lib\Core\win-x64\WebView2Loader.dll') `
+            -Present @()
+
+        $Message = $null
+        try {
+            & $Script:ConfirmScript -PackagePath $PackagePath -ErrorAction Stop
+        }
+        catch {
+            $Message = $_.Exception.Message
+        }
+
+        $Message | Should -Not -BeNullOrEmpty
+        $Message | Should -BeLike '*ThirdPartyNotices.txt*'
+        $Message | Should -BeLike '*lib\Core\win-x64\WebView2Loader.dll*'
+    }
+
+    It 'Should count every missing file, not stop at the first' {
+        $PackagePath = New-TestPackage -Name 'partly-missing' `
+            -Declared @('OmadaWeb.PS.psd1', 'a.dll', 'b.dll', 'c.dll') `
+            -Present @('a.dll')
+
+        $Message = $null
+        try {
+            & $Script:ConfirmScript -PackagePath $PackagePath -ErrorAction Stop
+        }
+        catch {
+            $Message = $_.Exception.Message
+        }
+
+        $Message | Should -BeLike '*missing 2 file(s)*'
+    }
+
+    It 'Should refuse a manifest with no FileList, which would verify nothing' {
+        $PackagePath = Join-Path $Script:WorkFolder -ChildPath 'no-filelist'
+        $null = New-Item -Path $PackagePath -ItemType Directory -Force
+        Set-Content -Path (Join-Path $PackagePath 'OmadaWeb.PS.psd1') -Value "@{ ModuleVersion = '1.0' }"
+
+        { & $Script:ConfirmScript -PackagePath $PackagePath -ErrorAction Stop } |
+            Should -Throw -ExpectedMessage '*declares no FileList*'
+    }
+}
+
+Describe 'psakeBuild.ps1 packaging' -Tag 'Unit' {
+    It 'Should bundle and verify inside the Build task itself' {
+        # nightly.yml runs `build.ps1 -Task Build`. When bundling lived in a separate task that only
+        # the aggregate task lists pulled in, that produced a package missing every file the manifest
+        # declares, and the failure surfaced at publish time.
+        $Content = Get-Content -Path $Script:PsakeBuild -Raw
+
+        $BuildTask = [regex]::Match($Content, '(?s)Task Build -depends Analyze \{.*?\r?\n\}')
+        $BuildTask.Success | Should -BeTrue
+
+        $BuildTask.Value | Should -BeLike '*Get-BundledDependency.ps1*' -Because 'a build that does not bundle produces a package its own manifest contradicts'
+        $BuildTask.Value | Should -BeLike '*Confirm-PackageFileList.ps1*' -Because 'the package must be checked where it is created, not where it is published'
+    }
+
+    It 'Should not leave a separate task the task lists have to remember' {
+        $Content = Get-Content -Path $Script:PsakeBuild -Raw
+        $Content | Should -Not -BeLike '*Task BundleDependencies*'
+    }
+}
+
+AfterAll {
+    if (Test-Path $Script:WorkFolder -PathType Container) {
+        Remove-Item -Path $Script:WorkFolder -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
Fixes the [Nightly Build failure](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/32683677479/job/97304886117) introduced by #62.

## What broke

`Package and Nightly Release` failed in `Build/PushToPsGallery.ps1`:

```
Failed to deploy to PowerShell Gallery: Cannot update the manifest properly.
'The specified FileList entry 'ThirdPartyNotices.txt' in the module manifest
'...\buildoutput\OmadaWeb.PS\OmadaWeb.PS.psd1' is invalid.'
```

`Update-ModuleManifest` — which that script runs to stamp the prerelease version — validates every
`FileList` entry against the file system. The downloaded `BuildOutput` artifact held four files and
**51,604 bytes**; a bundled package is ~3.4 MB. No `lib\`, no `ThirdPartyNotices.txt`, and a manifest
from the same build declaring all thirteen.

## Why

#62 put bundling in a `BundleDependencies` task and wired it into the aggregate task lists only:

| Workflow | psake task | Bundled? |
|---|---|---|
| `nightly.yml:73` | `-Task Build` | **no** |
| `release.yml` | `-Task TestBuildOnly` | yes |
| `pr-validation.yml` | `-Task TestBuildOnly` | yes |

Nothing made the bare `Build` task produce a bundle, and nightly is the one caller that invokes it
directly. Every `/validate` run on #62 was green because PR validation uses `TestBuildOnly` — no
signal there could have caught this.

Nothing reached the Gallery: the job failed before `Publish-Module`, and no tag or release was
created. `nuget pack` would have failed next on the nuspec's `lib\**` matching nothing.

## What changed

1. **Bundling moved into the `Build` task itself**, and the separate task is gone rather than left as
   something each caller must remember. The manifest declares those files unconditionally, so a
   package without them is not a cheaper build — it is a broken one. Every task list and every
   `-Task Build` caller now gets the same complete package.
2. **`Build/Confirm-PackageFileList.ps1` (new)** runs at the end of `Build` and fails it when
   anything the manifest declares is absent. This moves discovery from a publish job, minutes later,
   with an error about the manifest, to the moment the package is created. It is dependency-free so
   it also runs on builds that skip the test suite — which is how the nightly runs.

## Decisions worth reviewing

1. **Folded into `Build` rather than editing `nightly.yml`.** A one-line workflow change would have
   fixed this run and left the same trap for the next caller. The invariant is "a built package is
   always complete", and that belongs in the build.
2. **The verification duplicates part of `BundledWebView2.Tests.ps1`** on purpose. Those tests only
   run in the `Test` task, which nightly never invokes; this check runs on every build.
3. **A build still cannot succeed offline** — unchanged from #62, and deliberate.

## Verification

- `./Build/build.ps1 -Task Build` — the exact nightly invocation — now produces **17 files, 3.65 MB**,
  and prints `Package contents match the manifest: 16 file(s) declared and present`. On `main` today
  the same command produces the 4-file package that broke.
- The failing call itself, reproduced locally on the built package:
  `Update-ModuleManifest -ModuleVersion '2026.8.24' -Prerelease 'nightly99'` → **OK**. Deleting
  `lib\` and `ThirdPartyNotices.txt` from that same package reproduces the CI error verbatim.
- `./Build/build.ps1 -Task TestBuildOnly`: **405 passed / 26 failed**, against `origin/main` at
  `0042c5d` scoring **399 / 26** — the same 26 failures, name for name, zero difference. They are the
  WebView2 integration tests needing a real WebView2 runtime this machine lacks: environmental and
  pre-existing. The 6 new passes are this PR's tests.
