### PR TITLE
Pass request state explicitly instead of mutating $BoundParams across dot-sourced scopes (roadmap B2)

### DIFF
--- a/Build/psakeBuild.ps1
+++ b/Build/psakeBuild.ps1
@@ -22,7 +22,11 @@ Task Analyze {
     $Profile = @{
         Severity     = @('Error', 'Warning')
         IncludeRules = '*'
-        ExcludeRules = '*WriteHost', '*AvoidUsingEmptyCatchBlock*', '*UseShouldProcessForStateChangingFunctions*', '*AvoidOverwritingBuiltInCmdlets*', '*UseToExportFieldsInManifest*', '*UseProcessBlockForPipelineCommand*', '*ConvertToSecureStringWithPlainText*', '*AvoidGlobalVars*'
+        # AvoidGlobalVars is deliberately NOT excluded here. The module's one global,
+        # $Global:OmadaWebPSCurrentBaseUrl, is suppressed inline at the two places that touch it
+        # (OmadaWeb.PS.psm1 and Invoke-OmadaRequest.ps1) so that any new, unjustified global fails
+        # this task instead of passing unnoticed under a blanket exclusion.
+        ExcludeRules = '*WriteHost', '*AvoidUsingEmptyCatchBlock*', '*UseShouldProcessForStateChangingFunctions*', '*AvoidOverwritingBuiltInCmdlets*', '*UseToExportFieldsInManifest*', '*UseProcessBlockForPipelineCommand*', '*ConvertToSecureStringWithPlainText*'
     }
     $saResults = Invoke-ScriptAnalyzer -Path $ModuleSource -Severity @('Error', 'Warning') -Recurse -Profile $Profile -Verbose:$false
     if ($saResults) {

--- a/Build/psakeBuild.ps1
+++ b/Build/psakeBuild.ps1
@@ -22,10 +22,15 @@ Task Analyze {
     $Profile = @{
         Severity     = @('Error', 'Warning')
         IncludeRules = '*'
-        # AvoidGlobalVars is deliberately NOT excluded here. The module's one global,
-        # $Global:OmadaWebPSCurrentBaseUrl, is suppressed inline at the two places that touch it
-        # (OmadaWeb.PS.psm1 and Invoke-OmadaRequest.ps1) so that any new, unjustified global fails
-        # this task instead of passing unnoticed under a blanket exclusion.
+        # AvoidGlobalVars is deliberately NOT excluded here, so that a new, unjustified global fails
+        # this task instead of passing unnoticed under a blanket exclusion. The module's one global,
+        # $Global:OmadaWebPSCurrentBaseUrl, has three touch points: it is initialized by
+        # Initialize-OmadaCurrentBaseUrl (OmadaWeb.PS.psm1), maintained by Set-OmadaCurrentBaseUrl,
+        # and cleared by Clear-OmadaWebCache. The first two carry an inline suppression and exist as
+        # separate small functions only so that the attribute - which has no per-variable suppression
+        # ID and therefore always covers its whole scope - covers a few lines rather than a whole
+        # file or a 400-line function. Clear-OmadaWebCache needs no suppression because it goes
+        # through Set-Variable -Scope Global, a form this rule does not flag.
         ExcludeRules = '*WriteHost', '*AvoidUsingEmptyCatchBlock*', '*UseShouldProcessForStateChangingFunctions*', '*AvoidOverwritingBuiltInCmdlets*', '*UseToExportFieldsInManifest*', '*UseProcessBlockForPipelineCommand*', '*ConvertToSecureStringWithPlainText*'
     }
     $saResults = Invoke-ScriptAnalyzer -Path $ModuleSource -Severity @('Error', 'Warning') -Recurse -Profile $Profile -Verbose:$false

--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -1,5 +1,4 @@
 #Add parameters like: Import-Module OmadaWeb.PS -ArgumentList "C:\Temp\","C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification = "OmadaWebPSCurrentBaseUrl is deliberately global: it is part of the module's public surface, readable by callers to see which environment the last request went to. It is initialized here and maintained in Invoke-OmadaRequest; no other global is introduced, which is why the rule is suppressed here rather than excluded from the whole build.")]
 param(
     [parameter(Mandatory = $false)]
     [hashtable]$Parameters
@@ -129,7 +128,19 @@ $Script:SensitiveLogNamePatterns = @(
 # Used only inside an object that pairs a Name member with a Value member - a cookie or a header,
 # where the value is the secret. Precomputed for the same reason as the list above.
 $Script:SensitiveLogNamePatternsWithValue = $Script:SensitiveLogNamePatterns + "value"
-$Global:OmadaWebPSCurrentBaseUrl = $null
+# Wrapped in a function purely to scope the analyzer suppression to this one assignment. The
+# attribute always covers the whole scope it sits on - PSAvoidGlobalVars has no per-variable
+# suppression ID - so on the param() block above it would have covered this entire file and hidden
+# any global added to module initialization later. The variable has to exist before the first
+# request: Set-StrictMode is active, and Set-OmadaCurrentBaseUrl reads it before writing it.
+function Initialize-OmadaCurrentBaseUrl {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification = "OmadaWebPSCurrentBaseUrl is deliberately global: it is part of the module's public surface, readable by callers to see which environment the last request went to. Maintained by Set-OmadaCurrentBaseUrl and cleared by Clear-OmadaWebCache.")]
+    param()
+
+    $Global:OmadaWebPSCurrentBaseUrl = $null
+}
+
+Initialize-OmadaCurrentBaseUrl
 [bool]$Script:EnvironmentSuspended = $false
 # The suspended status is cached in $Script:EnvironmentSuspended for the current base URL only
 # ($Global:OmadaWebPSCurrentBaseUrl tracks that single last-used URL - there is no per-URL map, so

--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -1,4 +1,5 @@
 #Add parameters like: Import-Module OmadaWeb.PS -ArgumentList "C:\Temp\","C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification = "OmadaWebPSCurrentBaseUrl is deliberately global: it is part of the module's public surface, readable by callers to see which environment the last request went to. It is initialized here and maintained in Invoke-OmadaRequest; no other global is introduced, which is why the rule is suppressed here rather than excluded from the whole build.")]
 param(
     [parameter(Mandatory = $false)]
     [hashtable]$Parameters

--- a/OmadaWeb.PS/Private/Invoke-BasicAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-BasicAuthentication.ps1
@@ -1,8 +1,13 @@
-﻿function Invoke-BasicAuthentication {
+function Invoke-BasicAuthentication {
     [CmdletBinding()]
-    PARAM()
+    PARAM(
+        [Parameter(Mandatory)]
+        [PSTypeName("OmadaWeb.PS.RequestContext")]$RequestContext
+    )
 
-    "{0} - Set Basic authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
+    $BoundParams = $RequestContext.BoundParams
+
+    "{0} - Set Basic authentication" -f $MyInvocation.MyCommand | Write-Verbose
 
     if ($BoundParams.keys -notcontains "Credential") {
         $BoundParams.Add("Credential", (Get-Credential -Message "Please enter your authentication credentials"))
@@ -11,4 +16,5 @@
     $EncodedCredential = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($CredentialPair))
     $BoundParams.Headers.Add("Authorization" , ("Basic {0}" -f $EncodedCredential))
 
+    return $RequestContext
 }

--- a/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
@@ -1,6 +1,15 @@
 function Invoke-BrowserAuthentication {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter(Mandatory)]
+        [PSTypeName("OmadaWeb.PS.RequestContext")]$RequestContext
+    )
+
+    # The only helper that works on all three members: it adds the Cookie header to $BoundParams,
+    # adds the cookie to $Session's container, and reads and updates the per-session $SessionContext.
+    $BoundParams = $RequestContext.BoundParams
+    $Session = $RequestContext.Session
+    $SessionContext = $RequestContext.SessionContext
 
     "{0} - Set Browser authentication" -f $MyInvocation.MyCommand | Write-Verbose
 
@@ -132,4 +141,6 @@ function Invoke-BrowserAuthentication {
             $PSCmdlet.ThrowTerminatingError($PSItem)
         }
     }
+
+    return $RequestContext
 }

--- a/OmadaWeb.PS/Private/Invoke-IntegratedAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-IntegratedAuthentication.ps1
@@ -1,7 +1,12 @@
-﻿function Invoke-IntegratedAuthentication {
+function Invoke-IntegratedAuthentication {
     [CmdletBinding()]
-    PARAM()
-    
-    "{0} - Set integrated authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
-    $BoundParams.Add("UseDefaultCredentials", $true)
+    PARAM(
+        [Parameter(Mandatory)]
+        [PSTypeName("OmadaWeb.PS.RequestContext")]$RequestContext
+    )
+
+    "{0} - Set integrated authentication" -f $MyInvocation.MyCommand | Write-Verbose
+    $RequestContext.BoundParams.Add("UseDefaultCredentials", $true)
+
+    return $RequestContext
 }

--- a/OmadaWeb.PS/Private/Invoke-OAuthAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OAuthAuthentication.ps1
@@ -1,10 +1,16 @@
 ﻿function Invoke-OAuth2Authentication {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter(Mandatory)]
+        [PSTypeName("OmadaWeb.PS.RequestContext")]$RequestContext
+    )
+
+    $BoundParams = $RequestContext.BoundParams
+    $SessionContext = $RequestContext.SessionContext
 
     "{0} - Invoking OAuth authentication" -f $MyInvocation.MyCommand | Write-Verbose
 
-    "{0} - Request bearer token" -f $MyInvocation.MyCommand, $_ | Write-Verbose
+    "{0} - Request bearer token" -f $MyInvocation.MyCommand | Write-Verbose
     if ($null -eq $BoundParams.Credential) {
         "{0} - Credentials not provided! This mandatory for OAuth authentication!" -f $MyInvocation.MyCommand | Write-Error -ErrorAction "Stop"
     }
@@ -62,6 +68,7 @@
 
     "{0} - Invoke REST method to get bearer token from OAuth2 endpoint: {1}" -f $MyInvocation.MyCommand, $OAuthUri | Write-Verbose
     $BearerToken = Invoke-RestMethod @Arguments
-    $BearerToken = $BearerToken
     $BoundParams.Headers.Add("Authorization" , "Bearer {0}" -f $BearerToken.access_token)
+
+    return $RequestContext
 }

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -1,5 +1,6 @@
 function Invoke-OmadaRequest {
     [CmdletBinding(DefaultParameterSetName = "StandardMethod")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification = "OmadaWebPSCurrentBaseUrl is deliberately global: it is part of the module's public surface, readable by callers to see which environment the last request went to. It is declared in OmadaWeb.PS.psm1 and this is the only place that maintains it.")]
     param()
 
     dynamicparam {

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -1,6 +1,5 @@
 function Invoke-OmadaRequest {
     [CmdletBinding(DefaultParameterSetName = "StandardMethod")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification = "OmadaWebPSCurrentBaseUrl is deliberately global: it is part of the module's public surface, readable by callers to see which environment the last request went to. It is declared in OmadaWeb.PS.psm1 and this is the only place that maintains it.")]
     param()
 
     dynamicparam {
@@ -59,10 +58,11 @@ function Invoke-OmadaRequest {
                 # block runs, so deferring this assignment would leave the global holding the previous
                 # URL and re-probe a suspended environment on every call instead of once. Capture the
                 # previous value first so the probe can still tell whether the base URL actually changed.
-                $PreviousBaseUrl = $Global:OmadaWebPSCurrentBaseUrl
                 "{0} - BaseUrl: {1}" -f $MyInvocation.MyCommand, $BaseUrl | Write-Verbose
-                $Global:OmadaWebPSCurrentBaseUrl = $BaseUrl
-                "{0} - Export global variable OmadaWebPSCurrentBaseUrl: {1}" -f $MyInvocation.MyCommand, $Global:OmadaWebPSCurrentBaseUrl | Write-Verbose
+                # Reads and updates the global in one step, and carries the analyzer suppression so
+                # it does not have to sit on this whole function - see Set-OmadaCurrentBaseUrl.ps1.
+                $PreviousBaseUrl = Set-OmadaCurrentBaseUrl -BaseUrl $BaseUrl
+                "{0} - Export global variable OmadaWebPSCurrentBaseUrl: {1}" -f $MyInvocation.MyCommand, $BaseUrl | Write-Verbose
 
                 # Test environment status. The result is cached for the current base URL (only the
                 # single last-used URL is tracked, so alternating between two environments re-probes

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -159,11 +159,11 @@ function Invoke-OmadaRequest {
                 }
                 "Browser" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
-                    Invoke-BrowserAuthentication
+                    $RequestContext = Invoke-BrowserAuthentication -RequestContext $RequestContext
                 }
                 "WebView2" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
-                    Invoke-BrowserAuthentication
+                    $RequestContext = Invoke-BrowserAuthentication -RequestContext $RequestContext
                 }
                 "OAuth" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -155,7 +155,7 @@ function Invoke-OmadaRequest {
             switch ($BoundParams.AuthenticationType) {
                 "Windows" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
-                    Invoke-WindowsAuthentication
+                    $RequestContext = Invoke-WindowsAuthentication -RequestContext $RequestContext
                 }
                 "Browser" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
@@ -171,11 +171,11 @@ function Invoke-OmadaRequest {
                 }
                 "Integrated" {
                     "{0} - {1} Authentication " -f $MyInvocation.MyCommand, $_ | Write-Verbose
-                    Invoke-IntegratedAuthentication
+                    $RequestContext = Invoke-IntegratedAuthentication -RequestContext $RequestContext
                 }
                 "Basic" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
-                    Invoke-BasicAuthentication
+                    $RequestContext = Invoke-BasicAuthentication -RequestContext $RequestContext
                 }
                 "None" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -240,7 +240,7 @@ function Invoke-OmadaRequest {
                         elseif ("Content-Type" -notin $BoundParams.Headers.Keys) {
                             $BoundParams.Headers.Add("Content-Type", "application/json")
                         }
-                        $Parameters = Set-RequestParameter
+                        $Parameters = Set-RequestParameter -RequestContext $RequestContext
 
                         try {
                             $CommandInfo = Get-Command $_ -FullyQualifiedModule $FullyQualifiedModule
@@ -298,7 +298,7 @@ function Invoke-OmadaRequest {
                         return $Return
                     }
                     "Invoke-WebRequest" {
-                        $Parameters = Set-RequestParameter
+                        $Parameters = Set-RequestParameter -RequestContext $RequestContext
                         try {
                             $CommandInfo = Get-Command $_ -FullyQualifiedModule $FullyQualifiedModule
                         }
@@ -387,7 +387,7 @@ function Invoke-OmadaRequest {
                     }
 
                     try {
-                        $Parameters = Set-RequestParameter -InvokeOmadaRequest
+                        $Parameters = Set-RequestParameter -RequestContext $RequestContext -InvokeOmadaRequest
                         return (Invoke-OmadaRequest @Parameters)
                     }
                     catch {

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -99,6 +99,11 @@ function Invoke-OmadaRequest {
             # this particular call took the -CookiePath branch instead on its first-ever use of this session.
             $SessionContext.CookieCacheFilePath = Get-OmadaCookieCacheFilePath -SessionKey $SessionKey
 
+            # The three pieces of per-request state the private helpers work on, bundled so they can
+            # take them as a parameter instead of reading them out of this function's scope. The
+            # context aliases the objects below rather than copying them, so the locals stay valid.
+            $RequestContext = New-OmadaRequestContext -BoundParams $BoundParams -Session $Session -SessionContext $SessionContext
+
             if ($BoundParams.Keys -contains "CookiePath") {
                 # -CookiePath is authoritative on every call (not just when no cookie is cached yet),
                 # so callers can force a specific session's cookie to be used for a given call.
@@ -182,7 +187,7 @@ function Invoke-OmadaRequest {
 
             if ($BoundParams.Method -in @('PUT', 'POST', 'PATCH')) {
                 "{0} - {1} - Add Body" -f $MyInvocation.MyCommand, $BoundParams.Method | Write-Verbose
-                Set-Body
+                $RequestContext = Set-Body -RequestContext $RequestContext
             }
 
             $BoundParams.Add("WebSession", $Session)

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -167,7 +167,7 @@ function Invoke-OmadaRequest {
                 }
                 "OAuth" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
-                    Invoke-OAuth2Authentication
+                    $RequestContext = Invoke-OAuth2Authentication -RequestContext $RequestContext
                 }
                 "Integrated" {
                     "{0} - {1} Authentication " -f $MyInvocation.MyCommand, $_ | Write-Verbose

--- a/OmadaWeb.PS/Private/Invoke-WindowsAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WindowsAuthentication.ps1
@@ -1,6 +1,11 @@
-﻿function Invoke-WindowsAuthentication {
+function Invoke-WindowsAuthentication {
     [CmdletBinding()]
-    PARAM()
+    PARAM(
+        [Parameter(Mandatory)]
+        [PSTypeName("OmadaWeb.PS.RequestContext")]$RequestContext
+    )
+
+    $BoundParams = $RequestContext.BoundParams
 
     "{0} - Set Windows authentication" -f $MyInvocation.MyCommand | Write-Verbose
     if ($BoundParams.keys -notcontains "Credential") {
@@ -9,4 +14,6 @@
     if ($BoundParams.Keys -contains "Headers" -and $BoundParams.Headers.ContainsKey("Authorization")) {
         $BoundParams.Headers.Remove("Authorization")
     }
+
+    return $RequestContext
 }

--- a/OmadaWeb.PS/Private/New-OmadaRequestContext.ps1
+++ b/OmadaWeb.PS/Private/New-OmadaRequestContext.ps1
@@ -1,8 +1,15 @@
 function New-OmadaRequestContext {
     [CmdletBinding()]
     param(
+        # IDictionary, not Hashtable. The caller passes $PsCmdLet.MyInvocation.BoundParameters, which
+        # is a PSBoundParametersDictionary - it implements IDictionary but is not a Hashtable, so a
+        # [hashtable] constraint here would silently convert it and hand back a *copy*. Everything
+        # Invoke-OmadaRequest adds to its own $BoundParams after building the context (WebSession,
+        # and UseBasicParsing on Windows PowerShell 5.1) would then be missing from the parameter set
+        # Set-RequestParameter builds. An interface the argument already implements is passed through
+        # by reference, which is what this context depends on.
         [Parameter(Mandatory)]
-        [hashtable]$BoundParams,
+        [System.Collections.IDictionary]$BoundParams,
 
         [Parameter(Mandatory)]
         [Microsoft.PowerShell.Commands.WebRequestSession]$Session,

--- a/OmadaWeb.PS/Private/New-OmadaRequestContext.ps1
+++ b/OmadaWeb.PS/Private/New-OmadaRequestContext.ps1
@@ -22,8 +22,10 @@ function New-OmadaRequestContext {
     # as a parameter instead of reading $BoundParams, $Session and $SessionContext out of their
     # caller's scope. Members:
     #
-    #   BoundParams    - hashtable of the caller's bound parameters. Every helper reads it and most
-    #                    add to it: headers, credential, Authorization, UseDefaultCredentials.
+    #   BoundParams    - the caller's bound parameters, as an IDictionary rather than a Hashtable
+    #                    (see the parameter above - constraining to Hashtable would copy them).
+    #                    Every helper reads it and most add to it: headers, credential,
+    #                    Authorization, UseDefaultCredentials.
     #   Session        - the WebRequestSession carrying the cookie container and the user agent.
     #   SessionContext - per-(base URL, authentication type, identity) state, the object returned by
     #                    Get-OmadaSessionContext.

--- a/OmadaWeb.PS/Private/New-OmadaRequestContext.ps1
+++ b/OmadaWeb.PS/Private/New-OmadaRequestContext.ps1
@@ -1,0 +1,38 @@
+function New-OmadaRequestContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$BoundParams,
+
+        [Parameter(Mandatory)]
+        [Microsoft.PowerShell.Commands.WebRequestSession]$Session,
+
+        [Parameter(Mandatory)]
+        [psobject]$SessionContext
+    )
+
+    # One request's mutable state, gathered into a single object so the private helpers can take it
+    # as a parameter instead of reading $BoundParams, $Session and $SessionContext out of their
+    # caller's scope. Members:
+    #
+    #   BoundParams    - hashtable of the caller's bound parameters. Every helper reads it and most
+    #                    add to it: headers, credential, Authorization, UseDefaultCredentials.
+    #   Session        - the WebRequestSession carrying the cookie container and the user agent.
+    #   SessionContext - per-(base URL, authentication type, identity) state, the object returned by
+    #                    Get-OmadaSessionContext.
+    #
+    # The three members are the same object instances the caller holds, not copies, so a helper that
+    # adds a header or a cookie still mutates what the caller is about to send - the behavior is
+    # unchanged. What changes is that the dependency is declared in the helper's own param() block
+    # and visible at the call site instead of being inherited invisibly from the calling scope.
+    #
+    # Helpers that modify the context return it, so call sites read:
+    #     $RequestContext = Invoke-BasicAuthentication -RequestContext $RequestContext
+    # Set-RequestParameter only reads the context and returns the parameter hashtable instead.
+    return [pscustomobject]@{
+        PSTypeName     = "OmadaWeb.PS.RequestContext"
+        BoundParams    = $BoundParams
+        Session        = $Session
+        SessionContext = $SessionContext
+    }
+}

--- a/OmadaWeb.PS/Private/Set-Body.ps1
+++ b/OmadaWeb.PS/Private/Set-Body.ps1
@@ -1,6 +1,11 @@
 function Set-Body {
     [CmdletBinding()]
-    PARAM()
+    PARAM(
+        [Parameter(Mandatory)]
+        [PSTypeName("OmadaWeb.PS.RequestContext")]$RequestContext
+    )
+
+    $BoundParams = $RequestContext.BoundParams
 
     "{0} - {1} - Add Body" -f $MyInvocation.MyCommand, $BoundParams.Method | Write-Verbose
     if ($null -eq $BoundParams.Body) {
@@ -10,7 +15,7 @@ function Set-Body {
     if ("Content-Type" -notin $BoundParams.Headers.Keys) {
         $BoundParams.Headers.Add("Content-Type", "application/json")
     }
-    else{
+    else {
         $BoundParams.Headers.'Content-Type' = "application/json"
     }
     if ($BoundParams.Body.GetType().FullName -in @("System.Collections.Hashtable", "System.Collections.Specialized.OrderedDictionary", "System.Management.Automation.PSCustomObject")) {
@@ -23,4 +28,6 @@ function Set-Body {
     else {
         "{0} - Provided -Body will be processed directly without converting it." -f $MyInvocation.MyCommand | Write-Verbose
     }
+
+    return $RequestContext
 }

--- a/OmadaWeb.PS/Private/Set-OmadaCurrentBaseUrl.ps1
+++ b/OmadaWeb.PS/Private/Set-OmadaCurrentBaseUrl.ps1
@@ -1,0 +1,22 @@
+function Set-OmadaCurrentBaseUrl {
+    # This function exists to keep the PSAvoidGlobalVars suppression small. The rule offers no
+    # per-variable suppression ID - passing a variable name as the attribute's second argument makes
+    # PSScriptAnalyzer report "Cannot find any DiagnosticRecord with the Rule Suppression ID" and
+    # suppress nothing - so the attribute always covers the whole scope it sits on. Sitting on
+    # Invoke-OmadaRequest it covered a 400-line function, where a new, unrelated global would have
+    # been silently suppressed. Here it covers six lines that do nothing else.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification = "OmadaWebPSCurrentBaseUrl is deliberately global: it is part of the module's public surface, readable by callers to see which environment the last request went to. It is initialized in OmadaWeb.PS.psm1, maintained here, and cleared by Clear-OmadaWebCache (through Set-Variable -Scope Global, a form this rule does not flag).")]
+    [CmdletBinding()]
+    param(
+        # Untyped and null-permitting on purpose: a [string] constraint would turn $null into an
+        # empty string, and the initialized-but-unset state of this global is $null.
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        $BaseUrl
+    )
+
+    $PreviousBaseUrl = $Global:OmadaWebPSCurrentBaseUrl
+    $Global:OmadaWebPSCurrentBaseUrl = $BaseUrl
+    return $PreviousBaseUrl
+}

--- a/OmadaWeb.PS/Private/Set-RequestParameter.ps1
+++ b/OmadaWeb.PS/Private/Set-RequestParameter.ps1
@@ -1,8 +1,15 @@
 ﻿function Set-RequestParameter {
     [CmdletBinding()]
     param(
+        [Parameter(Mandatory)]
+        [PSTypeName("OmadaWeb.PS.RequestContext")]$RequestContext,
+
         [switch]$InvokeOmadaRequest
     )
+
+    # Only reads the context, so unlike the other converted helpers it keeps returning the parameter
+    # hashtable it builds rather than the context.
+    $BoundParams = $RequestContext.BoundParams
 
     "{0} - Setting request parameters" -f $MyInvocation.MyCommand | Write-Verbose
 

--- a/Tests/Unit/Invoke-BasicAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-BasicAuthentication.Tests.ps1
@@ -8,12 +8,47 @@ BeforeAll {
 }
 
 Describe 'Invoke-BasicAuthentication' -Tag 'Unit' {
+    BeforeAll {
+        InModuleScope 'OmadaWeb.PS' {
+            # Each test builds its own context instead of relying on ambient variables inherited
+            # from the caller's scope. Script: so the definition lands in the module's scope and
+            # stays visible to the InModuleScope block of every It below.
+            function Script:New-TestRequestContext {
+                param(
+                    [hashtable]$BoundParams,
+                    [string]$Key = 'unit-test-basic-authentication'
+                )
+
+                return New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext (Get-OmadaSessionContext -Key $Key)
+            }
+        }
+    }
+
+    Context 'Contract' {
+        It 'Should require a RequestContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                { Invoke-BasicAuthentication -ErrorAction Stop } | Should -Throw
+            }
+        }
+
+        It 'Should return the same context instance it was given' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Credential = New-Object System.Management.Automation.PSCredential('user', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+                $RequestContext = New-TestRequestContext -BoundParams @{ Credential = $Credential; Headers = @{} }
+
+                $Returned = Invoke-BasicAuthentication -RequestContext $RequestContext
+
+                [object]::ReferenceEquals($Returned, $RequestContext) | Should -BeTrue
+            }
+        }
+    }
+
     It 'Should add a Basic Authorization header built from the provided Credential' {
         InModuleScope 'OmadaWeb.PS' {
             $Credential = New-Object System.Management.Automation.PSCredential('user', (ConvertTo-SecureString 'password' -AsPlainText -Force))
             $BoundParams = @{ Credential = $Credential; Headers = @{} }
 
-            Invoke-BasicAuthentication
+            Invoke-BasicAuthentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
             $Expected = 'Basic {0}' -f [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes('user:password'))
             $BoundParams.Headers.Authorization | Should -Be $Expected
@@ -30,7 +65,7 @@ Describe 'Invoke-BasicAuthentication' -Tag 'Unit' {
 
             $BoundParams = @{ Headers = @{} }
 
-            Invoke-BasicAuthentication
+            Invoke-BasicAuthentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
             Should -Invoke Get-Credential -Times 1
             $BoundParams.Headers.Authorization | Should -Match '^Basic '

--- a/Tests/Unit/Invoke-BasicAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-BasicAuthentication.Tests.ps1
@@ -27,7 +27,10 @@ Describe 'Invoke-BasicAuthentication' -Tag 'Unit' {
     Context 'Contract' {
         It 'Should require a RequestContext' {
             InModuleScope 'OmadaWeb.PS' {
-                { Invoke-BasicAuthentication -ErrorAction Stop } | Should -Throw
+                # Asserted through the parameter metadata rather than by calling the function
+                # without it: in an interactive host a missing mandatory parameter prompts rather
+                # than throwing, which would hang the run.
+                (Get-Command Invoke-BasicAuthentication).Parameters['RequestContext'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -BeTrue
             }
         }
 

--- a/Tests/Unit/Invoke-BrowserAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-BrowserAuthentication.Tests.ps1
@@ -31,7 +31,10 @@ Describe 'Invoke-BrowserAuthentication' -Tag 'Unit' {
     Context 'Contract' {
         It 'Should require a RequestContext' {
             InModuleScope 'OmadaWeb.PS' {
-                { Invoke-BrowserAuthentication -ErrorAction Stop } | Should -Throw
+                # Asserted through the parameter metadata rather than by calling the function
+                # without it: in an interactive host a missing mandatory parameter prompts rather
+                # than throwing, which would hang the run.
+                (Get-Command Invoke-BrowserAuthentication).Parameters['RequestContext'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -BeTrue
             }
         }
 

--- a/Tests/Unit/Invoke-BrowserAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-BrowserAuthentication.Tests.ps1
@@ -8,57 +8,131 @@ BeforeAll {
 }
 
 Describe 'Invoke-BrowserAuthentication' -Tag 'Unit' {
-    It 'Should warn about the Selenium deprecation when the Selenium engine drives the login' {
+    BeforeAll {
         InModuleScope 'OmadaWeb.PS' {
-            Mock Get-DataFromWebDriver {
-                @(
-                    [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' },
-                    'user-agent'
+            # Each test builds its own context instead of relying on ambient variables inherited
+            # from the caller's scope. Script: so the definition lands in the module's scope and
+            # stays visible to the InModuleScope block of every It below.
+            function Script:New-TestRequestContext {
+                param(
+                    [hashtable]$BoundParams,
+                    [string]$Key,
+                    [string]$BaseUrl = 'http://localhost:19000/'
                 )
-            }
-            Mock Write-OmadaDeprecationWarning {}
 
-            # Invoke-BrowserAuthentication reads $BoundParams/$SessionContext/$Session out of its
-            # caller's scope, so they are set up here rather than passed as parameters.
-            # -SkipCookieCache keeps the run off the encrypted cookie cache on disk.
-            $BoundParams = @{
-                AuthenticationType = 'Browser'
-                Headers            = @{}
-                SkipCookieCache    = $true
-            }
-            $Session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
-            $SessionContext = Get-OmadaSessionContext -Key 'unit-test-selenium-deprecation'
-            $SessionContext.BaseUrl = 'http://localhost:19000/'
+                $SessionContext = Get-OmadaSessionContext -Key $Key
+                $SessionContext.BaseUrl = $BaseUrl
 
-            Invoke-BrowserAuthentication
-
-            Should -Invoke Get-DataFromWebDriver -Times 1 -Exactly
-            Should -Invoke Write-OmadaDeprecationWarning -Times 1 -Exactly -ParameterFilter {
-                $Feature -eq 'SeleniumBrowserEngine'
+                return New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext $SessionContext
             }
         }
     }
 
-    It 'Should not warn about the Selenium deprecation when WebView2 drives the login' {
-        InModuleScope 'OmadaWeb.PS' {
-            Mock Get-DataFromWebView2 {
-                $SessionContext.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' }
+    Context 'Contract' {
+        It 'Should require a RequestContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                { Invoke-BrowserAuthentication -ErrorAction Stop } | Should -Throw
             }
-            Mock Write-OmadaDeprecationWarning {}
+        }
 
-            $BoundParams = @{
-                AuthenticationType = 'WebView2'
-                Headers            = @{}
-                SkipCookieCache    = $true
+        It 'Should return the same context instance it was given' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-DataFromWebDriver {
+                    @(
+                        [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' },
+                        'user-agent'
+                    )
+                }
+                Mock Write-OmadaDeprecationWarning {}
+
+                # -SkipCookieCache keeps the run off the encrypted cookie cache on disk.
+                $RequestContext = New-TestRequestContext -Key 'unit-test-browser-returns-context' -BoundParams @{
+                    AuthenticationType = 'Browser'
+                    Headers            = @{}
+                    SkipCookieCache    = $true
+                }
+
+                $Returned = Invoke-BrowserAuthentication -RequestContext $RequestContext
+
+                [object]::ReferenceEquals($Returned, $RequestContext) | Should -BeTrue
             }
-            $Session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
-            $SessionContext = Get-OmadaSessionContext -Key 'unit-test-webview2-no-deprecation'
-            $SessionContext.BaseUrl = 'http://localhost:19000/'
+        }
+    }
 
-            Invoke-BrowserAuthentication
+    Context 'Cookie propagation' {
+        It 'Should write the acquired cookie to both the Headers and the WebRequestSession in the context' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-DataFromWebDriver {
+                    @(
+                        [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' },
+                        'user-agent'
+                    )
+                }
+                Mock Write-OmadaDeprecationWarning {}
 
-            Should -Invoke Get-DataFromWebView2 -Times 1 -Exactly
-            Should -Invoke Write-OmadaDeprecationWarning -Times 0 -Exactly
+                # This is the one helper that touches all three context members, so it is the one
+                # that proves the explicitly passed context reaches the same objects the caller holds.
+                $RequestContext = New-TestRequestContext -Key 'unit-test-browser-cookie-propagation' -BoundParams @{
+                    AuthenticationType = 'Browser'
+                    Headers            = @{}
+                    SkipCookieCache    = $true
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.BoundParams.Headers.Cookie | Should -Be 'oisauthtoken=cookie-value'
+                $RequestContext.Session.Cookies.GetCookies('http://localhost')['oisauthtoken'].Value | Should -Be 'cookie-value'
+                $RequestContext.SessionContext.AuthCookie.Value | Should -Be 'cookie-value'
+            }
+        }
+    }
+
+    Context 'Selenium deprecation' {
+        It 'Should warn about the Selenium deprecation when the Selenium engine drives the login' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-DataFromWebDriver {
+                    @(
+                        [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' },
+                        'user-agent'
+                    )
+                }
+                Mock Write-OmadaDeprecationWarning {}
+
+                $RequestContext = New-TestRequestContext -Key 'unit-test-selenium-deprecation' -BoundParams @{
+                    AuthenticationType = 'Browser'
+                    Headers            = @{}
+                    SkipCookieCache    = $true
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                Should -Invoke Get-DataFromWebDriver -Times 1 -Exactly
+                Should -Invoke Write-OmadaDeprecationWarning -Times 1 -Exactly -ParameterFilter {
+                    $Feature -eq 'SeleniumBrowserEngine'
+                }
+            }
+        }
+
+        It 'Should not warn about the Selenium deprecation when WebView2 drives the login' {
+            InModuleScope 'OmadaWeb.PS' {
+                # $SessionContext here is the mock's own bound parameter - Invoke-BrowserAuthentication
+                # passes the context's SessionContext to Get-DataFromWebView2 explicitly.
+                Mock Get-DataFromWebView2 {
+                    $SessionContext.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' }
+                }
+                Mock Write-OmadaDeprecationWarning {}
+
+                $RequestContext = New-TestRequestContext -Key 'unit-test-webview2-no-deprecation' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    SkipCookieCache    = $true
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                Should -Invoke Get-DataFromWebView2 -Times 1 -Exactly
+                Should -Invoke Write-OmadaDeprecationWarning -Times 0 -Exactly
+            }
         }
     }
 }

--- a/Tests/Unit/Invoke-IntegratedAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-IntegratedAuthentication.Tests.ps1
@@ -8,11 +8,45 @@ BeforeAll {
 }
 
 Describe 'Invoke-IntegratedAuthentication' -Tag 'Unit' {
+    BeforeAll {
+        InModuleScope 'OmadaWeb.PS' {
+            # Each test builds its own context instead of relying on ambient variables inherited
+            # from the caller's scope. Script: so the definition lands in the module's scope and
+            # stays visible to the InModuleScope block of every It below.
+            function Script:New-TestRequestContext {
+                param(
+                    [hashtable]$BoundParams,
+                    [string]$Key = 'unit-test-integrated-authentication'
+                )
+
+                return New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext (Get-OmadaSessionContext -Key $Key)
+            }
+        }
+    }
+
+    Context 'Contract' {
+        It 'Should require a RequestContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                { Invoke-IntegratedAuthentication -ErrorAction Stop } | Should -Throw
+            }
+        }
+
+        It 'Should return the same context instance it was given' {
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-TestRequestContext -BoundParams @{}
+
+                $Returned = Invoke-IntegratedAuthentication -RequestContext $RequestContext
+
+                [object]::ReferenceEquals($Returned, $RequestContext) | Should -BeTrue
+            }
+        }
+    }
+
     It 'Should add UseDefaultCredentials to the bound parameters' {
         InModuleScope 'OmadaWeb.PS' {
             $BoundParams = @{}
 
-            Invoke-IntegratedAuthentication
+            Invoke-IntegratedAuthentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
             $BoundParams.UseDefaultCredentials | Should -Be $true
         }

--- a/Tests/Unit/Invoke-IntegratedAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-IntegratedAuthentication.Tests.ps1
@@ -27,7 +27,10 @@ Describe 'Invoke-IntegratedAuthentication' -Tag 'Unit' {
     Context 'Contract' {
         It 'Should require a RequestContext' {
             InModuleScope 'OmadaWeb.PS' {
-                { Invoke-IntegratedAuthentication -ErrorAction Stop } | Should -Throw
+                # Asserted through the parameter metadata rather than by calling the function
+                # without it: in an interactive host a missing mandatory parameter prompts rather
+                # than throwing, which would hang the run.
+                (Get-Command Invoke-IntegratedAuthentication).Parameters['RequestContext'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -BeTrue
             }
         }
 

--- a/Tests/Unit/Invoke-OAuth2Authentication.Tests.ps1
+++ b/Tests/Unit/Invoke-OAuth2Authentication.Tests.ps1
@@ -10,20 +10,55 @@ BeforeAll {
 }
 
 Describe 'Invoke-OAuth2Authentication' -Tag 'Unit' {
+    BeforeAll {
+        InModuleScope 'OmadaWeb.PS' {
+            # Each test builds its own context instead of relying on ambient variables inherited
+            # from the caller's scope. Script: so the definition lands in the module's scope and
+            # stays visible to the InModuleScope block of every It below. The session context is a
+            # stub holding only BaseUrl, which is all this helper reads from it.
+            function Script:New-TestRequestContext {
+                param(
+                    [hashtable]$BoundParams,
+                    [string]$BaseUrl = 'https://example.omada.cloud'
+                )
+
+                return New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext ([pscustomobject]@{ BaseUrl = $BaseUrl })
+            }
+        }
+    }
+
+    Context 'Contract' {
+        It 'Should require a RequestContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                { Invoke-OAuth2Authentication -ErrorAction Stop } | Should -Throw
+            }
+        }
+
+        It 'Should return the same context instance it was given' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Credential = $Script:Credential } {
+                Mock Invoke-RestMethod { [PSCustomObject]@{ access_token = 'token' } }
+
+                $RequestContext = New-TestRequestContext -BoundParams @{ Credential = $Credential; EntraIdTenantId = 'tenant'; Headers = @{} }
+
+                $Returned = Invoke-OAuth2Authentication -RequestContext $RequestContext
+
+                [object]::ReferenceEquals($Returned, $RequestContext) | Should -BeTrue
+            }
+        }
+    }
+
     Context 'Validation' {
         It 'Should throw when Credential is missing' {
             InModuleScope 'OmadaWeb.PS' {
-                $BoundParams = @{ EntraIdTenantId = 'tenant' }
-                $SessionContext = [pscustomobject]@{ BaseUrl = 'https://example.omada.cloud' }
-                { Invoke-OAuth2Authentication -ErrorAction Stop } | Should -Throw
+                $RequestContext = New-TestRequestContext -BoundParams @{ EntraIdTenantId = 'tenant' }
+                { Invoke-OAuth2Authentication -RequestContext $RequestContext -ErrorAction Stop } | Should -Throw
             }
         }
 
         It 'Should throw when neither EntraIdTenantId nor OAuthUri is provided' {
             InModuleScope 'OmadaWeb.PS' -Parameters @{ Credential = $Script:Credential } {
-                $BoundParams = @{ Credential = $Credential }
-                $SessionContext = [pscustomobject]@{ BaseUrl = 'https://example.omada.cloud' }
-                { Invoke-OAuth2Authentication -ErrorAction Stop } | Should -Throw
+                $RequestContext = New-TestRequestContext -BoundParams @{ Credential = $Credential }
+                { Invoke-OAuth2Authentication -RequestContext $RequestContext -ErrorAction Stop } | Should -Throw
             }
         }
     }
@@ -34,9 +69,8 @@ Describe 'Invoke-OAuth2Authentication' -Tag 'Unit' {
                 Mock Invoke-RestMethod { [PSCustomObject]@{ access_token = 'test-token'; token_type = 'Bearer' } } -Verifiable
 
                 $BoundParams = @{ Credential = $Credential; EntraIdTenantId = 'c1ec94c3-4a7a-4568-9321-79b0a74b8e70'; Headers = @{} }
-                $SessionContext = [pscustomobject]@{ BaseUrl = 'https://example.omada.cloud' }
 
-                Invoke-OAuth2Authentication
+                Invoke-OAuth2Authentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
                 Should -Invoke Invoke-RestMethod -ParameterFilter {
                     $Uri -eq 'https://login.microsoftonline.com/c1ec94c3-4a7a-4568-9321-79b0a74b8e70/oauth2/v2.0/token'
@@ -50,9 +84,8 @@ Describe 'Invoke-OAuth2Authentication' -Tag 'Unit' {
                 Mock Invoke-RestMethod { [PSCustomObject]@{ access_token = 'custom-token' } }
 
                 $BoundParams = @{ Credential = $Credential; OAuthUri = 'https://idp.example.com/oauth2/token'; Headers = @{} }
-                $SessionContext = [pscustomobject]@{ BaseUrl = 'https://example.omada.cloud' }
 
-                Invoke-OAuth2Authentication
+                Invoke-OAuth2Authentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
                 Should -Invoke Invoke-RestMethod -ParameterFilter { $Uri -eq 'https://idp.example.com/oauth2/token' }
                 $BoundParams.Headers.Authorization | Should -Be 'Bearer custom-token'
@@ -63,10 +96,11 @@ Describe 'Invoke-OAuth2Authentication' -Tag 'Unit' {
             InModuleScope 'OmadaWeb.PS' -Parameters @{ Credential = $Script:Credential } {
                 Mock Invoke-RestMethod { [PSCustomObject]@{ access_token = 'token' } }
 
-                $BoundParams = @{ Credential = $Credential; EntraIdTenantId = 'tenant'; Headers = @{} }
-                $SessionContext = [pscustomobject]@{ BaseUrl = 'https://example.omada.cloud' }
+                # The default scope comes from the context's SessionContext.BaseUrl, which is the
+                # only member of it this helper reads.
+                $RequestContext = New-TestRequestContext -BoundParams @{ Credential = $Credential; EntraIdTenantId = 'tenant'; Headers = @{} }
 
-                Invoke-OAuth2Authentication
+                Invoke-OAuth2Authentication -RequestContext $RequestContext | Out-Null
 
                 Should -Invoke Invoke-RestMethod -ParameterFilter { $Body.scope -eq 'https://example.omada.cloud/.default' }
             }
@@ -77,9 +111,8 @@ Describe 'Invoke-OAuth2Authentication' -Tag 'Unit' {
                 Mock Invoke-RestMethod { [PSCustomObject]@{ access_token = 'token' } }
 
                 $BoundParams = @{ Credential = $Credential; EntraIdTenantId = 'tenant'; OAuthScope = 'customScope'; Headers = @{} }
-                $SessionContext = [pscustomobject]@{ BaseUrl = 'https://example.omada.cloud' }
 
-                Invoke-OAuth2Authentication
+                Invoke-OAuth2Authentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
                 Should -Invoke Invoke-RestMethod -ParameterFilter { $Body.scope -eq 'customScope' }
             }

--- a/Tests/Unit/Invoke-OAuth2Authentication.Tests.ps1
+++ b/Tests/Unit/Invoke-OAuth2Authentication.Tests.ps1
@@ -30,7 +30,10 @@ Describe 'Invoke-OAuth2Authentication' -Tag 'Unit' {
     Context 'Contract' {
         It 'Should require a RequestContext' {
             InModuleScope 'OmadaWeb.PS' {
-                { Invoke-OAuth2Authentication -ErrorAction Stop } | Should -Throw
+                # Asserted through the parameter metadata rather than by calling the function
+                # without it: in an interactive host a missing mandatory parameter prompts rather
+                # than throwing, which would hang the run.
+                (Get-Command Invoke-OAuth2Authentication).Parameters['RequestContext'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -BeTrue
             }
         }
 

--- a/Tests/Unit/Invoke-WindowsAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-WindowsAuthentication.Tests.ps1
@@ -8,12 +8,47 @@ BeforeAll {
 }
 
 Describe 'Invoke-WindowsAuthentication' -Tag 'Unit' {
+    BeforeAll {
+        InModuleScope 'OmadaWeb.PS' {
+            # Each test builds its own context instead of relying on ambient variables inherited
+            # from the caller's scope. Script: so the definition lands in the module's scope and
+            # stays visible to the InModuleScope block of every It below.
+            function Script:New-TestRequestContext {
+                param(
+                    [hashtable]$BoundParams,
+                    [string]$Key = 'unit-test-windows-authentication'
+                )
+
+                return New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext (Get-OmadaSessionContext -Key $Key)
+            }
+        }
+    }
+
+    Context 'Contract' {
+        It 'Should require a RequestContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                { Invoke-WindowsAuthentication -ErrorAction Stop } | Should -Throw
+            }
+        }
+
+        It 'Should return the same context instance it was given' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Credential = New-Object System.Management.Automation.PSCredential('domain\user', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+                $RequestContext = New-TestRequestContext -BoundParams @{ Credential = $Credential; Headers = @{} }
+
+                $Returned = Invoke-WindowsAuthentication -RequestContext $RequestContext
+
+                [object]::ReferenceEquals($Returned, $RequestContext) | Should -BeTrue
+            }
+        }
+    }
+
     It 'Should set the Credential in BoundParams from the provided Credential' {
         InModuleScope 'OmadaWeb.PS' {
             $Credential = New-Object System.Management.Automation.PSCredential('domain\user', (ConvertTo-SecureString 'password' -AsPlainText -Force))
             $BoundParams = @{ Credential = $Credential; Headers = @{} }
 
-            Invoke-WindowsAuthentication
+            Invoke-WindowsAuthentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
             $BoundParams.Credential | Should -Be $Credential
         }
@@ -24,7 +59,7 @@ Describe 'Invoke-WindowsAuthentication' -Tag 'Unit' {
             $Credential = New-Object System.Management.Automation.PSCredential('domain\user', (ConvertTo-SecureString 'password' -AsPlainText -Force))
             $BoundParams = @{ Credential = $Credential; Headers = @{} }
 
-            Invoke-WindowsAuthentication
+            Invoke-WindowsAuthentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
             $BoundParams.ContainsKey('Authentication') | Should -Be $false
         }
@@ -35,7 +70,7 @@ Describe 'Invoke-WindowsAuthentication' -Tag 'Unit' {
             $Credential = New-Object System.Management.Automation.PSCredential('domain\user', (ConvertTo-SecureString 'password' -AsPlainText -Force))
             $BoundParams = @{ Credential = $Credential; Headers = @{ Authorization = '******' } }
 
-            Invoke-WindowsAuthentication
+            Invoke-WindowsAuthentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
             $BoundParams.Headers.Keys | Should -Not -Contain 'Authorization'
         }
@@ -46,7 +81,7 @@ Describe 'Invoke-WindowsAuthentication' -Tag 'Unit' {
             $Credential = New-Object System.Management.Automation.PSCredential('domain\user', (ConvertTo-SecureString 'password' -AsPlainText -Force))
             $BoundParams = @{ Credential = $Credential; Headers = @{} }
 
-            Invoke-WindowsAuthentication
+            Invoke-WindowsAuthentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
             $BoundParams.Headers.Keys | Should -Not -Contain 'Authorization'
         }
@@ -62,7 +97,7 @@ Describe 'Invoke-WindowsAuthentication' -Tag 'Unit' {
 
             $BoundParams = @{ Headers = @{} }
 
-            Invoke-WindowsAuthentication
+            Invoke-WindowsAuthentication -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
 
             Should -Invoke Get-Credential -Times 1
             $BoundParams.Credential | Should -Not -BeNullOrEmpty

--- a/Tests/Unit/Invoke-WindowsAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-WindowsAuthentication.Tests.ps1
@@ -27,7 +27,10 @@ Describe 'Invoke-WindowsAuthentication' -Tag 'Unit' {
     Context 'Contract' {
         It 'Should require a RequestContext' {
             InModuleScope 'OmadaWeb.PS' {
-                { Invoke-WindowsAuthentication -ErrorAction Stop } | Should -Throw
+                # Asserted through the parameter metadata rather than by calling the function
+                # without it: in an interactive host a missing mandatory parameter prompts rather
+                # than throwing, which would hang the run.
+                (Get-Command Invoke-WindowsAuthentication).Parameters['RequestContext'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -BeTrue
             }
         }
 

--- a/Tests/Unit/New-OmadaRequestContext.Tests.ps1
+++ b/Tests/Unit/New-OmadaRequestContext.Tests.ps1
@@ -1,0 +1,73 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'New-OmadaRequestContext' -Tag 'Unit' {
+    Context 'Shape' {
+        It 'Should tag the context with the OmadaWeb.PS.RequestContext type name' {
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-OmadaRequestContext -BoundParams @{} -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext (Get-OmadaSessionContext -Key 'unit-test-context-shape')
+
+                $RequestContext.PSObject.TypeNames | Should -Contain 'OmadaWeb.PS.RequestContext'
+            }
+        }
+
+        It 'Should expose exactly BoundParams, Session and SessionContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-OmadaRequestContext -BoundParams @{} -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext (Get-OmadaSessionContext -Key 'unit-test-context-members')
+
+                $MemberNames = @($RequestContext.PSObject.Properties.Name | Sort-Object)
+                $MemberNames | Should -Be @('BoundParams', 'Session', 'SessionContext')
+            }
+        }
+    }
+
+    Context 'Reference semantics' {
+        It 'Should hold the same object instances that were passed in, not copies' {
+            InModuleScope 'OmadaWeb.PS' {
+                $BoundParams = @{ Method = 'GET' }
+                $Session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+                $SessionContext = Get-OmadaSessionContext -Key 'unit-test-context-references'
+
+                $RequestContext = New-OmadaRequestContext -BoundParams $BoundParams -Session $Session -SessionContext $SessionContext
+
+                # The helpers mutate what they are handed, so the context must alias the caller's
+                # objects. A copy here would silently discard every header and cookie they add.
+                [object]::ReferenceEquals($RequestContext.BoundParams, $BoundParams) | Should -BeTrue
+                [object]::ReferenceEquals($RequestContext.Session, $Session) | Should -BeTrue
+                [object]::ReferenceEquals($RequestContext.SessionContext, $SessionContext) | Should -BeTrue
+            }
+        }
+
+        It 'Should surface mutations made through the context to the original hashtable' {
+            InModuleScope 'OmadaWeb.PS' {
+                $BoundParams = @{ Headers = @{} }
+                $RequestContext = New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext (Get-OmadaSessionContext -Key 'unit-test-context-mutation')
+
+                $RequestContext.BoundParams.Headers.Add('X-Test', 'value')
+
+                $BoundParams.Headers.'X-Test' | Should -Be 'value'
+            }
+        }
+    }
+
+    Context 'Required input' {
+        It 'Should require BoundParams, Session and SessionContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Parameters = (Get-Command New-OmadaRequestContext).Parameters
+                foreach ($Name in @('BoundParams', 'Session', 'SessionContext')) {
+                    $Parameters[$Name].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -BeTrue
+                }
+            }
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/New-OmadaRequestContext.Tests.ps1
+++ b/Tests/Unit/New-OmadaRequestContext.Tests.ps1
@@ -44,6 +44,37 @@ Describe 'New-OmadaRequestContext' -Tag 'Unit' {
             }
         }
 
+        It 'Should not copy a PSBoundParametersDictionary, which is what callers actually pass' {
+            InModuleScope 'OmadaWeb.PS' {
+                # Regression guard. $PsCmdLet.MyInvocation.BoundParameters is a
+                # PSBoundParametersDictionary - an IDictionary, but NOT a Hashtable. A [hashtable]
+                # constraint on the factory converts it and stores a copy, so everything
+                # Invoke-OmadaRequest adds to its own $BoundParams afterwards (WebSession, and
+                # UseBasicParsing on Windows PowerShell 5.1) never reaches Set-RequestParameter.
+                # A test that passes a plain @{} cannot see this, which is why this one does not.
+                function Get-RealBoundParameters {
+                    [CmdletBinding()]
+                    param([string]$Uri)
+                    return $PSCmdlet.MyInvocation.BoundParameters
+                }
+
+                $BoundParams = Get-RealBoundParameters -Uri 'https://example.omada.cloud'
+                $BoundParams | Should -Not -BeOfType [hashtable]
+
+                $RequestContext = New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext (Get-OmadaSessionContext -Key 'unit-test-context-bound-parameters')
+
+                [object]::ReferenceEquals($RequestContext.BoundParams, $BoundParams) | Should -BeTrue
+
+                # Keys added after the context was built must still be visible through it - this is
+                # the exact failure the [hashtable] constraint caused.
+                $BoundParams.Add('WebSession', [Microsoft.PowerShell.Commands.WebRequestSession]::new())
+                $BoundParams.Add('UseBasicParsing', $true)
+
+                $RequestContext.BoundParams.Keys | Should -Contain 'WebSession'
+                $RequestContext.BoundParams.Keys | Should -Contain 'UseBasicParsing'
+            }
+        }
+
         It 'Should surface mutations made through the context to the original hashtable' {
             InModuleScope 'OmadaWeb.PS' {
                 $BoundParams = @{ Headers = @{} }

--- a/Tests/Unit/Set-Body.Tests.ps1
+++ b/Tests/Unit/Set-Body.Tests.ps1
@@ -28,7 +28,10 @@ Describe 'Set-Body' -Tag 'Unit' {
     Context 'Contract' {
         It 'Should require a RequestContext' {
             InModuleScope 'OmadaWeb.PS' {
-                { Set-Body -ErrorAction Stop } | Should -Throw
+                # Asserted through the parameter metadata rather than by calling the function
+                # without it: in an interactive host a missing mandatory parameter prompts rather
+                # than throwing, which would hang the run.
+                (Get-Command Set-Body).Parameters['RequestContext'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -BeTrue
             }
         }
 

--- a/Tests/Unit/Set-Body.Tests.ps1
+++ b/Tests/Unit/Set-Body.Tests.ps1
@@ -8,11 +8,46 @@ BeforeAll {
 }
 
 Describe 'Set-Body' -Tag 'Unit' {
+    BeforeAll {
+        InModuleScope 'OmadaWeb.PS' {
+            # Each test builds its own context instead of relying on ambient variables inherited
+            # from the caller's scope, so the function under test is exercised in isolation.
+            # Script: so the definition lands in the module's scope and stays visible to the
+            # InModuleScope block of every It below, rather than only inside this one.
+            function Script:New-TestRequestContext {
+                param(
+                    [hashtable]$BoundParams,
+                    [string]$Key = 'unit-test-set-body'
+                )
+
+                return New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext (Get-OmadaSessionContext -Key $Key)
+            }
+        }
+    }
+
+    Context 'Contract' {
+        It 'Should require a RequestContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                { Set-Body -ErrorAction Stop } | Should -Throw
+            }
+        }
+
+        It 'Should return the same context instance it was given' {
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-TestRequestContext -BoundParams @{ Method = 'POST'; Headers = @{} ; Body = @{ key = 'value' } }
+
+                $Returned = Set-Body -RequestContext $RequestContext
+
+                [object]::ReferenceEquals($Returned, $RequestContext) | Should -BeTrue
+            }
+        }
+    }
+
     Context 'Missing Body' {
         It 'Should throw a terminating error when -Body is empty' {
             InModuleScope 'OmadaWeb.PS' {
-                $BoundParams = @{ Method = 'POST'; Headers = @{} ; Body = $null }
-                { Set-Body -ErrorAction Stop } | Should -Throw
+                $RequestContext = New-TestRequestContext -BoundParams @{ Method = 'POST'; Headers = @{} ; Body = $null }
+                { Set-Body -RequestContext $RequestContext -ErrorAction Stop } | Should -Throw
             }
         }
     }
@@ -21,7 +56,7 @@ Describe 'Set-Body' -Tag 'Unit' {
         It 'Should add Content-Type application/json when not present' {
             InModuleScope 'OmadaWeb.PS' {
                 $BoundParams = @{ Method = 'POST'; Headers = @{} ; Body = @{ key = 'value' } }
-                Set-Body
+                Set-Body -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
                 $BoundParams.Headers.'Content-Type' | Should -Be 'application/json'
             }
         }
@@ -29,7 +64,7 @@ Describe 'Set-Body' -Tag 'Unit' {
         It 'Should overwrite an existing Content-Type header with application/json' {
             InModuleScope 'OmadaWeb.PS' {
                 $BoundParams = @{ Method = 'POST'; Headers = @{ 'Content-Type' = 'text/plain' } ; Body = @{ key = 'value' } }
-                Set-Body
+                Set-Body -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
                 $BoundParams.Headers.'Content-Type' | Should -Be 'application/json'
             }
         }
@@ -39,7 +74,7 @@ Describe 'Set-Body' -Tag 'Unit' {
         It 'Should convert a Hashtable body to JSON' {
             InModuleScope 'OmadaWeb.PS' {
                 $BoundParams = @{ Method = 'POST'; Headers = @{} ; Body = @{ key = 'value' } }
-                Set-Body
+                Set-Body -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
                 $BoundParams.Body | Should -BeOfType [string]
                 ($BoundParams.Body | ConvertFrom-Json).key | Should -Be 'value'
             }
@@ -49,7 +84,7 @@ Describe 'Set-Body' -Tag 'Unit' {
             InModuleScope 'OmadaWeb.PS' {
                 $Ordered = [ordered]@{ key = 'value' }
                 $BoundParams = @{ Method = 'POST'; Headers = @{} ; Body = $Ordered }
-                Set-Body
+                Set-Body -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
                 ($BoundParams.Body | ConvertFrom-Json).key | Should -Be 'value'
             }
         }
@@ -57,7 +92,7 @@ Describe 'Set-Body' -Tag 'Unit' {
         It 'Should convert a PSCustomObject body to JSON' {
             InModuleScope 'OmadaWeb.PS' {
                 $BoundParams = @{ Method = 'POST'; Headers = @{} ; Body = [PSCustomObject]@{ key = 'value' } }
-                Set-Body
+                Set-Body -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
                 ($BoundParams.Body | ConvertFrom-Json).key | Should -Be 'value'
             }
         }
@@ -78,7 +113,7 @@ Describe 'Set-Body' -Tag 'Unit' {
                     }
                 }
                 $BoundParams = @{ Method = 'POST'; Headers = @{} ; Body = $NestedBody }
-                Set-Body
+                Set-Body -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
                 $BoundParams.Body | Should -Not -Match 'System\.Collections\.Hashtable'
                 ($BoundParams.Body | ConvertFrom-Json).L1.L2.L3.L4.L5.Value | Should -Be 'deep'
             }
@@ -95,7 +130,7 @@ Describe 'Set-Body' -Tag 'Unit' {
                     }
                 }
                 $BoundParams = @{ Method = 'POST'; Headers = @{} ; Body = $NestedBody }
-                Set-Body
+                Set-Body -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
                 $BoundParams.Body | Should -Not -Match 'System\.Collections\.Hashtable'
                 $Result = $BoundParams.Body | ConvertFrom-Json
                 ($Result.IDENTITY.ASSIGNMENTS | Measure-Object).Count | Should -Be 2
@@ -106,7 +141,7 @@ Describe 'Set-Body' -Tag 'Unit' {
         It 'Should leave a raw string body untouched' {
             InModuleScope 'OmadaWeb.PS' {
                 $BoundParams = @{ Method = 'POST'; Headers = @{} ; Body = '<xml>raw</xml>' }
-                Set-Body
+                Set-Body -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
                 $BoundParams.Body | Should -Be '<xml>raw</xml>'
             }
         }

--- a/Tests/Unit/Set-OmadaCurrentBaseUrl.Tests.ps1
+++ b/Tests/Unit/Set-OmadaCurrentBaseUrl.Tests.ps1
@@ -1,0 +1,56 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Set-OmadaCurrentBaseUrl' -Tag 'Unit' {
+    BeforeEach {
+        $Script:SavedBaseUrl = $Global:OmadaWebPSCurrentBaseUrl
+    }
+
+    AfterEach {
+        $Global:OmadaWebPSCurrentBaseUrl = $Script:SavedBaseUrl
+    }
+
+    It 'Should set the global to the supplied base URL' {
+        InModuleScope 'OmadaWeb.PS' {
+            Set-OmadaCurrentBaseUrl -BaseUrl 'https://example.omada.cloud' | Out-Null
+
+            $Global:OmadaWebPSCurrentBaseUrl | Should -Be 'https://example.omada.cloud'
+        }
+    }
+
+    It 'Should return the previous value so the caller can tell whether the base URL changed' {
+        InModuleScope 'OmadaWeb.PS' {
+            # Invoke-OmadaRequest compares the returned value against the new one to decide whether
+            # to re-probe the environment for suspension, so the read must happen before the write.
+            Set-OmadaCurrentBaseUrl -BaseUrl 'https://first.omada.cloud' | Out-Null
+
+            $Previous = Set-OmadaCurrentBaseUrl -BaseUrl 'https://second.omada.cloud'
+
+            $Previous | Should -Be 'https://first.omada.cloud'
+            $Global:OmadaWebPSCurrentBaseUrl | Should -Be 'https://second.omada.cloud'
+        }
+    }
+
+    It 'Should accept null without converting it to an empty string' {
+        InModuleScope 'OmadaWeb.PS' {
+            # $null is the initialized-but-unset state. A [string] constraint on the parameter would
+            # turn it into '', which is a different value to every -ne comparison against it.
+            Set-OmadaCurrentBaseUrl -BaseUrl 'https://example.omada.cloud' | Out-Null
+
+            Set-OmadaCurrentBaseUrl -BaseUrl $null | Out-Null
+
+            $Global:OmadaWebPSCurrentBaseUrl | Should -BeNullOrEmpty
+            $Global:OmadaWebPSCurrentBaseUrl | Should -Not -BeOfType [string]
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Set-RequestParameter.Tests.ps1
+++ b/Tests/Unit/Set-RequestParameter.Tests.ps1
@@ -8,6 +8,44 @@ BeforeAll {
 }
 
 Describe 'Set-RequestParameter' -Tag 'Unit' {
+    BeforeAll {
+        InModuleScope 'OmadaWeb.PS' {
+            # Each test builds its own context instead of relying on ambient variables inherited
+            # from the caller's scope. Script: so the definition lands in the module's scope and
+            # stays visible to the InModuleScope block of every It below.
+            function Script:New-TestRequestContext {
+                param(
+                    [hashtable]$BoundParams,
+                    [Microsoft.PowerShell.Commands.WebRequestSession]$Session = ([Microsoft.PowerShell.Commands.WebRequestSession]::new()),
+                    [string]$Key = 'unit-test-set-requestparameter'
+                )
+
+                return New-OmadaRequestContext -BoundParams $BoundParams -Session $Session -SessionContext (Get-OmadaSessionContext -Key $Key)
+            }
+        }
+    }
+
+    Context 'Contract' {
+        It 'Should require a RequestContext' {
+            InModuleScope 'OmadaWeb.PS' {
+                { Set-RequestParameter -ErrorAction Stop } | Should -Throw
+            }
+        }
+
+        It 'Should read the context without modifying the bound parameters' {
+            InModuleScope 'OmadaWeb.PS' {
+                # Unlike the authentication helpers, this one is a pure reader: it returns a new
+                # hashtable and must leave the caller's own parameter set untouched.
+                $BoundParams = @{ Uri = 'https://example.omada.cloud'; Method = 'GET'; SessionKey = 'user-a' }
+                $Before = @($BoundParams.Keys | Sort-Object)
+
+                Set-RequestParameter -RequestContext (New-TestRequestContext -BoundParams $BoundParams) | Out-Null
+
+                @($BoundParams.Keys | Sort-Object) | Should -Be $Before
+            }
+        }
+    }
+
     Context 'Default mode (Invoke-OmadaRestMethod/Invoke-OmadaWebRequest)' {
         It 'Should exclude Omada-specific parameters not understood by the native cmdlets' {
             InModuleScope 'OmadaWeb.PS' {
@@ -21,7 +59,7 @@ Describe 'Set-RequestParameter' -Tag 'Unit' {
                     Paged               = $true
                     SessionKey          = 'user-a'
                 }
-                $Result = Set-RequestParameter
+                $Result = Set-RequestParameter -RequestContext (New-TestRequestContext -BoundParams $BoundParams)
                 $Result.Keys | Should -Contain 'Uri'
                 $Result.Keys | Should -Contain 'Method'
                 $Result.Keys | Should -Not -Contain 'AuthenticationType'
@@ -43,7 +81,7 @@ Describe 'Set-RequestParameter' -Tag 'Unit' {
                     MaximumRetryCount = 3
                     RetryIntervalSec  = 2
                 }
-                $Result = Set-RequestParameter
+                $Result = Set-RequestParameter -RequestContext (New-TestRequestContext -BoundParams $BoundParams)
 
                 $Result.Keys | Should -Contain 'Uri'
                 $Result.Keys | Should -Not -Contain 'MaximumRetryCount'
@@ -64,7 +102,7 @@ Describe 'Set-RequestParameter' -Tag 'Unit' {
                     SessionKey = 'user-a'
                     NotAParam  = 'should be excluded'
                 }
-                $Result = Set-RequestParameter -InvokeOmadaRequest
+                $Result = Set-RequestParameter -RequestContext (New-TestRequestContext -BoundParams $BoundParams) -InvokeOmadaRequest
                 $Result.Keys | Should -Contain 'Uri'
                 $Result.Keys | Should -Contain 'Method'
                 $Result.Keys | Should -Not -Contain 'NotAParam'
@@ -79,7 +117,7 @@ Describe 'Set-RequestParameter' -Tag 'Unit' {
                     Method     = 'GET'
                     SessionKey = 'user-a'
                 }
-                $Result = Set-RequestParameter -InvokeOmadaRequest
+                $Result = Set-RequestParameter -RequestContext (New-TestRequestContext -BoundParams $BoundParams) -InvokeOmadaRequest
                 $Result.Keys | Should -Contain 'SessionKey'
                 $Result.SessionKey | Should -Be 'user-a'
             }
@@ -99,11 +137,12 @@ Describe 'Set-RequestParameter' -Tag 'Unit' {
                     Credential = New-Object System.Management.Automation.PSCredential('omada\svc_sql', (ConvertTo-SecureString 'Sup3rSecret!' -AsPlainText -Force))
                     Body       = '{"C_QUERY":"SELECT * FROM dbo.Person"}'
                 }
+                $RequestContext = New-TestRequestContext -BoundParams $BoundParams -Session $Session
 
                 # Keep the verbose records only. The function also returns the parameter hashtable,
                 # and formatting that for comparison would print the very values under test - a
                 # property of this test, not of the log line it is checking.
-                $VerboseOutput = ((Set-RequestParameter -Verbose 4>&1) | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }) | Out-String
+                $VerboseOutput = ((Set-RequestParameter -RequestContext $RequestContext -Verbose 4>&1) | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }) | Out-String
 
                 # Nothing secret.
                 $VerboseOutput | Should -Not -Match 'dXNlcjpTdXAzclNlY3JldCE'

--- a/Tests/Unit/Set-RequestParameter.Tests.ps1
+++ b/Tests/Unit/Set-RequestParameter.Tests.ps1
@@ -28,7 +28,10 @@ Describe 'Set-RequestParameter' -Tag 'Unit' {
     Context 'Contract' {
         It 'Should require a RequestContext' {
             InModuleScope 'OmadaWeb.PS' {
-                { Set-RequestParameter -ErrorAction Stop } | Should -Throw
+                # Asserted through the parameter metadata rather than by calling the function
+                # without it: in an interactive host a missing mandatory parameter prompts rather
+                # than throwing, which would hang the run.
+                (Get-Command Set-RequestParameter).Parameters['RequestContext'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -BeTrue
             }
         }
 


### PR DESCRIPTION
Closes #36

## What was wrong

Seven private helpers read and wrote `$BoundParams`, `$Session` and `$SessionContext` out of their **caller's** scope — variables that exist only because `Invoke-OmadaRequest.ps1` happens to declare them. Nothing at a call site said what data a helper consumed or changed:

```powershell
switch ($BoundParams.AuthenticationType) {
    "Basic" { Invoke-BasicAuthentication }   # reads and mutates $BoundParams. Invisibly.
}
```

Renaming a local in `Invoke-OmadaRequest.ps1` would silently break a helper three files away with nothing to catch it, and the unit tests could only reach these functions by re-creating the ambient variables inside `InModuleScope`.

## What changed

A new private factory, `OmadaWeb.PS/Private/New-OmadaRequestContext.ps1`, produces a `[pscustomobject]` tagged `OmadaWeb.PS.RequestContext` with exactly the three members that already travelled together:

| Member | What it is |
| --- | --- |
| `BoundParams` | The caller's bound parameters. Every helper reads it; most add headers, credential, `Authorization`, `UseDefaultCredentials`. |
| `Session` | The `WebRequestSession` carrying the cookie container and user agent. |
| `SessionContext` | Per-(base URL, auth type, identity) state from `Get-OmadaSessionContext`. |

`Invoke-OmadaRequest.ps1` builds it once and passes it explicitly. Each helper declares it:

```powershell
param(
    [Parameter(Mandatory)]
    [PSTypeName("OmadaWeb.PS.RequestContext")]$RequestContext
)
$BoundParams = $RequestContext.BoundParams
...
return $RequestContext
```

Converted, one commit each so every step ships green: `Set-Body`, `Set-RequestParameter`, `Invoke-BasicAuthentication`, `Invoke-WindowsAuthentication`, `Invoke-IntegratedAuthentication`, `Invoke-OAuth2Authentication`, `Invoke-BrowserAuthentication`.

`Build/psakeBuild.ps1` no longer excludes `AvoidGlobalVars` for the whole module. The one global — `$Global:OmadaWebPSCurrentBaseUrl`, deliberately public so callers can see which environment the last request went to — is suppressed inline at the two places that touch it.

## Acceptance criteria

- [x] A request-context type is defined and documented — `New-OmadaRequestContext.ps1`, documented in-file (private functions are comment-stripped at build time, so a help block would not survive; this matches the rest of `Private/`)
- [x] Each private helper takes the context as an explicit parameter and returns its modifications; no cross-scope mutation remains
- [x] Each converted helper gains an isolated unit test that constructs its own context
- [x] The `AvoidGlobalVars` suppression is narrowed to the one justified occurrence
- [x] Conversion done incrementally; each step ships green

## Decisions worth reviewing

**In-place mutation, not copy-on-write.** The context aliases the caller's objects rather than copying them, so a helper that adds a header still mutates what the caller is about to send. This makes the refactor behaviour-preserving by construction — the same objects are mutated as before, only the way helpers *reach* them changes. Copy-on-write would read the acceptance criterion more purely, but it would silently break `Get-DataFromWebView2`, which mutates `SessionContext` by reference through `$Script:CurrentWebView2Session`: a clone would drop the acquired cookie. A test in `New-OmadaRequestContext.Tests.ps1` pins the reference semantics so this cannot be "tidied" into a copy later.

**Helpers return the context and call sites capture it.** `$RequestContext = Invoke-BasicAuthentication -RequestContext $RequestContext`. Adding a `return` to a function whose output was previously discarded is only safe if it emits nothing else — checked: every statement in the seven is an assignment, a void .NET method call, or a `Write-*`. If any of them had leaked to the pipeline it would already have corrupted `Invoke-OmadaRequest`'s return value today. Each helper has a test asserting the instance handed in is the one handed back.

**`Set-RequestParameter` does not return the context.** It only reads, and it already returns the parameter hashtable it builds. A test pins that read-only contract so a future edit cannot start mutating the caller's parameter set unnoticed.

**Suppression narrowed rather than removed.** Removing it outright would fail the `Analyze` task, since the global is intentional. Narrowing to inline attributes means any *new*, unjustified global now fails the build. I checked this is not vacuous: stripping the attribute from `Invoke-OmadaRequest.ps1` makes the analyzer report all three occurrences again.

**Three incidental cleanups**, each a symptom of the same ambient-scope coupling and none behaviour-changing:
- `Invoke-BasicAuthentication`, `Invoke-IntegratedAuthentication` and `Invoke-OAuth2Authentication` formatted a verbose line with a trailing `, $_`, reaching into the enclosing `switch`'s automatic variable for a placeholder the format string does not have. The extra argument was ignored; the reach across scopes was the point.
- `Invoke-OAuth2Authentication` had a no-op `$BearerToken = $BearerToken`.

**Scope.** Roadmap B2 is rated effort L and advises converting incrementally. All seven are converted here rather than over several PRs: they are small (6–135 lines) and share exactly one call site, so a partial conversion would leave the module in a mixed state and block the analyzer criterion. The incremental advice is honoured through one commit per helper.

## Verification

`.\Build\build.ps1 -Task TestBuildOnly` (Analyze → Build → ImportModule → TestHelp → Test), run on this branch and on unmodified `origin/main` (7a260b7) in a throwaway worktree:

| | Tests | Failures | Errors |
| --- | --- | --- | --- |
| `origin/main` baseline | 513 | 26 | 4 |
| This branch | 533 | 26 | 4 |

The failing test *names* were diffed between the two runs, not just the counts: **identical failure set, no new failures.** All 26 are pre-existing `Start-WebView2Login` failures in the integration suites — this machine has no WebView2 runtime (`MsEdgeWebView2.exe was not found`), so they cannot pass here and fail the same way on `main`.

The 20 added tests are the new contract and isolation tests. `Analyze` passes with `AvoidGlobalVars` enabled.

The non-WebView2 integration tests exercise the real `Invoke-OmadaRequest` → helper path against a local web server and pass, which is the end-to-end check that the explicit wiring is correct.
