### PR TITLE
Improve Entra ID autofill: passwordless credentials, account selection and safer MFA handling (WebView2)

### DIFF
--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -168,7 +168,6 @@ $Script:OmadaSessions = @{}
 # Bridges the blocking WinForm/WebView2 dialog's .NET event-handler closures (which cannot see the
 # Invoke-OmadaRequest call stack) to the session context driving the current interactive login.
 $Script:CurrentWebView2Session = $null
-$Script:AccountSelectionAttempted = $false
 # Deprecation warnings are shown once per session rather than once per request - see
 # Write-OmadaDeprecationWarning.ps1. Module scope means Import-Module -Force resets the set.
 $Script:DeprecationWarningsShown = @{}
@@ -178,7 +177,6 @@ $Script:DeprecationUtcNow = $null
 $Script:DebugWebView2 = $false
 $Script:CurrentScenario = $null
 $Script:FunctionName = $null
-$Script:IdAttributes = $null
 $Script:InstalledEdgeFilePath = $null
 $Script:LastCheckedHost = $null
 $Script:LastLoggedSecond = -1
@@ -187,10 +185,51 @@ $Script:LoginFailed = $false
 $Script:LoginState = $null
 $Script:LoginSubState = $null
 $Script:LoginTask = $null
+# The snapshot of the sign-in page the current decision is being made from, and the submit
+# button still to be clicked once a field has been filled in.
+$Script:PageState = $null
+$Script:PendingSubmitId = $null
 # Seconds the sign-in automation may sit on the same page without making progress before it stops
 # filling in credentials and lets the user sign in manually - see Switch-ToManualLogin.ps1. Generous
 # on purpose: a slow round trip to Entra must not be mistaken for a changed sign-in page.
 $Script:LoginAutomationFallbackTimeout = 60
+# Every element the Microsoft sign-in automation recognizes a screen by, in one place so that the
+# JavaScript that reads the page (Get-EntraSignInProbeScript) and the rule set that judges what it
+# read (Resolve-EntraSignInScreen) cannot drift apart on a selector.
+#
+# These ids are what makes the automation language agnostic: the Entra sign-in app is served fully
+# localized, but its element ids are the same in every language, so a screen is identified by an id
+# and never by the words on it. They are, however, internal to Microsoft's sign-in app and not a
+# contracted API - which is why Resolve-EntraSignInScreen keeps structural fallbacks behind them and
+# ends in Switch-ToManualLogin rather than in a guess when none of them match.
+$Script:EntraSignInElementId = [ordered]@{
+    UserName           = "i0116"
+    Password           = "i0118"
+    Submit             = "idSIButton9"
+    Back               = "idBtn_Back"
+    KeepMeSignedIn     = "KmsiCheckboxField"
+    PasswordlessNumber = "idRemoteNGC_DisplaySign"
+    NumberMatch        = "idRichContext_DisplaySign"
+    OneTimeCode        = "idTxtBx_SAOTCC_OTC"
+    OneTimeCodeSubmit  = "idSubmit_SAOTCC_Continue"
+    ProofsContainer    = "idDiv_SAOTCS_Proofs"
+    MethodPicker       = "i0281"
+    SwitchToCredPicker = "idA_PWD_SwitchToCredPicker"
+    SignInAnotherWay   = "signInAnotherWay"
+    ForgotPassword     = "idA_PWD_ForgotPassword"
+    PasswordError      = "passwordError"
+    CantAccessAccount  = "cantAccessAccount"
+    MfaResendTotp      = "idA_SAASTO_Resend"
+    MfaResendDs        = "idA_SAASDS_Resend"
+}
+# Set once per sign-in when -PreferredMfaMethod named a verification method the account does not
+# offer, so the 150 ms timer reports that once instead of on every tick.
+$Script:PreferredMfaMethodWarningIssued = $false
+# Wall clock of the last "still waiting for approval" line, so a multi-minute wait for someone to
+# reach for their phone reports progress without filling the verbose stream at 150 ms intervals.
+$Script:MfaWaitLastReported = $null
+# Seconds between two of those lines.
+$Script:MfaWaitReportInterval = 10
 $Script:ManualLoginFallbackActive = $false
 $Script:UnmatchedPageSignature = $null
 $Script:UnmatchedPageSince = $null
@@ -218,7 +257,6 @@ $Script:OmadaWatchdogTimeout = 600
 # Only used to seed the first session context created in this Runspace when the module is imported
 # with -ArgumentList @{ Parameters = @{ OmadaWebAuthCookie = ... } } - see Get-OmadaSessionContext.ps1.
 $Script:OmadaWebAuthCookie = $null
-$Script:PreviousAttributes = $null
 $Script:PreviousScenario = $null
 $Script:ProgressCounter = 0
 $Script:StopError = $false

--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -222,6 +222,11 @@ $Script:EntraSignInElementId = [ordered]@{
     MfaResendTotp      = "idA_SAASTO_Resend"
     MfaResendDs        = "idA_SAASDS_Resend"
 }
+# The JavaScript built from the table above, kept because it is built from nothing else: the same
+# table produces the same script, and the sign-in reads the page over and over while a user works
+# through it. Reset here rather than only inside the function so that Import-Module -Force rebuilds
+# it - otherwise an edited selector table would keep serving the script made from the old one.
+$Script:EntraSignInProbeScript = $null
 # Set once per sign-in when -PreferredMfaMethod named a verification method the account does not
 # offer, so the 150 ms timer reports that once instead of on every tick.
 $Script:PreferredMfaMethodWarningIssued = $false

--- a/OmadaWeb.PS/Private/Get-EntraElementVisibilityScript.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraElementVisibilityScript.ps1
@@ -16,13 +16,22 @@ function Get-EntraElementVisibilityScript {
         them.
 
         Visible means all of: not display:none, not visibility:hidden, not fully transparent, not
-        marked aria-hidden, neither disabled nor read-only, and occupying somewhere on the page.
-        getComputedStyle throws on a detached node, which is not a visible element either, so it is
-        caught.
+        clipped away to nothing, not marked aria-hidden, neither disabled nor read-only, and big
+        enough on the page to be aimed at. getComputedStyle throws on a detached node, which is not a
+        visible element either, so it is caught.
 
         Read-only counts as not visible because of what the answer is used for. Nothing here merely
         looks at an element - it fills it in or clicks it - and a field that cannot be typed into is
         as useless to that as one that cannot be seen.
+
+        The size floor and the clip tests are there for one specific and very common thing: the
+        "visually hidden" pattern, which hides an element from sight while leaving it to screen
+        readers by shrinking it to a pixel and clipping it away - position:absolute with width:1px,
+        height:1px and clip:rect(0 0 0 0), or a clip-path of inset(50%). None of the property checks
+        above see anything wrong with such an element: it is displayed, opaque, and reports a
+        non-zero width. Asking only whether it occupies *somewhere* therefore called it visible,
+        which is how a hidden template option or account tile could be counted and clicked. Nothing
+        a user is expected to click is two pixels across, so the floor costs nothing and closes that.
 
     .OUTPUTS
         System.String. A JavaScript function declaration named isVisible, to be pasted into a larger
@@ -40,9 +49,12 @@ function Get-EntraElementVisibilityScript {
             if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') { return false; }
         }
         catch (e) { return false; }
+        if (style.clip === 'rect(0px, 0px, 0px, 0px)') { return false; }
+        if (style.clipPath === 'inset(50%)') { return false; }
         if (element.getAttribute('aria-hidden') === 'true') { return false; }
         if (element.disabled === true || element.readOnly === true) { return false; }
-        return element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0;
+        var rect = element.getBoundingClientRect();
+        return rect.width >= 2 && rect.height >= 2;
     }
 '@
 }

--- a/OmadaWeb.PS/Private/Get-EntraElementVisibilityScript.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraElementVisibilityScript.ps1
@@ -1,0 +1,48 @@
+function Get-EntraElementVisibilityScript {
+    <#
+    .SYNOPSIS
+        Returns the JavaScript function the sign-in automation decides "the user can see and act on
+        this" with.
+
+    .DESCRIPTION
+        Three scripts need this question answered and they must answer it identically: the probe that
+        reports what is on the page, the click that picks an account tile, and the click that picks a
+        verification method. When they disagree, the disagreement is silent and it is a loop - the
+        probe reports an element the click cannot find, or the click acts on an element the probe
+        never counted, and either way the page does not change while the driver believes it acted.
+
+        So the definition lives here, once, and is injected into each of them - the same reason the
+        element ids live in $Script:EntraSignInElementId rather than in each script that looks for
+        them.
+
+        Visible means all of: not display:none, not visibility:hidden, not fully transparent, not
+        marked aria-hidden, neither disabled nor read-only, and occupying somewhere on the page.
+        getComputedStyle throws on a detached node, which is not a visible element either, so it is
+        caught.
+
+        Read-only counts as not visible because of what the answer is used for. Nothing here merely
+        looks at an element - it fills it in or clicks it - and a field that cannot be typed into is
+        as useless to that as one that cannot be seen.
+
+    .OUTPUTS
+        System.String. A JavaScript function declaration named isVisible, to be pasted into a larger
+        script.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param()
+
+    return @'
+    function isVisible(element) {
+        if (!element) { return false; }
+        try {
+            var style = window.getComputedStyle(element);
+            if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') { return false; }
+        }
+        catch (e) { return false; }
+        if (element.getAttribute('aria-hidden') === 'true') { return false; }
+        if (element.disabled === true || element.readOnly === true) { return false; }
+        return element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0;
+    }
+'@
+}

--- a/OmadaWeb.PS/Private/Get-EntraErrorVerdict.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraErrorVerdict.ps1
@@ -1,0 +1,120 @@
+function Get-EntraErrorVerdict {
+    <#
+    .SYNOPSIS
+        Turns an Entra ID sign-in error code into a decision about what the automation may do next.
+
+    .DESCRIPTION
+        The Entra sign-in page ships its own state in a script block - the object the page calls
+        '$Config', also served as ServerData - and that object carries the failure of the last step
+        as a number in 'iErrorCode' and as text in 'sErrorCode'. Those numbers are the AADSTS codes
+        Microsoft's support articles are indexed by, and unlike the sentence rendered next to them
+        they are identical in every language the sign-in page is served in. They are therefore the
+        signal this module judges a failed step by, and the rendered message is never read.
+
+        Three answers are possible, and the difference between them matters more than the wording:
+
+          - Stop. The sign-in cannot succeed however many times it is attempted, so the caller hands
+            this to Stop-OmadaLogin, which ends the sign-in rather than opening another window. A
+            wrong password is deliberately in this group: resubmitting a credential that was just
+            refused is precisely what drives an account into Entra ID smart lockout, so the module
+            refuses the second attempt instead of making it.
+          - Manual. The account has to do something in the browser that no stored credential can do -
+            register security information, complete an extra verification step. The window is open
+            and the user can finish there, so autofill steps aside through Switch-ToManualLogin
+            rather than failing the request.
+          - None. There is no error. A healthy page reports iErrorCode 0.
+
+        An error code this function does not recognize is answered with Manual, not with silence:
+        the list below is not, and cannot be, exhaustive, so anything unknown fails safe by handing
+        the sign-in back to the user with the code named in the diagnostic.
+
+    .PARAMETER ErrorCode
+        The value of iErrorCode, or sErrorCode, as read from the page. Accepts a number, the same
+        number as a string, or a string such as 'AADSTS50126' - only the digits are used.
+
+    .OUTPUTS
+        PSCustomObject with the members IsError, Code, Numeric, Action, IsTerminal and Reason.
+        Action is one of 'None', 'Stop' or 'Manual'.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    param(
+        [Parameter(Position = 0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$ErrorCode
+    )
+
+    $Verdict = [pscustomobject]@{
+        IsError    = $false
+        Code       = $null
+        Numeric    = 0
+        Action     = "None"
+        IsTerminal = $false
+        Reason     = $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($ErrorCode)) {
+        return $Verdict
+    }
+
+    # 'AADSTS50126', '50126' and 50126 all have to arrive at the same number, and a page that reports
+    # no failure at all writes 0.
+    $DigitMatch = [regex]::Match($ErrorCode, '\d+')
+    if (-not $DigitMatch.Success) {
+        return $Verdict
+    }
+
+    [long]$Numeric = 0
+    if (-not [long]::TryParse($DigitMatch.Value, [ref]$Numeric)) {
+        return $Verdict
+    }
+
+    if ($Numeric -eq 0) {
+        return $Verdict
+    }
+
+    $Verdict.IsError = $true
+    $Verdict.Numeric = $Numeric
+    $Verdict.Code = "AADSTS{0}" -f $Numeric
+
+    # Sign-ins that no retry can turn into a success. Each of these ends the sign-in.
+    $TerminalReason = @{
+        50126 = "The user name or password is wrong. The credential is not sent again, because repeating a refused sign-in is what drives an account into Entra ID smart lockout."
+        50053 = "The account is locked, or Entra ID smart lockout is in effect after too many failed sign-in attempts."
+        50055 = "The password of this account has expired and has to be changed before the account can sign in again."
+        53003 = "A Conditional Access policy blocked this sign-in. Entra ID will refuse it the same way on every attempt, so no further attempts are made."
+    }
+
+    # Sign-ins that can still succeed, but only if a person acts in the browser window. Autofill has
+    # nothing left to contribute, so it steps aside instead of driving the page.
+    $ManualReason = @{
+        50072 = "This account has to register security information before it can sign in."
+        50074 = "Entra ID requires an additional verification step that cannot be filled in from a stored credential."
+        50158 = "An external security challenge has to be completed for this sign-in."
+        # Not named in issue #18, but the same family and the same answer: multi-factor
+        # authentication is required, or has to be enrolled in, before this account can continue.
+        50076 = "Entra ID requires multi-factor authentication for this sign-in."
+        50079 = "This account has to enroll in multi-factor authentication before it can sign in."
+    }
+
+    if ($TerminalReason.ContainsKey([int]$Numeric)) {
+        $Verdict.Action = "Stop"
+        $Verdict.IsTerminal = $true
+        $Verdict.Reason = $TerminalReason[[int]$Numeric]
+        return $Verdict
+    }
+
+    if ($ManualReason.ContainsKey([int]$Numeric)) {
+        $Verdict.Action = "Manual"
+        $Verdict.Reason = $ManualReason[[int]$Numeric]
+        return $Verdict
+    }
+
+    # Unknown, so fail safe rather than guessing. Naming the code is the whole point - it is what
+    # turns a support question into a searchable one.
+    $Verdict.Action = "Manual"
+    $Verdict.Reason = "The sign-in page reported error {0}, which this module does not recognize." -f $Verdict.Code
+
+    return $Verdict
+}

--- a/OmadaWeb.PS/Private/Get-EntraSignInProbeScript.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraSignInProbeScript.ps1
@@ -139,7 +139,19 @@ __IS_VISIBLE__
         accountTiles.push({ index: accountTiles.length, testId: String(testId) });
     }
 
-    var hasOtherTile = document.querySelector('[aria-labelledby="otherTileText"]') !== null || document.getElementById('otherTileText') !== null;
+    // Reported only when it is something the user could click, because that is what
+    // Resolve-EntraSignInScreen uses it for - the fallback when no tile matches the credential. A
+    // hidden one would have the driver clicking at nothing and calling it progress.
+    var hasOtherTile = false;
+    var otherAccount = document.querySelector('[aria-labelledby="otherTileText"]');
+    if (otherAccount && isVisible(otherAccount)) { hasOtherTile = true; }
+    if (!hasOtherTile) {
+        var otherTileText = document.getElementById('otherTileText');
+        if (otherTileText) {
+            var otherClickable = otherTileText.closest('[role="button"], button, a, div');
+            if (otherClickable && isVisible(otherClickable)) { hasOtherTile = true; }
+        }
+    }
 
     var displaySign = readNumber(document.getElementById(passwordlessNumberId));
     if (!displaySign) { displaySign = readNumber(document.getElementById(numberMatchId)); }

--- a/OmadaWeb.PS/Private/Get-EntraSignInProbeScript.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraSignInProbeScript.ps1
@@ -63,17 +63,7 @@ function Get-EntraSignInProbeScript {
     var passwordlessNumberId = __PASSWORDLESS_NUMBER_ID__;
     var numberMatchId = __NUMBER_MATCH_ID__;
 
-    function isVisible(element) {
-        if (!element) { return false; }
-        try {
-            var style = window.getComputedStyle(element);
-            if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') { return false; }
-        }
-        catch (e) { return false; }
-        if (element.getAttribute('aria-hidden') === 'true') { return false; }
-        if (element.disabled === true || element.readOnly === true) { return false; }
-        return element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0;
-    }
+__IS_VISIBLE__
 
     function readNumber(element) {
         if (!element) { return null; }
@@ -122,13 +112,19 @@ function Get-EntraSignInProbeScript {
     // One clickable option per offered method. Counted rather than matched to a method, because the
     // options carry no identifier naming which method they are; Resolve-EntraSignInScreen refuses to
     // click by position when this count and the proofs array disagree.
+    //
+    // Only the options a user could actually click are counted, which is what makes that check mean
+    // anything: a hidden template option counted here but skipped by the click - or the reverse -
+    // shifts every index after it, and the click still succeeds, so the account is sent a different
+    // verification method than the one that was chosen and nothing reports an error. The click
+    // filters through this same isVisible.
     var proofOptionCount = 0;
     var proofsContainer = document.getElementById(proofsContainerId);
     if (proofsContainer) {
         var options = proofsContainer.querySelectorAll('[data-value], [role="button"], [role="listitem"]');
         var counted = [];
         for (var o = 0; o < options.length; o++) {
-            if (counted.indexOf(options[o]) === -1) { counted.push(options[o]); }
+            if (counted.indexOf(options[o]) === -1 && isVisible(options[o])) { counted.push(options[o]); }
         }
         proofOptionCount = counted.length;
     }
@@ -178,6 +174,7 @@ function Get-EntraSignInProbeScript {
 })();
 '@
 
+    $ProbeScript = $ProbeScript.Replace("__IS_VISIBLE__", (Get-EntraElementVisibilityScript))
     $ProbeScript = $ProbeScript.Replace("__ELEMENT_IDS__", $ElementIdJson)
     $ProbeScript = $ProbeScript.Replace("__PROOFS_CONTAINER_ID__", $ProofsContainerJson)
     $ProbeScript = $ProbeScript.Replace("__PASSWORDLESS_NUMBER_ID__", $PasswordlessNumberJson)

--- a/OmadaWeb.PS/Private/Get-EntraSignInProbeScript.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraSignInProbeScript.ps1
@@ -1,0 +1,179 @@
+function Get-EntraSignInProbeScript {
+    <#
+    .SYNOPSIS
+        Returns the JavaScript that reads one language-independent snapshot off an Entra ID sign-in
+        page.
+
+    .DESCRIPTION
+        The sign-in automation used to ask the page a question per step - is this element there, is
+        it visible, what does that button say - which meant a decision spread over half a dozen
+        asynchronous round trips, and one that could only be exercised with a real browser in front
+        of it. This returns a single script that reads everything the rules in
+        Resolve-EntraSignInScreen need, once, into one JSON document. What comes back is data, so
+        the decision made from it is a function that can be tested.
+
+        Nothing it reads is text a person sees. The Entra sign-in app is served in the user's
+        language, so any rule written against a visible label works on English tenants and silently
+        does nothing everywhere else. The snapshot therefore carries only things the server decides:
+
+          - Which of the ids in $Script:EntraSignInElementId are on the page, and which of those are
+            visible, enabled and not hidden from assistive technology.
+          - The numbers out of the object the page ships its own state in - '$Config', also served as
+            ServerData: 'iErrorCode' and 'sErrorCode', which are the AADSTS codes, and the
+            'arrUserProofs' array, whose 'authMethodId' values name the offered verification methods
+            in a fixed vocabulary rather than in prose.
+          - The 'data-test-id' of each account tile on 'Pick an account' - Entra puts the account
+            name there - and whether the tile that leads to another account exists.
+          - The approval number, from both the element passwordless sign-in shows it in and the one
+            Authenticator number match uses.
+          - Whether a password field and an e-mail field are visible at all, by input type. This is
+            the only rule that does not depend on an id, and it exists so that a page whose ids
+            Microsoft has renamed can still be reported as "this was the password screen" instead of
+            as "nothing matched".
+
+        The ids are injected from $Script:EntraSignInElementId rather than written out here, so the
+        script and the rules that read its output cannot come to disagree about a selector.
+
+    .OUTPUTS
+        System.String. JavaScript returning a JSON document with the members 'ids', 'visibleIds',
+        'errorCode', 'errorCodeText', 'proofs', 'proofOptionCount', 'accountTiles', 'hasOtherTile',
+        'displaySign', 'hasVisiblePasswordInput', 'hasVisibleEmailInput' and 'path'.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param()
+
+    $ElementIdJson = ConvertTo-Json -InputObject @($Script:EntraSignInElementId.Values) -Compress
+    $ProofsContainerJson = ConvertTo-JavaScriptLiteral $Script:EntraSignInElementId.ProofsContainer
+    $PasswordlessNumberJson = ConvertTo-JavaScriptLiteral $Script:EntraSignInElementId.PasswordlessNumber
+    $NumberMatchJson = ConvertTo-JavaScriptLiteral $Script:EntraSignInElementId.NumberMatch
+
+    $ProbeScript = @'
+(function () {
+    var knownIds = __ELEMENT_IDS__;
+    var proofsContainerId = __PROOFS_CONTAINER_ID__;
+    var passwordlessNumberId = __PASSWORDLESS_NUMBER_ID__;
+    var numberMatchId = __NUMBER_MATCH_ID__;
+
+    function isVisible(element) {
+        if (!element) { return false; }
+        try {
+            var style = window.getComputedStyle(element);
+            if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') { return false; }
+        }
+        catch (e) { return false; }
+        if (element.getAttribute('aria-hidden') === 'true') { return false; }
+        if (element.disabled === true || element.readOnly === true) { return false; }
+        return element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0;
+    }
+
+    function readNumber(element) {
+        if (!element) { return null; }
+        var value = null;
+        if (element.childNodes && element.childNodes[0] && element.childNodes[0].data) {
+            value = element.childNodes[0].data;
+        }
+        if (!value) { value = element.textContent; }
+        if (!value) { return null; }
+        value = value.replace(/\s+/g, ' ').trim();
+        return value.length > 0 ? value : null;
+    }
+
+    var ids = [];
+    var visibleIds = [];
+    for (var i = 0; i < knownIds.length; i++) {
+        var element = document.getElementById(knownIds[i]);
+        if (!element) { continue; }
+        ids.push(knownIds[i]);
+        if (isVisible(element)) { visibleIds.push(knownIds[i]); }
+    }
+
+    // The sign-in app publishes its own server-side state on the window. Everything read from it is
+    // numeric or an identifier - never a rendered sentence.
+    var config = null;
+    try { config = window.$Config || window.ServerData || null; }
+    catch (e) { config = null; }
+
+    var errorCode = '';
+    var errorCodeText = '';
+    var proofs = [];
+    if (config) {
+        if (config.iErrorCode !== undefined && config.iErrorCode !== null) { errorCode = String(config.iErrorCode); }
+        if (config.sErrorCode !== undefined && config.sErrorCode !== null) { errorCodeText = String(config.sErrorCode); }
+        if (config.arrUserProofs && config.arrUserProofs.length) {
+            for (var p = 0; p < config.arrUserProofs.length; p++) {
+                var proof = config.arrUserProofs[p] || {};
+                proofs.push({
+                    authMethodId: proof.authMethodId ? String(proof.authMethodId) : '',
+                    isDefault: proof.isDefault === true
+                });
+            }
+        }
+    }
+
+    // One clickable option per offered method. Counted rather than matched to a method, because the
+    // options carry no identifier naming which method they are; Resolve-EntraSignInScreen refuses to
+    // click by position when this count and the proofs array disagree.
+    var proofOptionCount = 0;
+    var proofsContainer = document.getElementById(proofsContainerId);
+    if (proofsContainer) {
+        var options = proofsContainer.querySelectorAll('[data-value], [role="button"], [role="listitem"]');
+        var counted = [];
+        for (var o = 0; o < options.length; o++) {
+            if (counted.indexOf(options[o]) === -1) { counted.push(options[o]); }
+        }
+        proofOptionCount = counted.length;
+    }
+
+    // Entra writes the account name of each tile on 'Pick an account' into data-test-id.
+    var accountTiles = [];
+    var tiles = document.querySelectorAll('[data-test-id]');
+    for (var t = 0; t < tiles.length; t++) {
+        var testId = tiles[t].getAttribute('data-test-id');
+        if (!testId) { continue; }
+        if (!isVisible(tiles[t])) { continue; }
+        accountTiles.push({ index: accountTiles.length, testId: String(testId) });
+    }
+
+    var hasOtherTile = document.querySelector('[aria-labelledby="otherTileText"]') !== null || document.getElementById('otherTileText') !== null;
+
+    var displaySign = readNumber(document.getElementById(passwordlessNumberId));
+    if (!displaySign) { displaySign = readNumber(document.getElementById(numberMatchId)); }
+
+    // Type-based, so a renamed id still tells the diagnostic which screen this was.
+    var hasVisiblePasswordInput = false;
+    var passwordInputs = document.querySelectorAll('input[type="password"]');
+    for (var w = 0; w < passwordInputs.length; w++) {
+        if (isVisible(passwordInputs[w])) { hasVisiblePasswordInput = true; break; }
+    }
+
+    var hasVisibleEmailInput = false;
+    var emailInputs = document.querySelectorAll('input[type="email"], input[name="loginfmt"]');
+    for (var m = 0; m < emailInputs.length; m++) {
+        if (isVisible(emailInputs[m])) { hasVisibleEmailInput = true; break; }
+    }
+
+    return JSON.stringify({
+        ids: ids,
+        visibleIds: visibleIds,
+        errorCode: errorCode,
+        errorCodeText: errorCodeText,
+        proofs: proofs,
+        proofOptionCount: proofOptionCount,
+        accountTiles: accountTiles,
+        hasOtherTile: hasOtherTile,
+        displaySign: displaySign,
+        hasVisiblePasswordInput: hasVisiblePasswordInput,
+        hasVisibleEmailInput: hasVisibleEmailInput,
+        path: window.location.pathname || ''
+    });
+})();
+'@
+
+    $ProbeScript = $ProbeScript.Replace("__ELEMENT_IDS__", $ElementIdJson)
+    $ProbeScript = $ProbeScript.Replace("__PROOFS_CONTAINER_ID__", $ProofsContainerJson)
+    $ProbeScript = $ProbeScript.Replace("__PASSWORDLESS_NUMBER_ID__", $PasswordlessNumberJson)
+    $ProbeScript = $ProbeScript.Replace("__NUMBER_MATCH_ID__", $NumberMatchJson)
+
+    return $ProbeScript
+}

--- a/OmadaWeb.PS/Private/Get-EntraSignInProbeScript.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraSignInProbeScript.ps1
@@ -43,6 +43,14 @@ function Get-EntraSignInProbeScript {
     [OutputType([System.String])]
     param()
 
+    # The script depends on nothing but the selector table, and the sign-in reads the page again and
+    # again while a user works through it - so it is built once and handed out after that. The build
+    # is small, but it happens on the WebView2 UI thread, which is the one place in this module where
+    # small and repeated is worth not doing at all.
+    if (-not [string]::IsNullOrEmpty($Script:EntraSignInProbeScript)) {
+        return $Script:EntraSignInProbeScript
+    }
+
     $ElementIdJson = ConvertTo-Json -InputObject @($Script:EntraSignInElementId.Values) -Compress
     $ProofsContainerJson = ConvertTo-JavaScriptLiteral $Script:EntraSignInElementId.ProofsContainer
     $PasswordlessNumberJson = ConvertTo-JavaScriptLiteral $Script:EntraSignInElementId.PasswordlessNumber
@@ -174,6 +182,9 @@ function Get-EntraSignInProbeScript {
     $ProbeScript = $ProbeScript.Replace("__PROOFS_CONTAINER_ID__", $ProofsContainerJson)
     $ProbeScript = $ProbeScript.Replace("__PASSWORDLESS_NUMBER_ID__", $PasswordlessNumberJson)
     $ProbeScript = $ProbeScript.Replace("__NUMBER_MATCH_ID__", $NumberMatchJson)
+
+    # Populated before returning, so that the very next call is the cached one.
+    $Script:EntraSignInProbeScript = $ProbeScript
 
     return $ProbeScript
 }

--- a/OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1
+++ b/OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1
@@ -38,6 +38,7 @@ function Get-OmadaSessionContext {
         BaseUrl             = $null
         AuthCookie          = $AuthCookie
         Credential          = $null
+        PreferredMfaMethod  = $null
         LastSessionType     = $null
         WebView2Used        = $false
         ForceAuthentication = $false

--- a/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
@@ -23,6 +23,14 @@ function Invoke-BrowserAuthentication {
     if ($BoundParams.keys -contains "Credential") {
         $SessionContext.Credential = $BoundParams.Credential
     }
+
+    # Carried on the session rather than passed down: the WebView2 sign-in runs inside a blocking
+    # WinForm dialog whose event handlers cannot see this call stack, and the session context is how
+    # everything else - the credential included - reaches them.
+    $SessionContext.PreferredMfaMethod = $null
+    if ($BoundParams.keys -contains "PreferredMfaMethod") {
+        $SessionContext.PreferredMfaMethod = $BoundParams.PreferredMfaMethod
+    }
     switch ($SessionContext.LastSessionType) {
         { $_ -eq "Normal" -and $($BoundParams.InPrivate).IsPresent -eq $true } {
             "{0} - Reset OmadaWebAuthCookie because session has changed to InPrivate" -f $MyInvocation.MyCommand | Write-Verbose

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -157,7 +157,13 @@ function Invoke-OmadaRequest {
             # automates. Every other authentication type would accept the parameter and quietly do
             # nothing with it, so it is refused here rather than silently ignored.
             if ("PreferredMfaMethod" -in $BoundParams.Keys -and -not [string]::IsNullOrWhiteSpace($BoundParams.PreferredMfaMethod)) {
-                $UsesWebView2 = $BoundParams.AuthenticationType -eq "WebView2" -or ($BoundParams.AuthenticationType -eq "Browser" -and $BoundParams.ContainsKey("UseWebView2") -and $BoundParams.UseWebView2)
+                # The three ways a sign-in ends up on WebView2, which is what Invoke-BrowserAuthentication
+                # itself checks: the authentication type, the deprecated switch, and a session that
+                # has already used WebView2 - after which -AuthenticationType Browser keeps using it
+                # without either of the first two being supplied again. Leaving that last one out
+                # refused the parameter on exactly the sign-in it would have applied to.
+                $UsesWebView2 = $BoundParams.AuthenticationType -eq "WebView2" -or
+                    ($BoundParams.AuthenticationType -eq "Browser" -and (($BoundParams.ContainsKey("UseWebView2") -and $BoundParams.UseWebView2) -or $SessionContext.WebView2Used))
                 if (-not $UsesWebView2) {
                     "{0} - -PreferredMfaMethod only applies to -AuthenticationType WebView2, got '{1}'" -f $MyInvocation.MyCommand, $BoundParams.AuthenticationType | Write-Error -ErrorAction "Stop"
                 }

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -153,6 +153,16 @@ function Invoke-OmadaRequest {
 
             "{0} - Authentication type: {1}" -f $MyInvocation.MyCommand, $($BoundParams.AuthenticationType) | Write-Verbose
 
+            # -PreferredMfaMethod drives the Entra ID sign-in screens, which only the WebView2 engine
+            # automates. Every other authentication type would accept the parameter and quietly do
+            # nothing with it, so it is refused here rather than silently ignored.
+            if ("PreferredMfaMethod" -in $BoundParams.Keys -and -not [string]::IsNullOrWhiteSpace($BoundParams.PreferredMfaMethod)) {
+                $UsesWebView2 = $BoundParams.AuthenticationType -eq "WebView2" -or ($BoundParams.AuthenticationType -eq "Browser" -and $BoundParams.ContainsKey("UseWebView2") -and $BoundParams.UseWebView2)
+                if (-not $UsesWebView2) {
+                    "{0} - -PreferredMfaMethod only applies to -AuthenticationType WebView2, got '{1}'" -f $MyInvocation.MyCommand, $BoundParams.AuthenticationType | Write-Error -ErrorAction "Stop"
+                }
+            }
+
             switch ($BoundParams.AuthenticationType) {
                 "Windows" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -52,12 +52,22 @@ function Invoke-WebView2MicrosoftLogin {
             return $false
         }
 
-        # Writes a value into a field and raises the events the sign-in app listens for. Applied to
-        # its arguments by the call site, so it stays a bare function expression.
+        # Every one of these answers true only when it acted on something the user could have acted
+        # on themselves, and that is what the driver reads to decide whether the page moved.
+        #
+        # Checking again here, after the probe already reported the element as visible, is not
+        # redundant. The probe's answer is a snapshot, and several ticks pass between taking it and
+        # acting on it - the page can navigate in between. Without the second check the script would
+        # report success for typing into a field that had gone, the driver would count that as
+        # progress and restart the stall clock, and the sign-in would sit on a page nothing was
+        # happening to. The predicate is the shared one, so it cannot disagree with the probe's.
+        #
+        # Applied to its arguments by the call site, so it stays a bare function expression.
         $SetElementValueScript = @"
 (function(elementId, value) {
+$(Get-EntraElementVisibilityScript)
     var element = document.getElementById(elementId);
-    if (element) {
+    if (element && isVisible(element)) {
         element.value = value;
         element.dispatchEvent(new Event('input', { bubbles: true }));
         element.dispatchEvent(new Event('change', { bubbles: true }));
@@ -69,8 +79,9 @@ function Invoke-WebView2MicrosoftLogin {
 
         $ClickElementScript = @"
 (function(elementId) {
+$(Get-EntraElementVisibilityScript)
     var element = document.getElementById(elementId);
-    if (element) {
+    if (element && isVisible(element)) {
         element.click();
         return true;
     }
@@ -104,15 +115,16 @@ $(Get-EntraElementVisibilityScript)
         # the element that labels it is not.
         $ClickUseAnotherAccountScript = @"
 (function() {
+$(Get-EntraElementVisibilityScript)
     var otherAccount = document.querySelector('[aria-labelledby="otherTileText"]');
-    if (otherAccount) {
+    if (otherAccount && isVisible(otherAccount)) {
         otherAccount.click();
         return true;
     }
     var otherTileText = document.getElementById('otherTileText');
     if (otherTileText) {
         var clickable = otherTileText.closest('[role="button"], button, a, div');
-        if (clickable) {
+        if (clickable && isVisible(clickable)) {
             clickable.click();
             return true;
         }

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -410,9 +410,30 @@ function Invoke-WebView2MicrosoftLogin {
                     return $false
                 }
 
-                if (-not [string]::IsNullOrWhiteSpace($Script:PendingSubmitId)) {
-                    $SubmitId = $Script:PendingSubmitId
-                    $Script:PendingSubmitId = $null
+                # Every snippet above answers true when it found its element and acted on it, and
+                # false when it did not. That answer has to be read, because "the script ran" and
+                # "the page was driven" are not the same thing: an element Microsoft has renamed
+                # produces a script that executes perfectly and does nothing at all.
+                #
+                # Counting that as progress is what turns a renamed element into an endless loop.
+                # Progress clears the stall clock, so a click that silently did nothing would restart
+                # the clock on every tick, and Test-LoginAutomationStalled - the one thing that ends
+                # this - would never run out however long its timeout was.
+                $Acted = ($Script:LoginTask.Result -eq "true")
+                $SubmitId = $Script:PendingSubmitId
+                $Script:PendingSubmitId = $null
+
+                if (-not $Acted) {
+                    "Invoke-WebView2MicrosoftLogin - The page did not respond to the '{0}' step, leaving the stall clock running" -f $Script:CurrentScenario | Write-Verbose
+                    $Script:LoginTask = $null
+                    $Script:PageState = $null
+                    $Script:LoginState = "ReadingPage"
+                    return $false
+                }
+
+                # The field was filled in, so submit it. Reached only when the value was written -
+                # clicking submit over a field that stayed empty would send the empty value.
+                if (-not [string]::IsNullOrWhiteSpace($SubmitId)) {
                     $Script:LoginTask = $Script:WebView2.CoreWebView2.ExecuteScriptAsync("$ClickElementScript($(ConvertTo-JavaScriptLiteral $SubmitId))")
                     return $false
                 }

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -305,6 +305,20 @@ function Invoke-WebView2MicrosoftLogin {
                         return $false
                     }
 
+                    "Manual" {
+                        # Entra ID named its own error, and it is one only the person at the keyboard
+                        # can resolve - registering security information, completing an extra
+                        # verification step. Waiting out the stall timeout first would add a silent
+                        # minute to a message that is already known, so hand over now.
+                        $Reason = $Decision.Reason
+                        if (-not [string]::IsNullOrWhiteSpace($Decision.Code)) {
+                            $Reason = "{0}: {1}" -f $Decision.Code, $Reason
+                        }
+
+                        Switch-ToManualLogin -State ("Deciding/{0}" -f $Decision.Screen) -FoundElementId $Present -Url $Script:WebView2.Source.AbsoluteUri -Reason $Reason | Out-Null
+                        return $false
+                    }
+
                     "Retry" {
                         "`nMFA failed! Please retry!" | Write-Warning
                         $Script:MfaRequestDisplayed = $false

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -79,12 +79,30 @@ function Invoke-WebView2MicrosoftLogin {
 "@
 
         # 'Pick an account' identifies each tile by the account name in its data-test-id.
+        #
+        # The visibility test is not decoration: Get-EntraSignInProbeScript reports only visible
+        # tiles, so the resolver can only ever choose one. Clicking the first element carrying the
+        # id regardless would let a hidden namesake take the click instead, and that failure is
+        # invisible from here - the click reports success, which restarts the stall clock, so the
+        # driver would sit on the same page clicking nothing for as long as the window is open.
         $ClickAccountTileScript = @"
 (function(dataTestId) {
+    function isVisible(element) {
+        if (!element) { return false; }
+        try {
+            var style = window.getComputedStyle(element);
+            if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') { return false; }
+        }
+        catch (e) { return false; }
+        if (element.getAttribute('aria-hidden') === 'true') { return false; }
+        if (element.disabled === true) { return false; }
+        return element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0;
+    }
+
     var elements = document.querySelectorAll('[data-test-id]');
     for (var i = 0; i < elements.length; i++) {
         var value = elements[i].getAttribute('data-test-id');
-        if (value != null && value.toLowerCase() === dataTestId.toLowerCase()) {
+        if (value != null && value.toLowerCase() === dataTestId.toLowerCase() && isVisible(elements[i])) {
             elements[i].click();
             return true;
         }

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -173,29 +173,39 @@ function Invoke-WebView2MicrosoftLogin {
                     return $false
                 }
 
-                if ($Script:LoginTask.IsFaulted) {
-                    "Invoke-WebView2MicrosoftLogin - Could not read the sign-in page: {0}" -f $Script:LoginTask.Exception.Message | Write-Verbose
-                    $Script:LoginTask = $null
-                    return $false
-                }
-
                 $Snapshot = $null
-                try {
-                    # ExecuteScriptAsync hands back the script's return value as JSON, and the script
-                    # returns a JSON document - so the payload is decoded twice.
-                    $Snapshot = $Script:LoginTask.Result | ConvertFrom-Json | ConvertFrom-Json
+                $UnreadableReason = $null
+
+                if ($Script:LoginTask.IsFaulted) {
+                    $UnreadableReason = $Script:LoginTask.Exception.Message
+                    "Invoke-WebView2MicrosoftLogin - Could not read the sign-in page: {0}" -f $UnreadableReason | Write-Verbose
                 }
-                catch {
-                    "Invoke-WebView2MicrosoftLogin - The sign-in page snapshot could not be read: {0}" -f $_.Exception.Message | Write-Verbose
+                else {
+                    try {
+                        # ExecuteScriptAsync hands back the script's return value as JSON, and the
+                        # script returns a JSON document - so the payload is decoded twice.
+                        $Snapshot = $Script:LoginTask.Result | ConvertFrom-Json | ConvertFrom-Json
+                    }
+                    catch {
+                        $UnreadableReason = $_.Exception.Message
+                        "Invoke-WebView2MicrosoftLogin - The sign-in page snapshot could not be read: {0}" -f $UnreadableReason | Write-Verbose
+                    }
+
+                    if ($null -eq $Snapshot -and $null -eq $UnreadableReason) {
+                        $UnreadableReason = "The sign-in page did not answer the query this module reads it with."
+                    }
                 }
 
                 $Script:LoginTask = $null
 
                 if ($null -eq $Snapshot) {
-                    # A page that answers nothing at all is the loudest form of a selector break, and
-                    # retrying it would otherwise never end.
+                    # A page that cannot be read is the loudest form of a selector break - and a
+                    # script that cannot even be executed is no different from here. Both retry on
+                    # the next tick, because a page mid-navigation produces exactly this; the stall
+                    # clock is what ends the retrying, and leaving it unarmed on either path would
+                    # loop until the window is closed by hand.
                     if (Test-LoginAutomationStalled -ElementId @()) {
-                        Switch-ToManualLogin -State "ReadingPage" -MissingElementId @($Script:EntraSignInElementId.Values) -FoundElementId @() -Url $Script:WebView2.Source.AbsoluteUri -Reason "The sign-in page did not answer the query this module reads it with." | Out-Null
+                        Switch-ToManualLogin -State "ReadingPage" -MissingElementId @($Script:EntraSignInElementId.Values) -FoundElementId @() -Url $Script:WebView2.Source.AbsoluteUri -Reason $UnreadableReason | Out-Null
                     }
 
                     return $false

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -87,18 +87,7 @@ function Invoke-WebView2MicrosoftLogin {
         # driver would sit on the same page clicking nothing for as long as the window is open.
         $ClickAccountTileScript = @"
 (function(dataTestId) {
-    function isVisible(element) {
-        if (!element) { return false; }
-        try {
-            var style = window.getComputedStyle(element);
-            if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') { return false; }
-        }
-        catch (e) { return false; }
-        if (element.getAttribute('aria-hidden') === 'true') { return false; }
-        if (element.disabled === true) { return false; }
-        return element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0;
-    }
-
+$(Get-EntraElementVisibilityScript)
     var elements = document.querySelectorAll('[data-test-id]');
     for (var i = 0; i < elements.length; i++) {
         var value = elements[i].getAttribute('data-test-id');
@@ -135,14 +124,21 @@ function Invoke-WebView2MicrosoftLogin {
         # Verification methods on 'choose a way to sign in' are clicked by position, because the
         # options carry nothing that names which method they are. Resolve-EntraSignInScreen only
         # produces an index after checking that the options and the methods line up.
+        #
+        # Which makes counting the same options the probe counted the whole safety of it. A hidden
+        # template option included here and not there - or the reverse - shifts every index after it,
+        # and the failure is silent in the worst possible way: the click succeeds, so nothing reports
+        # an error, and the account is sent a weaker verification method than the one that was
+        # chosen. Both sides filter through the same isVisible.
         $ClickProofOptionScript = @"
 (function(containerId, index) {
+$(Get-EntraElementVisibilityScript)
     var container = document.getElementById(containerId);
     if (!container) { return false; }
     var options = container.querySelectorAll('[data-value], [role="button"], [role="listitem"]');
     var counted = [];
     for (var i = 0; i < options.length; i++) {
-        if (counted.indexOf(options[i]) === -1) { counted.push(options[i]); }
+        if (counted.indexOf(options[i]) === -1 && isVisible(options[i])) { counted.push(options[i]); }
     }
     if (index < 0 || index >= counted.length) { return false; }
     counted[index].click();

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -1,6 +1,40 @@
 function Invoke-WebView2MicrosoftLogin {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'KeepMeSignedInId', Justification = 'Added for later use in the function')]
+    <#
+    .SYNOPSIS
+        Drives the Microsoft Entra ID sign-in page from the supplied credential, one timer tick at a
+        time.
+
+    .DESCRIPTION
+        Called from the 150 ms WebView2 timer while the browser is on login.microsoftonline.com. Each
+        tick does one small piece of work and returns, because everything here runs on the UI thread
+        of an open window: blocking it would freeze the browser the user may still have to type in.
+
+        The work is split in three so that the part worth testing can be tested. Reading the page is
+        one asynchronous script - the one Get-EntraSignInProbeScript builds - which returns a snapshot
+        carrying no rendered text at all. Deciding what that snapshot means is Resolve-EntraSignInScreen,
+        an ordinary function with no browser behind it. Acting on the decision is this function, and
+        it is deliberately dull: fill a field, click an element, read a number, or stop.
+
+        Two of those outcomes end the sign-in rather than continuing it, and the difference matters:
+
+          - Stop. Entra ID reported a failure that no retry can change - a Conditional Access block,
+            a locked account, a refused password. Stop-OmadaLogin records why and closes the window,
+            and the driver reports that instead of opening another one. A wrong password belongs
+            here: sending it again is what drives an account into smart lockout.
+          - Wait. The page is one this module cannot drive, or has never seen. Nothing happens
+            immediately, because a page caught mid-navigation looks exactly the same; only when
+            Test-LoginAutomationStalled says the page has stopped changing does Switch-ToManualLogin
+            hand the sign-in to the user, quoting what the decision said about it.
+
+        The credential's password is read here and nowhere else. It is passed to the page through
+        ConvertTo-JavaScriptLiteral, which is what keeps a password containing a quote from ending the
+        string literal it is written into (issue #19).
+
+    .OUTPUTS
+        System.Boolean. True when this tick moved the sign-in forward, false otherwise.
+    #>
     [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param()
 
     try {
@@ -11,116 +45,16 @@ function Invoke-WebView2MicrosoftLogin {
         }
 
         if (!$Script:MicrosoftOnlineLogin) {
-            return
+            return $false
         }
 
         if ($null -eq $Script:WebView2 -or $null -eq $Script:WebView2.CoreWebView2) {
-            return
+            return $false
         }
 
-        # Element IDs used by Microsoft login
-        $UserNameElementId = "i0116"
-        $PasswordElementId = "i0118"
-        $SubmitButtonId = "idSIButton9"
-        $CantAccessAccountId = "cantAccessAccount"
-        $MfaElementId1 = "idRichContext_DisplaySign"
-        $MfaElementId2 = "idRemoteNGC_DisplaySign"
-        $MfaRetryId1 = "idA_SAASTO_Resend"
-        $MfaRetryId2 = "idA_SAASDS_Resend"
-        $ButtonBackId = "idBtn_Back"
-        $KeepMeSignedInId = "KmsiCheckboxField"
-
-        # Everything the scenarios below recognize a page by, and so everything a diagnostic has to
-        # be able to report as absent.
-        $KnownElementId = @($UserNameElementId, $PasswordElementId, $SubmitButtonId, $ButtonBackId, $CantAccessAccountId, $MfaElementId1, $MfaElementId2, $MfaRetryId1, $MfaRetryId2, $KeepMeSignedInId)
-
-        # JavaScript to get all element details on the page
-        $getAllIdsScript = @"
-(function() {
-    var idsToFind = [
-        'i0116',
-        'i0118',
-        'idSIButton9',
-        'cantAccessAccount',
-        'idRichContext_DisplaySign',
-        'idA_SAASTO_Resend',
-        'idA_SAASDS_Resend',
-        'idBtn_Back',
-        'i0281',
-        'idA_PWD_ForgotPassword',
-        'passwordError',
-        'idRemoteNGC_DisplaySign',
-        'KmsiCheckboxField'
-    ];
-
-    var foundElements = [];
-    for (var i = 0; i < idsToFind.length; i++) {
-        var element = document.getElementById(idsToFind[i]);
-        if (element) {
-            foundElements.push({
-                id: idsToFind[i],
-                tagName: element.tagName,
-                type: element.type || null,
-                name: element.name || null,
-                className: element.className || null,
-                outerHTML: element.outerHTML
-            });
-        }
-    }
-    return JSON.stringify(foundElements);
-})();
-"@
-
-        #         $getAllNameElementsScript = @"
-        # (function() {
-        #     var namesToFind = [
-        #         'login'
-        #     ];
-        #     var foundElements = [];
-        #     for (var i = 0; i < namesToFind.length; i++) {
-        #         var element = document.getElementsByName(namesToFind[i]);
-        #         if (element != null && element[0].value != null) {
-        #             foundElements.push({
-        #                 name: element[0].name,
-        #                 value: element[0].value
-        #              });
-        #         }
-        #     }
-        #     return foundElements;
-        # })();
-        # "@
-
-        # JavaScript to get element property
-        $getElementPropertyScript = @"
-(function(elementId, property) {
-    var element = document.getElementById(elementId);
-    if (element) {
-        return element[property] || element.getAttribute(property);
-    }
-    return null;
-})
-"@
-
-
-        $getMfaElementPropertyScript = @"
-(function() {
-    var idsToFind = [
-        'idRichContext_DisplaySign',
-        'idRemoteNGC_DisplaySign'
-    ];
-    var foundElements = [];
-    for (var i = 0; i < idsToFind.length; i++) {
-        var element = document.getElementById(idsToFind[i]);
-        if (element != null) {
-            foundElements.push(element.childNodes[0] != null ? element.childNodes[0].data : null);
-        }
-    }
-    return JSON.stringify(foundElements);
-})();
-"@
-
-        # JavaScript to set element value and trigger events
-        $setElementValueScript = @"
+        # Writes a value into a field and raises the events the sign-in app listens for. Applied to
+        # its arguments by the call site, so it stays a bare function expression.
+        $SetElementValueScript = @"
 (function(elementId, value) {
     var element = document.getElementById(elementId);
     if (element) {
@@ -133,8 +67,7 @@ function Invoke-WebView2MicrosoftLogin {
 })
 "@
 
-        # JavaScript to click element
-        $clickElementScript = @"
+        $ClickElementScript = @"
 (function(elementId) {
     var element = document.getElementById(elementId);
     if (element) {
@@ -145,31 +78,13 @@ function Invoke-WebView2MicrosoftLogin {
 })
 "@
 
-        # JavaScript to check if element is visible and enabled
-        $isElementVisibleScript = @"
-(function(elementId) {
-    var element = document.getElementById(elementId);
-    if (!element) return false;
-
-    var style = window.getComputedStyle(element);
-    var isVisible = style.display !== 'none' &&
-                    style.visibility !== 'hidden' &&
-                    style.opacity !== '0' &&
-                    element.offsetWidth > 0 &&
-                    element.offsetHeight > 0;
-
-    var isEnabled = !element.disabled && !element.readOnly;
-
-    return isVisible && isEnabled;
-})
-"@
-
-        # JavaScript to get element by data-test-id
-        $getElementByDataTestIdScript = @"
+        # 'Pick an account' identifies each tile by the account name in its data-test-id.
+        $ClickAccountTileScript = @"
 (function(dataTestId) {
     var elements = document.querySelectorAll('[data-test-id]');
     for (var i = 0; i < elements.length; i++) {
-        if (elements[i].getAttribute('data-test-id') != null && elements[i].getAttribute('data-test-id').toLowerCase() === dataTestId.toLowerCase()) {
+        var value = elements[i].getAttribute('data-test-id');
+        if (value != null && value.toLowerCase() === dataTestId.toLowerCase()) {
             elements[i].click();
             return true;
         }
@@ -178,53 +93,43 @@ function Invoke-WebView2MicrosoftLogin {
 })
 "@
 
-        # JavaScript to click "Use another account" option
-        $clickUseAnotherAccountScript = @"
+        # The tile that leads away from the remembered accounts. Its label is localized; the id of
+        # the element that labels it is not.
+        $ClickUseAnotherAccountScript = @"
 (function() {
-    // Try by aria-labelledby first
     var otherAccount = document.querySelector('[aria-labelledby="otherTileText"]');
     if (otherAccount) {
         otherAccount.click();
         return true;
     }
+    var otherTileText = document.getElementById('otherTileText');
+    if (otherTileText) {
+        var clickable = otherTileText.closest('[role="button"], button, a, div');
+        if (clickable) {
+            clickable.click();
+            return true;
+        }
+    }
     return false;
 })();
 "@
 
-        # JavaScript to check for error messages
-        $checkForErrorScript = @"
-(function() {
-    // Check for common error element IDs and classes
-    var errorIds = ['passwordError', 'usernameError'];
-    var errorTexts = ['incorrect', 'invalid', 'wrong password', 'wrong username', 'not recognized'];
-
-    // Check by ID
-    for (var i = 0; i < errorIds.length; i++) {
-        var elem = document.getElementById(errorIds[i]);
-        if (elem && elem.offsetHeight > 0) {
-            return elem.textContent || elem.innerText;
-        }
+        # Verification methods on 'choose a way to sign in' are clicked by position, because the
+        # options carry nothing that names which method they are. Resolve-EntraSignInScreen only
+        # produces an index after checking that the options and the methods line up.
+        $ClickProofOptionScript = @"
+(function(containerId, index) {
+    var container = document.getElementById(containerId);
+    if (!container) { return false; }
+    var options = container.querySelectorAll('[data-value], [role="button"], [role="listitem"]');
+    var counted = [];
+    for (var i = 0; i < options.length; i++) {
+        if (counted.indexOf(options[i]) === -1) { counted.push(options[i]); }
     }
-
-    // Check by role and aria-live
-    var alerts = document.querySelectorAll('[role="alert"], [aria-live="assertive"], [aria-live="polite"]');
-    for (var i = 0; i < alerts.length; i++) {
-        if (alerts[i].offsetHeight > 0) {
-            var text = alerts[i].textContent || alerts[i].innerText;
-            if (text && text.trim().length > 0) {
-                // Check if it contains error keywords
-                var lowerText = text.toLowerCase();
-                for (var j = 0; j < errorTexts.length; j++) {
-                    if (lowerText.indexOf(errorTexts[j]) !== -1) {
-                        return text;
-                    }
-                }
-            }
-        }
-    }
-
-    return null;
-})();
+    if (index < 0 || index >= counted.length) { return false; }
+    counted[index].click();
+    return true;
+})
 "@
 
         # Check if we're on the Microsoft login page
@@ -233,652 +138,276 @@ function Invoke-WebView2MicrosoftLogin {
             # Reset state when leaving login page
             $Script:LoginState = $null
             $Script:LoginTask = $null
-            $Script:IdAttributes = $null
-            $Script:PreviousAttributes = $null
+            $Script:PageState = $null
+            $Script:PendingSubmitId = $null
             $Script:LoginSubState = $null
-            $Script:BackButtonText = $null
             $Script:LoginFailed = $false
             $Script:CurrentScenario = $null
             $Script:PreviousScenario = $null
+            $Script:MfaWaitLastReported = $null
             Reset-LoginAutomationState
             return $false
         }
 
-        # Check if we have credentials - so we know whether to attempt login
-        if ($Script:CurrentWebView2Session.Credential -and -not [string]::IsNullOrWhiteSpace($Script:CurrentWebView2Session.Credential.UserName)) {
-            # Initialize login state if needed
-            if ($null -eq $Script:LoginState) {
-                $Script:LoginState = "GettingIds"
-                $Script:LoginTask = $null
-                $Script:LoginSubState = $null
-            }
+        # No user name means nothing to fill in, so the user signs in by hand in the open window.
+        if (-not $Script:CurrentWebView2Session.Credential -or [string]::IsNullOrWhiteSpace($Script:CurrentWebView2Session.Credential.UserName)) {
+            return $false
+        }
 
-            # State machine for non-blocking async operations
-            switch ($Script:LoginState) {
-                "GettingIds" {
-                    "GettingIds" | Write-Verbose
-                    if ($null -eq $Script:LoginTask) {
-                        # Start the async task to get IDs
-                        "Getting page element IDs..." | Write-Verbose
-                        $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($getAllIdsScript)
-                        return $false  # Come back on next timer tick
-                    }
+        if ($null -eq $Script:LoginState) {
+            $Script:LoginState = "ReadingPage"
+            $Script:LoginTask = $null
+            $Script:PageState = $null
+            $Script:PendingSubmitId = $null
+        }
 
-                    # Check if task is complete (non-blocking)
-                    if ($Script:LoginTask.IsCompleted) {
-                        if ($Script:LoginTask.IsFaulted) {
-                            "Failed to get element IDs: $($Script:LoginTask.Exception.Message)" | Write-Verbose
-                            $Script:LoginState = "GettingIds"
-                            $Script:LoginTask = $null
-                            return $false
-                        }
-
-                        $IdsJson = $Script:LoginTask.Result
-                        $Script:IdAttributes = $IdsJson | ConvertFrom-Json | ConvertFrom-Json
-
-                        if ($null -eq $Script:IdAttributes -or $Script:IdAttributes.Count -eq 0) {
-                            "No element IDs found on page, retrying..." | Write-Verbose
-                            # A sign-in page carrying none of the known IDs at all is the loudest
-                            # form of a selector break, and retrying it would otherwise never end.
-                            if (Test-LoginAutomationStalled -ElementId @()) {
-                                # Every known selector is missing here, so name them all rather than
-                                # leaving the diagnostic without a single selector in it.
-                                Switch-ToManualLogin -State "GettingIds" -MissingElementId $KnownElementId -FoundElementId @() -Url $Script:WebView2.Source.AbsoluteUri -Reason "The page carries none of the element IDs this module looks for." | Out-Null
-                                return $false
-                            }
-
-                            $Script:LoginState = "GettingIds"
-                            $Script:LoginTask = $null
-                            return $false
-                        }
-
-                        # Check if page has changed (different IDs) - if so, reset active scenario
-                        if ($null -ne $Script:PreviousAttributes) {
-                            $idsChanged = $false
-                            # Check if key elements changed
-                            $prevHadUsername = $UserNameElementId -in $Script:PreviousAttributes.id -and ($Script:PreviousAttributes | Where-Object { $_.id -eq $UserNameElementId }).outerHTML -notlike '*aria-hidden="true"*'
-                            $prevHadPassword = $PasswordElementId -in $Script:PreviousAttributes.id -and ($Script:PreviousAttributes | Where-Object { $_.id -eq $PasswordElementId }).outerHTML -notlike '*aria-hidden="true"*'
-                            $nowHasUsername = $UserNameElementId -in $Script:IdAttributes.id -and ($Script:IdAttributes | Where-Object { $_.id -eq $UserNameElementId }).outerHTML -notlike '*aria-hidden="true"*'
-                            $nowHasPassword = $PasswordElementId -in $Script:IdAttributes.id -and ($Script:IdAttributes | Where-Object { $_.id -eq $PasswordElementId }).outerHTML -notlike '*aria-hidden="true"*'
-
-                            if ($prevHadUsername -ne $nowHasUsername -or $prevHadPassword -ne $nowHasPassword) {
-                                $idsChanged = $true
-                                "Page changed detected - resetting active scenario" | Write-Verbose
-                            }
-
-                            if ($idsChanged) {
-                                $Script:LoginSubState = $null
-                            }
-                        }
-
-                        # Store current IDs for next comparison
-                        $Script:PreviousAttributes = $Script:IdAttributes
-
-                        # Move to processing scenarios
-                        "Found $($Script:IdAttributes.Count) element IDs on page" | Write-Verbose
-                        $Script:LoginState = "ProcessingScenarios"
-                        $Script:LoginTask = $null
-                        return $false  # Process scenarios on next tick
-                    }
-
-                    # Task still running, check again on next tick
+        switch ($Script:LoginState) {
+            "ReadingPage" {
+                if ($null -eq $Script:LoginTask) {
+                    "Invoke-WebView2MicrosoftLogin - Reading the sign-in page" | Write-Verbose
+                    $Script:LoginTask = $Script:WebView2.CoreWebView2.ExecuteScriptAsync((Get-EntraSignInProbeScript))
                     return $false
                 }
 
-                "ProcessingScenarios" {
-                    "ProcessingScenarios" | Write-Verbose
-                    # Now we have IdAttributes, process all scenarios
+                if (-not $Script:LoginTask.IsCompleted) {
+                    return $false
+                }
 
+                if ($Script:LoginTask.IsFaulted) {
+                    "Invoke-WebView2MicrosoftLogin - Could not read the sign-in page: {0}" -f $Script:LoginTask.Exception.Message | Write-Verbose
+                    $Script:LoginTask = $null
+                    return $false
+                }
 
+                $Snapshot = $null
+                try {
+                    # ExecuteScriptAsync hands back the script's return value as JSON, and the script
+                    # returns a JSON document - so the payload is decoded twice.
+                    $Snapshot = $Script:LoginTask.Result | ConvertFrom-Json | ConvertFrom-Json
+                }
+                catch {
+                    "Invoke-WebView2MicrosoftLogin - The sign-in page snapshot could not be read: {0}" -f $_.Exception.Message | Write-Verbose
+                }
 
-                    # Debug: Log what IDs we found
-                    "Page IDs found: $($Script:IdAttributes.id -join ', ')" | Write-Verbose
-                    "Looking for username: $UserNameElementId, password: $PasswordElementId, submit: $SubmitButtonId" | Write-Verbose
-                    "Username exists: $($UserNameElementId -in $Script:IdAttributes.id -and ($Script:IdAttributes | Where-Object { $_.id -eq $UserNameElementId }).outerHTML -notlike '*aria-hidden="true"*')" | Write-Verbose
-                    "Password exists: $($PasswordElementId -in $Script:IdAttributes.id -and ($Script:IdAttributes | Where-Object { $_.id -eq $PasswordElementId }).outerHTML -notlike '*aria-hidden="true"*')" | Write-Verbose
-                    "Username existed: $($UserNameElementId -in $Script:PreviousAttributes.id -and ($Script:PreviousAttributes | Where-Object { $_.id -eq $UserNameElementId }).outerHTML -notlike '*aria-hidden="true"*')" | Write-Verbose
-                    "Password existed: $($PasswordElementId -in $Script:PreviousAttributes.id -and ($Script:PreviousAttributes | Where-Object { $_.id -eq $PasswordElementId }).outerHTML -notlike '*aria-hidden="true"*')" | Write-Verbose
-                    "CantAccessAccount exists: $( $CantAccessAccountId -in $Script:IdAttributes.id)" | Write-Verbose
-                    "SubmitButton exists: $( $SubmitButtonId -in $Script:IdAttributes.id)" | Write-Verbose
-                    "ButtonBack exists: $( $ButtonBackId -in $Script:IdAttributes.id)" | Write-Verbose
-                    "MfaElementIds exists: $( $MfaElementId1 -in $Script:IdAttributes.id -or   $MfaElementId2 -in $Script:IdAttributes.id)" | Write-Verbose
+                $Script:LoginTask = $null
 
-                    # Every scenario below recognizes the page by the element IDs above. When
-                    # Microsoft changes that markup, either no scenario matches or the one that does
-                    # can no longer act, and the timer keeps re-evaluating the same page forever.
-                    # Detect that and let the user sign in by hand instead - the window is open and
-                    # for a tenant that is not on Entra typing the credentials there is the normal
-                    # path anyway (issue #32).
-                    $WaitingForApproval = $Script:MfaRequestDisplayed -and ($MfaElementId1 -in $Script:IdAttributes.id -or $MfaElementId2 -in $Script:IdAttributes.id)
-                    if (Test-LoginAutomationStalled -ElementId $Script:IdAttributes.id -WaitingForApproval:$WaitingForApproval) {
-                        $MissingElementId = @($KnownElementId | Where-Object { $_ -notin $Script:IdAttributes.id })
-                        $ScenarioName = "NoMatchingScenario"
-                        if (-not [string]::IsNullOrWhiteSpace($Script:CurrentScenario)) {
-                            $ScenarioName = $Script:CurrentScenario
+                if ($null -eq $Snapshot) {
+                    # A page that answers nothing at all is the loudest form of a selector break, and
+                    # retrying it would otherwise never end.
+                    if (Test-LoginAutomationStalled -ElementId @()) {
+                        Switch-ToManualLogin -State "ReadingPage" -MissingElementId @($Script:EntraSignInElementId.Values) -FoundElementId @() -Url $Script:WebView2.Source.AbsoluteUri -Reason "The sign-in page did not answer the query this module reads it with." | Out-Null
+                    }
+
+                    return $false
+                }
+
+                $Script:PageState = $Snapshot
+                $Script:LoginState = "Deciding"
+                return $false
+            }
+
+            "Deciding" {
+                $HasPassword = $false
+                $NetworkCredential = $Script:CurrentWebView2Session.Credential.GetNetworkCredential()
+                if (-not [string]::IsNullOrEmpty($NetworkCredential.Password)) {
+                    $HasPassword = $true
+                }
+
+                $PreferredMfaMethod = $null
+                if ($null -ne $Script:CurrentWebView2Session.PreferredMfaMethod) {
+                    $PreferredMfaMethod = [string]$Script:CurrentWebView2Session.PreferredMfaMethod
+                }
+
+                $Decision = Resolve-EntraSignInScreen -PageState $Script:PageState -UserName $Script:CurrentWebView2Session.Credential.UserName.Trim() -HasPassword:$HasPassword -PreferredMfaMethod $PreferredMfaMethod -MfaRequestDisplayed:$Script:MfaRequestDisplayed
+
+                "Invoke-WebView2MicrosoftLogin - Screen '{0}', action '{1}'" -f $Decision.Screen, $Decision.Action | Write-Verbose
+                $Script:PreviousScenario = $Script:CurrentScenario
+                $Script:CurrentScenario = $Decision.Screen
+
+                # Waiting for someone to reach for their phone is not a stall, and it is the one step
+                # that legitimately takes minutes.
+                # Read through the property bag: Set-StrictMode turns a plain access on a member the
+                # snapshot does not carry into a terminating error, and a partly readable page is
+                # exactly the case this diagnostic exists for.
+                $Present = @()
+                $IdProperty = $Script:PageState.PSObject.Properties["ids"]
+                if ($null -ne $IdProperty) {
+                    $Present = @($IdProperty.Value)
+                }
+
+                $WaitingForApproval = $Script:MfaRequestDisplayed -and $Decision.Screen -eq "ApprovalNumber"
+                if (Test-LoginAutomationStalled -ElementId $Present -WaitingForApproval:$WaitingForApproval) {
+                    $MissingElementId = @($Script:EntraSignInElementId.Values | Where-Object { $_ -notin $Present })
+                    $ScenarioName = "NoMatchingScreen"
+                    if (-not [string]::IsNullOrWhiteSpace($Decision.Screen) -and $Decision.Screen -ne "Unknown") {
+                        $ScenarioName = $Decision.Screen
+                    }
+
+                    Switch-ToManualLogin -State ("Deciding/{0}" -f $ScenarioName) -MissingElementId $MissingElementId -FoundElementId $Present -Url $Script:WebView2.Source.AbsoluteUri -Reason $Decision.Reason | Out-Null
+                    return $false
+                }
+
+                switch ($Decision.Action) {
+                    "Stop" {
+                        $Message = $Decision.Reason
+                        if ([string]::IsNullOrWhiteSpace($Message)) {
+                            $Message = "Entra ID refused this sign-in."
                         }
 
-                        Switch-ToManualLogin -State ("ProcessingScenarios/{0}" -f $ScenarioName) -MissingElementId $MissingElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri | Out-Null
+                        Stop-OmadaLogin -Message $Message -Code $Decision.Code -Reason $Decision.Reason -Url $Script:WebView2.Source.AbsoluteUri -Engine "WebView2" | Out-Null
+
+                        # The watchdog counters belong to the window that is closing, not to the next.
+                        $Script:OmadaWatchdogStart = $null
+                        $Script:OmadaWatchdogRunning = $false
+                        $Script:ProgressCounter = 0
+                        $Script:LastFiredSecond = -1
+
+                        try {
+                            if ($null -ne $Script:WebView2) {
+                                $LoginForm = $Script:WebView2.FindForm()
+                                if ($null -ne $LoginForm) {
+                                    $LoginForm.Close()
+                                }
+                            }
+                        }
+                        catch {
+                            "Invoke-WebView2MicrosoftLogin - Could not close the sign-in window: {0}" -f $_.Exception.Message | Write-Verbose
+                        }
+
                         return $false
                     }
 
-                    # Scenario 1: Username entry page
-                    # Check if username field exists - we'll verify visibility in the sub-state
-                    if (  $UserNameElementId -in $Script:IdAttributes.id -and ($Script:IdAttributes | Where-Object { $_.id -eq $UserNameElementId }).outerHTML -notlike '*aria-hidden="true"*' -and $SubmitButtonId -in $Script:IdAttributes.id) {
-                        "Scenario 1: Username entry page" | Write-Verbose
-                        $Script:CurrentScenario = "UsernameEntry"
-                        "Scenario 1: PreviousScenario {0}" -f $Script:PreviousScenario | Write-Verbose
-
-                        # Sub-state machine for username entry
-                        switch ($Script:LoginSubState) {
-                            $null {
-                                # First check for error messages
-                                "Checking for error messages on page..." | Write-Verbose
-                                $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($checkForErrorScript)
-                                $Script:LoginSubState = "CheckingForError"
-                                return $false
-                            }
-                            "CheckingForError" {
-                                "Scenario 1: CheckingForError" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $errorMessage = ConvertFrom-JavaScriptResult $Script:LoginTask.Result
-                                        if (-not [string]::IsNullOrWhiteSpace($errorMessage)) {
-                                            Write-Warning "Login error detected: $errorMessage"
-                                            Write-Warning "Please verify your credentials and try again. Automatic login aborted."
-                                            $Script:LoginFailed = $true
-                                            $Script:LoginState = $null
-                                            $Script:LoginSubState = $null
-                                            $Script:IdAttributes = $null
-                                            $Script:LoginTask = $null
-                                            $Script:MicrosoftOnlineLogin = $false
-                                            return $false
-                                        }
-                                    }
-                                    # No error, proceed to check username field visibility
-                                    $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync("$isElementVisibleScript($(ConvertTo-JavaScriptLiteral $UserNameElementId))")
-                                    $Script:LoginSubState = "CheckingUsernameField"
-                                }
-                                return $false
-                            }
-                            "CheckingUsernameField" {
-                                "Scenario 1: CheckingUsernameField" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $isVisible = $Script:LoginTask.Result
-                                        "Username field visibility check result: $isVisible" | Write-Verbose
-                                        if ($isVisible -eq "true") {
-                                            "Matched Scenario 1: Username entry page" | Write-Verbose
-                                            "Username field is visible, entering username..." | Write-Verbose
-                                            $UserName = $Script:CurrentWebView2Session.Credential.UserName.Trim()
-                                            $usernameScript = "$setElementValueScript($(ConvertTo-JavaScriptLiteral $UserNameElementId), $(ConvertTo-JavaScriptLiteral $UserName))"
-                                            $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($usernameScript)
-                                            $Script:LoginSubState = "SettingUsername"
-                                        }
-                                        else {
-                                            # Field not visible, not username page - reset to check other scenarios
-                                            "Username field not visible, trying other scenarios..." | Write-Verbose
-                                            $Script:LoginSubState = $null
-                                            # Don't return - let other scenarios be checked
-                                        }
-                                    }
-                                    else {
-                                        # The visibility check could not run at all, so autofill is
-                                        # over for this sign-in. Say so instead of going quiet.
-                                        Switch-ToManualLogin -State "Scenario1/CheckingUsernameField" -MissingElementId $UserNameElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
-                                    }
-                                }
-                                return $false
-                            }
-                            "SettingUsername" {
-                                "Scenario 1: SettingUsername" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        "Username set, clicking submit..." | Write-Verbose
-                                        Start-Sleep -Milliseconds 200
-                                        $clickScript = "$clickElementScript($(ConvertTo-JavaScriptLiteral $SubmitButtonId))"
-                                        $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($clickScript)
-                                        $Script:LoginSubState = "ClickingSubmit"
-                                    }
-                                    else {
-                                        # The username could not be written into the field, so the
-                                        # user has to type it. Tell them, rather than stopping mute.
-                                        Switch-ToManualLogin -State "Scenario1/SettingUsername" -MissingElementId $UserNameElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
-                                    }
-                                }
-                                return $false
-                            }
-                            "ClickingSubmit" {
-                                "Scenario 1: ClickingSubmit" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    "Clicked submit, waiting for page change..." | Write-Verbose
-                                    # Reset state to detect next page
-                                    # Clicking counts as progress, so restart the stall clock. The
-                                    # username and password pages carry the same element IDs, so
-                                    # without this the clock would keep running across the step.
-                                    $Script:UnmatchedPageSince = $null
-                                    $Script:LoginState = "GettingIds"
-                                    $Script:LoginSubState = $null
-                                    $Script:IdAttributes = $null
-                                    $Script:LoginTask = $null
-                                    Start-Sleep -Milliseconds 500
-                                    return $true
-                                }
-                                return $false
-                            }
-                        }
-                    }
-
-                    # Scenario 2: Password entry page
-                    # Check if password field exists - we'll verify visibility in the sub-state
-                    if (  $PasswordElementId -in $Script:IdAttributes.id -and ($Script:IdAttributes | Where-Object { $_.id -eq $PasswordElementId }).outerHTML -notlike '*aria-hidden="true"*' -and $SubmitButtonId -in $Script:IdAttributes.id) {
-
-                        "Scenario 2: Password entry page" | Write-Verbose
-                        $Script:CurrentScenario = "PasswordEntry"
-                        "Scenario 2: PreviousScenario {0}" -f $Script:PreviousScenario | Write-Verbose
-                        # Sub-state machine for password entry
-                        switch ($Script:LoginSubState) {
-                            $null {
-                                # First check for error messages
-                                "Checking for error messages on page..." | Write-Verbose
-                                $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($checkForErrorScript)
-                                $Script:LoginSubState = "CheckingForError"
-                                return $false
-                            }
-                            "CheckingForError" {
-                                "Scenario 2: CheckingForError" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $errorMessage = ConvertFrom-JavaScriptResult $Script:LoginTask.Result
-                                        if (-not [string]::IsNullOrWhiteSpace($errorMessage)) {
-                                            "Login error detected: $errorMessage" | Write-Warning
-                                            "Please verify your credentials and try again. Automatic login aborted." | Write-Warning
-                                            $Script:LoginFailed = $true
-                                            $Script:LoginState = $null
-                                            $Script:LoginSubState = $null
-                                            $Script:IdAttributes = $null
-                                            $Script:LoginTask = $null
-                                            $Script:MicrosoftOnlineLogin = $false
-                                            return $false
-                                        }
-                                    }
-                                    # No error, proceed to check password field visibility
-                                    $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync("$isElementVisibleScript($(ConvertTo-JavaScriptLiteral $PasswordElementId))")
-                                    $Script:LoginSubState = "CheckingPasswordField"
-                                }
-                                return $false
-                            }
-                            "CheckingPasswordField" {
-                                "Scenario 2: CheckingPasswordField" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $isVisible = $Script:LoginTask.Result
-                                        "Password field visibility check result: $isVisible" | Write-Verbose
-                                        if ($isVisible -eq "true") {
-                                            "Matched Scenario 2: Password entry page" | Write-Verbose
-                                            "Password field is visible, entering password..." | Write-Verbose
-                                            $password = $Script:CurrentWebView2Session.Credential.GetNetworkCredential().Password
-                                            $passwordScript = "$setElementValueScript($(ConvertTo-JavaScriptLiteral $PasswordElementId), $(ConvertTo-JavaScriptLiteral $password))"
-                                            $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($passwordScript)
-                                            $Script:LoginSubState = "SettingPassword"
-                                        }
-                                        else {
-                                            # Field not visible, not password page - reset to check other scenarios
-                                            "Password field not visible, trying other scenarios..." | Write-Verbose
-                                            $Script:LoginSubState = $null
-                                            # Don't return - let other scenarios be checked
-                                        }
-                                    }
-                                    else {
-                                        Switch-ToManualLogin -State "Scenario2/CheckingPasswordField" -MissingElementId $PasswordElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
-                                    }
-                                }
-                                return $false
-                            }
-                            "SettingPassword" {
-                                "Scenario 2: SettingPassword" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        "Password set, clicking submit..." | Write-Verbose
-                                        Start-Sleep -Milliseconds 200
-                                        $clickScript = "$clickElementScript($(ConvertTo-JavaScriptLiteral $SubmitButtonId))"
-                                        $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($clickScript)
-                                        $Script:LoginSubState = "ClickingSubmit"
-                                    }
-                                    else {
-                                        Switch-ToManualLogin -State "Scenario2/SettingPassword" -MissingElementId $PasswordElementId -FoundElementId $Script:IdAttributes.id -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
-                                    }
-                                }
-                                return $false
-                            }
-                            "ClickingSubmit" {
-                                "Scenario 2: ClickingSubmit" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    "Clicked submit, waiting for page change..." | Write-Verbose
-                                    # Reset state to detect next page
-                                    $Script:UnmatchedPageSince = $null
-                                    $Script:LoginState = "GettingIds"
-                                    $Script:LoginSubState = $null
-                                    $Script:IdAttributes = $null
-                                    $Script:LoginTask = $null
-                                    return $true
-                                }
-                                return $false
-                            }
-                        }
-                    }
-
-                    # Scenario 3: "Stay signed in?" page - Click "No"
-                    if ($Script:IdAttributes.id -notcontains $UserNameElementId -and $Script:IdAttributes.id -notcontains $PasswordElementId -and $ButtonBackId -in $Script:IdAttributes.id -and $SubmitButtonId -in $Script:IdAttributes.id -and $Script:IdAttributes.id -notcontains $MfaElementId1 -and $Script:IdAttributes.id -notcontains $MfaElementId2) {
-
-                        "Scenario 3: 'Stay signed in?' page" | Write-Verbose
-                        $Script:CurrentScenario = "StaySignedIn"
-                        "Scenario 3: PreviousScenario {0}" -f $Script:PreviousScenario | Write-Verbose
-                        # Sub-state machine for "Stay signed in?" prompt
-                        switch ($Script:LoginSubState) {
-                            $null {
-                                # Start checking back button text
-                                "Detected 'Stay signed in?' page, checking button labels..." | Write-Verbose
-                                $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync("$getElementPropertyScript($(ConvertTo-JavaScriptLiteral $ButtonBackId), $(ConvertTo-JavaScriptLiteral 'textContent'))")
-                                $Script:LoginSubState = "CheckingBackButton"
-                                return $false
-                            }
-                            "CheckingBackButton" {
-                                "Scenario 3: CheckingBackButton" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $Script:BackButtonText = ConvertFrom-JavaScriptResult $Script:LoginTask.Result
-                                        # Now check submit button
-                                        $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync("$getElementPropertyScript($(ConvertTo-JavaScriptLiteral $SubmitButtonId), $(ConvertTo-JavaScriptLiteral 'textContent'))")
-                                        $Script:LoginSubState = "CheckingSubmitButton"
-                                    }
-                                    else {
-                                        $Script:LoginSubState = $null
-                                    }
-                                }
-                                return $false
-                            }
-                            "CheckingSubmitButton" {
-                                "Scenario 3: CheckingSubmitButton" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $submitText = ConvertFrom-JavaScriptResult $Script:LoginTask.Result
-                                        if ($Script:BackButtonText -like "*No*" -and $submitText -like "*Yes*") {
-                                            "Clicking 'No' to stay signed in prompt..." | Write-Verbose
-                                            $clickScript = "$clickElementScript($(ConvertTo-JavaScriptLiteral $ButtonBackId))"
-                                            $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($clickScript)
-                                            $Script:LoginSubState = "ClickingNo"
-                                        }
-                                        else {
-                                            # Buttons don't match expected text, reset
-                                            $Script:LoginSubState = $null
-                                            $Script:BackButtonText = $null
-                                        }
-                                    }
-                                    else {
-                                        $Script:LoginSubState = $null
-                                        $Script:BackButtonText = $null
-                                    }
-                                }
-                                return $false
-                            }
-                            "ClickingNo" {
-                                "Scenario 3: ClickingNo" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    "Clicked No, waiting for page change..." | Write-Verbose
-                                    # Reset state to detect next page
-                                    $Script:UnmatchedPageSince = $null
-                                    $Script:LoginState = "GettingIds"
-                                    $Script:LoginSubState = $null
-                                    $Script:IdAttributes = $null
-                                    $Script:LoginTask = $null
-                                    $Script:BackButtonText = $null
-                                    return $true
-                                }
-                                return $false
-                            }
-                        }
-                    }
-
-                    # Scenario 4: Select account by data-test-id
-                    if ($Script:IdAttributes.id -notcontains $UserNameElementId -and $Script:IdAttributes.id -notcontains $PasswordElementId -and $Script:IdAttributes.id -notcontains $ButtonBackId) {
-
-                        "Scenario 4: Account selection page" | Write-Verbose
-                        "Scenario 4: PreviousScenario {0}" -f $Script:PreviousScenario | Write-Verbose
-
-                        $Script:CurrentScenario = "AccountSelection"
-                        # Sub-state for account selection
-                        switch ($Script:LoginSubState) {
-                            $null {
-                                # Try to click account with matching data-test-id
-                                "Attempting to select account..." | Write-Verbose
-                                $UserName = $Script:CurrentWebView2Session.Credential.UserName.Trim()
-                                $clickAccountScript = "$getElementByDataTestIdScript($(ConvertTo-JavaScriptLiteral $UserName))"
-                                $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($clickAccountScript)
-                                $Script:LoginSubState = "ClickingAccount"
-                                $Script:AccountSelectionAttempted = $false
-                                return $false
-                            }
-                            "ClickingAccount" {
-                                "Scenario 4: ClickingAccount" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $result = $Script:LoginTask.Result
-                                        if ($result -eq "true") {
-                                            "Selected logged-in account" | Write-Verbose
-                                            # Reset state to detect next page
-                                            $Script:UnmatchedPageSince = $null
-                                            $Script:LoginState = "GettingIds"
-                                            $Script:LoginSubState = $null
-                                            $Script:IdAttributes = $null
-                                            $Script:LoginTask = $null
-                                            $Script:AccountSelectionAttempted = $false
-                                            return $true
-                                        }
-                                        else {
-                                            # Account not found - try "Use another account" if not already attempted
-                                            if (-not $Script:AccountSelectionAttempted) {
-                                                "Account not found in list, clicking 'Use another account'..." | Write-Verbose
-                                                $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($clickUseAnotherAccountScript)
-                                                $Script:LoginSubState = "ClickingUseAnotherAccount"
-                                                $Script:AccountSelectionAttempted = $true
-                                            }
-                                            else {
-                                                # Already tried, reset and wait
-                                                "Could not find 'Use another account' option" | Write-Verbose
-                                                $Script:LoginSubState = $null
-                                                $Script:AccountSelectionAttempted = $false
-                                            }
-                                        }
-                                    }
-                                    else {
-                                        # Task faulted, reset
-                                        $Script:LoginSubState = $null
-                                        $Script:AccountSelectionAttempted = $false
-                                    }
-                                }
-                                return $false
-                            }
-                            "ClickingUseAnotherAccount" {
-                                "Scenario 4: ClickingUseAnotherAccount" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $result = $Script:LoginTask.Result
-                                        if ($result -eq "true") {
-                                            "Clicked 'Use another account', going to username entry..." | Write-Verbose
-                                            # Reset state to detect username page
-                                            $Script:UnmatchedPageSince = $null
-                                            $Script:LoginState = "GettingIds"
-                                            $Script:LoginSubState = $null
-                                            $Script:IdAttributes = $null
-                                            $Script:LoginTask = $null
-                                            $Script:AccountSelectionAttempted = $false
-                                            return $true
-                                        }
-                                        else {
-                                            "'Use another account' option not found" | Write-Verbose
-                                        }
-                                    }
-                                    # Failed or not found, reset
-                                    $Script:LoginSubState = $null
-                                    $Script:AccountSelectionAttempted = $false
-                                }
-                                return $false
-                            }
-                        }
-                    }
-
-                    # Scenario 5: MFA request
-                    if (-not $Script:MfaRequestDisplayed -and $Script:IdAttributes.id -notcontains $UserNameElementId -and $Script:IdAttributes.id -notcontains $PasswordElementId -and (  $MfaElementId1 -in $Script:IdAttributes.id -or $MfaElementId2 -in $Script:IdAttributes.id) -and $Script:IdAttributes.id -notcontains $MfaRetryId1 -and $Script:IdAttributes.id -notcontains $MfaRetryId2) {
-
-                        "Scenario 5: MFA request page" | Write-Verbose
-                        "Scenario 5: PreviousScenario {0}" -f $Script:PreviousScenario | Write-Verbose
-
-                        $Script:CurrentScenario = "MfaRequest"
-                        # Sub-state for MFA code retrieval
-                        switch ($Script:LoginSubState) {
-                            $null {
-                                # Get MFA code
-                                "Detected MFA page, retrieving code..." | Write-Verbose
-                                $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync("$getMfaElementPropertyScript")
-                                $Script:LoginSubState = "GettingMfaCode"
-                                return $false
-                            }
-                            "GettingMfaCode" {
-                                "Scenario 5: GettingMfaCode" | Write-Verbose
-                                if ($Script:LoginTask.IsCompleted) {
-                                    if (-not $Script:LoginTask.IsFaulted) {
-                                        $MfaText = $Script:LoginTask.Result | ConvertFrom-Json | ConvertFrom-Json
-
-                                        if (-not [string]::IsNullOrWhiteSpace($MfaText)) {
-                                            $Message = "`nWaiting for you to approve this sign-in request."
-
-                                            # Check if PhoneLink is active
-                                            $PhoneLinkActive = $false
-                                            if ((Get-Process | Where-Object { $_.ProcessName -eq "PhoneExperienceHost" } | Measure-Object).Count -gt 0) {
-                                                $PhoneLinkActive = $true
-                                            }
-
-                                            if ($PhoneLinkActive) {
-                                                if ($null -ne $MfaText) {
-                                                    $Message = "{0}: {1} (This value is now in your clipboard so you can paste it into your Authenticator app using PhoneLink)." -f $Message.TrimEnd("."), $MfaText
-                                                    $MfaText | Set-Clipboard
-                                                }
-                                                else {
-                                                    $Message = "Failed to set clipboard with message: {0}." -f $Message.TrimEnd(".")
-                                                }
-                                            }
-                                            else {
-                                                $Message = "{0} {1}" -f $Message.TrimEnd("."), $MfaText
-                                            }
-
-                                            $Message | Write-Host -ForegroundColor Yellow
-                                            $Script:MfaRequestDisplayed = $true
-                                            $Script:LoginSubState = $null
-                                            return $true
-                                        }
-                                    }
-                                    # Failed or empty MFA code, reset
-                                    $Script:LoginSubState = $null
-                                }
-                                return $false
-                            }
-                        }
-                    }
-
-                    # Scenario 6: MFA retry
-                    if ($Script:MfaRequestDisplayed -and $Script:IdAttributes.id -notcontains $UserNameElementId -and $Script:IdAttributes.id -notcontains $PasswordElementId -and $Script:IdAttributes.id -notin $MfaElementIds -and (  $MfaRetryId1 -in $Script:IdAttributes.id -or $MfaRetryId2 -in $Script:IdAttributes.id)) {
-
-                        "Scenario 6: MFA retry page" | Write-Verbose
-                        "Scenario 6: PreviousScenario {0}" -f $Script:PreviousScenario | Write-Verbose
-
-                        $Script:CurrentScenario = "MfaRetry"
+                    "Retry" {
                         "`nMFA failed! Please retry!" | Write-Warning
                         $Script:MfaRequestDisplayed = $false
-                        # Reset state to detect next page
+                        $Script:MfaWaitLastReported = $null
                         $Script:UnmatchedPageSince = $null
-                        $Script:LoginState = "GettingIds"
-                        $Script:IdAttributes = $null
+                        $Script:LoginState = "ReadingPage"
+                        $Script:PageState = $null
                         return $true
                     }
 
-                    # No scenario matched. Re-read the page on the next tick rather than
-                    # re-evaluating attributes that are already stale, so that a page which is only
-                    # mid-navigation is picked up as soon as it settles. The stall check above ends
-                    # this loop when the same page keeps not matching.
-                    # Nothing on this page is being acted on, so the scenario the previous page was
-                    # in no longer describes anything - keep it for the verbose trail, but do not
-                    # let the stall diagnostic report it as the current state.
-                    $Script:PreviousScenario = $Script:CurrentScenario
-                    $Script:CurrentScenario = $null
-                    $Script:LoginState = "GettingIds"
-                    $Script:LoginTask = $null
-                    $Script:IdAttributes = $null
-                    return $false
+                    "ReadNumber" {
+                        $Shown = Show-EntraApprovalNumber -Number $Decision.Value
 
+                        # Read the page again on the next tick. Nothing is clicked here - the user
+                        # approves on their phone - so this screen is left by the page changing, and
+                        # deciding from the snapshot already in hand would never see that happen.
+                        $Script:LoginState = "ReadingPage"
+                        $Script:PageState = $null
+                        return $Shown
+                    }
+
+                    "SetValueAndClick" {
+                        $Value = $Decision.Value
+                        if ($Decision.ValueSource -eq "Password") {
+                            # Read here and nowhere else, so the secret never travels in the decision.
+                            $Value = $NetworkCredential.Password
+                        }
+
+                        $SetScript = "$SetElementValueScript($(ConvertTo-JavaScriptLiteral $Decision.ElementId), $(ConvertTo-JavaScriptLiteral $Value))"
+                        $Script:LoginTask = $Script:WebView2.CoreWebView2.ExecuteScriptAsync($SetScript)
+                        $Script:PendingSubmitId = $Decision.SubmitId
+                        $Script:LoginState = "Acting"
+                        return $false
+                    }
+
+                    "Click" {
+                        $Script:LoginTask = $Script:WebView2.CoreWebView2.ExecuteScriptAsync("$ClickElementScript($(ConvertTo-JavaScriptLiteral $Decision.ElementId))")
+                        $Script:PendingSubmitId = $null
+                        $Script:LoginState = "Acting"
+                        return $false
+                    }
+
+                    "ClickAccountTile" {
+                        $Script:LoginTask = $Script:WebView2.CoreWebView2.ExecuteScriptAsync("$ClickAccountTileScript($(ConvertTo-JavaScriptLiteral $Decision.Value))")
+                        $Script:PendingSubmitId = $null
+                        $Script:LoginState = "Acting"
+                        return $false
+                    }
+
+                    "ClickUseAnotherAccount" {
+                        $Script:LoginTask = $Script:WebView2.CoreWebView2.ExecuteScriptAsync($ClickUseAnotherAccountScript)
+                        $Script:PendingSubmitId = $null
+                        $Script:LoginState = "Acting"
+                        return $false
+                    }
+
+                    "ClickProofOption" {
+                        $Script:LoginTask = $Script:WebView2.CoreWebView2.ExecuteScriptAsync("$ClickProofOptionScript($(ConvertTo-JavaScriptLiteral $Script:EntraSignInElementId.ProofsContainer), $($Decision.Index))")
+                        $Script:PendingSubmitId = $null
+                        $Script:LoginState = "Acting"
+                        return $false
+                    }
+
+                    default {
+                        # 'Wait'. The stall clock above decides when waiting has gone on long enough;
+                        # until then, read the page again on the next tick so a page that is only
+                        # mid-navigation is picked up as soon as it settles.
+                        if (-not [string]::IsNullOrWhiteSpace($Decision.Reason)) {
+                            "Invoke-WebView2MicrosoftLogin - Waiting: {0}" -f $Decision.Reason | Write-Verbose
+                        }
+
+                        $Script:LoginState = "ReadingPage"
+                        $Script:PageState = $null
+                        return $false
+                    }
                 }
             }
+
+            "Acting" {
+                if ($null -eq $Script:LoginTask) {
+                    $Script:LoginState = "ReadingPage"
+                    return $false
+                }
+
+                if (-not $Script:LoginTask.IsCompleted) {
+                    return $false
+                }
+
+                if ($Script:LoginTask.IsFaulted) {
+                    # The page could not be driven at all, so autofill is over for this sign-in. Say
+                    # so rather than going quiet.
+                    $FoundElementId = @()
+                    if ($null -ne $Script:PageState) {
+                        $IdProperty = $Script:PageState.PSObject.Properties["ids"]
+                        if ($null -ne $IdProperty) {
+                            $FoundElementId = @($IdProperty.Value)
+                        }
+                    }
+
+                    Switch-ToManualLogin -State ("Acting/{0}" -f $Script:CurrentScenario) -FoundElementId $FoundElementId -Url $Script:WebView2.Source.AbsoluteUri -Reason $Script:LoginTask.Exception.Message | Out-Null
+                    $Script:LoginTask = $null
+                    $Script:PendingSubmitId = $null
+                    return $false
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($Script:PendingSubmitId)) {
+                    $SubmitId = $Script:PendingSubmitId
+                    $Script:PendingSubmitId = $null
+                    $Script:LoginTask = $Script:WebView2.CoreWebView2.ExecuteScriptAsync("$ClickElementScript($(ConvertTo-JavaScriptLiteral $SubmitId))")
+                    return $false
+                }
+
+                # Something was clicked, which counts as progress even when the next page happens to
+                # carry the same element ids - the username and the password screen do.
+                $Script:UnmatchedPageSince = $null
+                $Script:LoginTask = $null
+                $Script:PageState = $null
+                $Script:LoginState = "ReadingPage"
+                return $true
+            }
         }
-        else {
 
-            # TODO: Add support for grabbing the username and use it later at re-authentication
-            # # Initialize login state if needed
-            # if ($null -eq $Script:LoginState) {
-            #     $Script:LoginState = "GettingNames"
-            #     $Script:LoginTask = $null
-            #     $Script:LoginSubState = $null
-            # }
-
-            # # When not, check if we can grab the username and password
-            # switch ($Script:LoginState) {
-            #     "GettingNames" {
-            #         if ($null -eq $Script:LoginTask) {
-            #             "Starting to get element names..." | Write-Verbose
-            #             $Script:LoginTask = $WebView2.CoreWebView2.ExecuteScriptAsync($getAllNamesScript)
-            #         }
-            #         else {
-            #             if ($Script:LoginTask.IsCompleted) {
-
-            #                 if (-not $Script:LoginTask.IsFaulted) {
-            #                     $NamesJson = $Script:LoginTask.Result
-
-            #                     $NamesJson|Write-Verbose
-            #                     $Script:NameObjects = $NamesJson | ConvertFrom-Json | ConvertFrom-Json
-            #                     if ($null -ne $Script:NameObjects) {
-            #                         "Retrieved element names, switching to processing state..." | Write-Verbose
-            #                         $Script:LoginState = "Processing"
-            #                         $Script:LoginTask = $null
-            #                         return $true
-            #                     }
-            #                     else {
-            #                         "Failed to parse element names JSON." | Write-Verbose
-            #                         # Failed to parse, reset task to try again
-            #                         $Script:LoginTask = $null
-            #                     }
-            #                 }
-            #                 else {
-            #                     "Failed to get element names: $($Script:LoginTask.Exception.Message)" | Write-Verbose
-            #                     # Task faulted, reset to try again
-            #                     $Script:LoginTask = $null
-            #                 }
-            #             }
-            #         }
-            #         return $false
-            #     }
-            # }
-        }
-        $Script:PreviousScenario = $Script:CurrentScenario
-
-        # Shouldn't reach here, but return false just in case
         return $false
     }
     catch {
         [Console]::WriteLine("Error in Invoke-WebView2MicrosoftLogin: $_")
         # Reset state on error
-        $Script:LoginState = "GettingIds"
+        $Script:LoginState = "ReadingPage"
         $Script:LoginTask = $null
-        $Script:IdAttributes = $null
-        $Script:LoginSubState = $null
-        $Script:BackButtonText = $null
+        $Script:PageState = $null
+        $Script:PendingSubmitId = $null
         return $false
     }
 }

--- a/OmadaWeb.PS/Private/Reset-LoginAutomationState.ps1
+++ b/OmadaWeb.PS/Private/Reset-LoginAutomationState.ps1
@@ -22,6 +22,13 @@ function Reset-LoginAutomationState {
     $Script:UnmatchedPageSignature = $null
     $Script:UnmatchedPageSince = $null
 
+    # Both are "report this once, not once per 150 ms tick" guards, and both are about the window
+    # that is starting rather than the one that ended: a second attempt has to be allowed to say
+    # again that the preferred verification method is not available, and to start counting its own
+    # wait for an approval from zero.
+    $Script:PreferredMfaMethodWarningIssued = $false
+    $Script:MfaWaitLastReported = $null
+
     # Scrape state of Get-WebView2LogonPageError. It belongs to a browser window - a pending script
     # task cannot outlive the CoreWebView2 that was asked to run it - so it is cleared here with the
     # rest of the per-window state. $Script:LoginAbortReason deliberately is not: a refused sign-in

--- a/OmadaWeb.PS/Private/Reset-LoginAutomationState.ps1
+++ b/OmadaWeb.PS/Private/Reset-LoginAutomationState.ps1
@@ -22,12 +22,19 @@ function Reset-LoginAutomationState {
     $Script:UnmatchedPageSignature = $null
     $Script:UnmatchedPageSince = $null
 
-    # Both are "report this once, not once per 150 ms tick" guards, and both are about the window
-    # that is starting rather than the one that ended: a second attempt has to be allowed to say
-    # again that the preferred verification method is not available, and to start counting its own
-    # wait for an approval from zero.
+    # All three are "report this once, not once per 150 ms tick" guards, and all three are about the
+    # window that is starting rather than the one that ended: a second attempt has to be allowed to
+    # say again that the preferred verification method is not available, to start counting its own
+    # wait for an approval from zero, and to show its own approval number.
+    #
+    # That last one matters most. The number belongs to a single sign-in request, and a new window
+    # means a new request with a new number - so carrying the flag over would suppress the only
+    # thing the user needs in order to approve it, leaving them looking at a window that is waiting
+    # for something it never told them about. It would also let a resend link on the new page read
+    # as a failed approval that never happened.
     $Script:PreferredMfaMethodWarningIssued = $false
     $Script:MfaWaitLastReported = $null
+    $Script:MfaRequestDisplayed = $false
 
     # Scrape state of Get-WebView2LogonPageError. It belongs to a browser window - a pending script
     # task cannot outlive the CoreWebView2 that was asked to run it - so it is cleared here with the

--- a/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
+++ b/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
@@ -169,7 +169,13 @@ function Resolve-EntraSignInScreen {
 
     # 3. 'Stay signed in?'. Its checkbox is on no other screen, and the back button is its decline
     #    action - which is what the two localized button labels used to be compared for.
-    if ($Id.KeepMeSignedIn -in $Present -and $Id.Back -in $Present) {
+    #
+    #    The checkbox is asked for by presence and the button by visibility, which is not an
+    #    oversight either way. The checkbox is the marker - it is what makes this screen unmistakable
+    #    - but a checkbox is routinely styled by hiding the real input behind a label, so requiring
+    #    it to be visible would risk not recognizing the screen at all. The back button is the thing
+    #    that gets clicked, and clicking one that is not actionable would do nothing at all.
+    if ($Id.KeepMeSignedIn -in $Present -and $Id.Back -in $Visible) {
         $Decision.Screen = "StaySignedIn"
         $Decision.Action = "Click"
         $Decision.ElementId = $Id.Back

--- a/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
+++ b/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
@@ -42,6 +42,13 @@ function Resolve-EntraSignInScreen {
         type comes from the credential's password, and the caller - which holds the credential
         anyway - reads it.
 
+        Every rule asks whether an element is *visible*, not whether it is in the markup. The sign-in
+        app leaves elements behind after hiding them - the username field is still there on the
+        password screen - so presence says nothing about which screen this is, and acting on a hidden
+        element does nothing while reporting success, which restarts the stall clock and is therefore
+        indistinguishable from working. The one exception is KmsiCheckboxField, and the reason is
+        given where it is used.
+
     .PARAMETER PageState
         The deserialized snapshot of the page, as produced by the script from
         Get-EntraSignInProbeScript.
@@ -158,8 +165,8 @@ function Resolve-EntraSignInScreen {
 
     # 2. A failed approval offers to send a new one. Recognized before the approval screen itself,
     #    because a resend link and an approval number can be on the page at the same time.
-    $HasResendLink = ($Id.MfaResendTotp -in $Present) -or ($Id.MfaResendDs -in $Present)
-    $HasApprovalNumber = ($Id.PasswordlessNumber -in $Present) -or ($Id.NumberMatch -in $Present)
+    $HasResendLink = ($Id.MfaResendTotp -in $Visible) -or ($Id.MfaResendDs -in $Visible)
+    $HasApprovalNumber = ($Id.PasswordlessNumber -in $Visible) -or ($Id.NumberMatch -in $Visible)
     if ($MfaRequestDisplayed -and $HasResendLink -and -not $HasApprovalNumber) {
         $Decision.Screen = "MfaRetry"
         $Decision.Action = "Retry"
@@ -220,7 +227,7 @@ function Resolve-EntraSignInScreen {
     #    match in another; both mean the same thing to the user, so both are read.
     if ($HasApprovalNumber) {
         $NumberElementId = $Id.PasswordlessNumber
-        if ($Id.PasswordlessNumber -notin $Present) {
+        if ($Id.PasswordlessNumber -notin $Visible) {
             $NumberElementId = $Id.NumberMatch
         }
 
@@ -250,7 +257,7 @@ function Resolve-EntraSignInScreen {
         $Proof = @($Value["proofs"])
     }
 
-    $HasProofScreen = ($Id.ProofsContainer -in $Present) -or ($Id.MethodPicker -in $Present) -or $Proof.Count -gt 0
+    $HasProofScreen = ($Id.ProofsContainer -in $Visible) -or ($Id.MethodPicker -in $Visible) -or $Proof.Count -gt 0
     if ($HasProofScreen) {
         $Decision.Screen = "MethodPicker"
 
@@ -317,7 +324,7 @@ function Resolve-EntraSignInScreen {
     }
 
     # 9. The username screen, the most generic of the sign-in screens and therefore the last one.
-    if ($Id.UserName -in $Visible -and $Id.Submit -in $Present) {
+    if ($Id.UserName -in $Visible -and $Id.Submit -in $Visible) {
         $Decision.Screen = "UsernameEntry"
         $Decision.Action = "SetValueAndClick"
         $Decision.ElementId = $Id.UserName

--- a/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
+++ b/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
@@ -194,6 +194,16 @@ function Resolve-EntraSignInScreen {
     if ($Id.Password -in $Visible) {
         if ($HasPassword) {
             $Decision.Screen = "PasswordEntry"
+
+            # Filling the field and submitting it are two steps, so both have to be possible before
+            # the first one is taken. A page still rendering its button would otherwise have the
+            # password typed into it once per cycle with nothing to submit it - and the sign-in would
+            # wait out the whole stall timeout rather than the tick or two the page actually needed.
+            if ($Id.Submit -notin $Visible) {
+                $Decision.Reason = "The password field is ready but the button that submits it is not, so the page is given a moment to finish."
+                return $Decision
+            }
+
             $Decision.Action = "SetValueAndClick"
             $Decision.ElementId = $Id.Password
             $Decision.SubmitId = $Id.Submit

--- a/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
+++ b/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
@@ -1,0 +1,331 @@
+function Resolve-EntraSignInScreen {
+    <#
+    .SYNOPSIS
+        Decides which Entra ID sign-in screen the browser is on, and what to do about it.
+
+    .DESCRIPTION
+        This is the whole judgement of the Microsoft sign-in automation, kept apart from the browser
+        so it can be tested without one. It is given a snapshot of the page - the JSON document
+        Get-EntraSignInProbeScript's JavaScript produces - and returns one decision:
+        which screen this is, and the single action that moves the sign-in forward from it.
+
+        Nothing in the snapshot is text a user reads. The Entra sign-in app is served fully
+        localized, and the previous implementation recognized the 'Stay signed in?' screen by
+        comparing its two buttons to the words 'Yes' and 'No', which is why credential autofill did
+        nothing at all on a tenant served in any other language, and did it silently. Every rule
+        below keys on something the server decides rather than something a translator does: the
+        stable element ids of the sign-in app, the numeric error code in the page's own $Config
+        object, the authMethodId values in its proofs array, and - only as a last resort - the shape
+        of the form itself.
+
+        The order of the rules is not arbitrary, because several screens share element ids:
+
+          1. An error code outranks everything. A page can carry a perfectly ordinary password field
+             and still be reporting that the previous password was wrong, and acting on the field
+             before reading the code is exactly how an account gets locked out.
+          2. 'Stay signed in?' is recognized by its checkbox, which no other screen carries. It has
+             to be tested before the submit button it shares with the username and password screens.
+          3. The password screen, which for a credential that has no password is not a password
+             screen at all but a prompt to sign in another way.
+          4. The approval number - passwordless sign-in and Authenticator number match both show one,
+             in two different elements, and both are read here. Only the first was read before.
+          5. The remaining screens, ending with the username screen, which is the most generic.
+
+        Anything not recognized returns the action 'Wait'. That is deliberate rather than lazy: a
+        page caught mid-navigation is indistinguishable from a page this module has never seen, so
+        the decision of when an unrecognized page has stopped being a temporary one belongs to
+        Test-LoginAutomationStalled, and the explanation this function puts in Reason is what
+        Switch-ToManualLogin then reports.
+
+        The password is never part of the returned decision. A verdict that carried it would be one
+        Write-Verbose call away from a support log; instead the decision says only that the value to
+        type comes from the credential's password, and the caller - which holds the credential
+        anyway - reads it.
+
+    .PARAMETER PageState
+        The deserialized snapshot of the page, as produced by the script from
+        Get-EntraSignInProbeScript.
+
+    .PARAMETER UserName
+        The user name from the credential, used to fill the username field and to pick the matching
+        tile on the 'Pick an account' screen.
+
+    .PARAMETER HasPassword
+        Whether the credential carries a password. A credential without one is a passwordless
+        account, and the password screen is then answered by switching to another sign-in method
+        rather than by submitting an empty string.
+
+    .PARAMETER PreferredMfaMethod
+        The authMethodId the caller asked for through -PreferredMfaMethod, when there was one.
+
+    .PARAMETER MfaRequestDisplayed
+        Whether an approval number has already been shown to the user for this sign-in. It is what
+        tells a resend link that follows a failed approval from one that is merely offered next to a
+        request still waiting.
+
+    .OUTPUTS
+        PSCustomObject with the members Screen, Action, ElementId, SubmitId, Index, Value,
+        ValueSource, Code, Reason and IsTerminal.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [AllowNull()]
+        $PageState,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$UserName,
+
+        [switch]$HasPassword,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$PreferredMfaMethod,
+
+        [switch]$MfaRequestDisplayed
+    )
+
+    $Id = $Script:EntraSignInElementId
+
+    $Decision = [pscustomobject]@{
+        Screen      = "Unknown"
+        Action      = "Wait"
+        ElementId   = $null
+        SubmitId    = $null
+        Index       = -1
+        Value       = $null
+        ValueSource = $null
+        Code        = $null
+        Reason      = $null
+        IsTerminal  = $false
+    }
+
+    if ($null -eq $PageState) {
+        $Decision.Reason = "The sign-in page could not be read."
+        return $Decision
+    }
+
+    # A snapshot from an older or a partly failed read may not carry every member, and Set-StrictMode
+    # turns a plain property access on a missing member into a terminating error. Reading the whole
+    # snapshot once, through the property bag, keeps a missing member a missing value - which is what
+    # the rules below are written to handle.
+    $Value = @{}
+    foreach ($Property in $PageState.PSObject.Properties) {
+        $Value[$Property.Name] = $Property.Value
+    }
+
+    $Present = @()
+    if ($null -ne $Value["ids"]) {
+        $Present = @($Value["ids"] | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    $Visible = @()
+    if ($null -ne $Value["visibleIds"]) {
+        $Visible = @($Value["visibleIds"] | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    # 1. Whatever else the page shows, a failure reported by the server decides first.
+    $ReportedCode = $null
+    if (-not [string]::IsNullOrWhiteSpace([string]$Value["errorCode"])) {
+        $ReportedCode = [string]$Value["errorCode"]
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace([string]$Value["errorCodeText"])) {
+        $ReportedCode = [string]$Value["errorCodeText"]
+    }
+
+    $ErrorVerdict = Get-EntraErrorVerdict -ErrorCode $ReportedCode
+    if ($ErrorVerdict.IsError) {
+        $Decision.Screen = "SignInError"
+        $Decision.Code = $ErrorVerdict.Code
+        $Decision.Reason = $ErrorVerdict.Reason
+        $Decision.IsTerminal = $ErrorVerdict.IsTerminal
+        $Decision.Action = "Wait"
+        if ($ErrorVerdict.Action -eq "Stop") {
+            $Decision.Action = "Stop"
+        }
+
+        return $Decision
+    }
+
+    # 2. A failed approval offers to send a new one. Recognized before the approval screen itself,
+    #    because a resend link and an approval number can be on the page at the same time.
+    $HasResendLink = ($Id.MfaResendTotp -in $Present) -or ($Id.MfaResendDs -in $Present)
+    $HasApprovalNumber = ($Id.PasswordlessNumber -in $Present) -or ($Id.NumberMatch -in $Present)
+    if ($MfaRequestDisplayed -and $HasResendLink -and -not $HasApprovalNumber) {
+        $Decision.Screen = "MfaRetry"
+        $Decision.Action = "Retry"
+        $Decision.Reason = "The sign-in request was not approved, so Entra ID is offering to send a new one."
+        return $Decision
+    }
+
+    # 3. 'Stay signed in?'. Its checkbox is on no other screen, and the back button is its decline
+    #    action - which is what the two localized button labels used to be compared for.
+    if ($Id.KeepMeSignedIn -in $Present -and $Id.Back -in $Present) {
+        $Decision.Screen = "StaySignedIn"
+        $Decision.Action = "Click"
+        $Decision.ElementId = $Id.Back
+        $Decision.Reason = "Declining to stay signed in."
+        return $Decision
+    }
+
+    # 4. The password screen - or, for a passwordless credential, the screen to leave.
+    if ($Id.Password -in $Visible) {
+        if ($HasPassword) {
+            $Decision.Screen = "PasswordEntry"
+            $Decision.Action = "SetValueAndClick"
+            $Decision.ElementId = $Id.Password
+            $Decision.SubmitId = $Id.Submit
+            $Decision.ValueSource = "Password"
+            return $Decision
+        }
+
+        # The credential names an account but carries no password, so this account signs in another
+        # way. Submitting an empty password would spend one of the attempts before smart lockout on
+        # a value that cannot be right.
+        foreach ($SwitchId in @($Id.SwitchToCredPicker, $Id.SignInAnotherWay)) {
+            if ($SwitchId -in $Present) {
+                $Decision.Screen = "SwitchToPasswordless"
+                $Decision.Action = "Click"
+                $Decision.ElementId = $SwitchId
+                $Decision.Reason = "The credential has no password, so another sign-in method is chosen instead of submitting an empty one."
+                return $Decision
+            }
+        }
+
+        $Decision.Screen = "PasswordRequired"
+        $Decision.Action = "Wait"
+        $Decision.Reason = "The credential has no password and this page offers no way to sign in without one. An empty password is deliberately not submitted."
+        return $Decision
+    }
+
+    # 5. The approval number. Passwordless sign-in shows it in one element and Authenticator number
+    #    match in another; both mean the same thing to the user, so both are read.
+    if ($HasApprovalNumber) {
+        $NumberElementId = $Id.PasswordlessNumber
+        if ($Id.PasswordlessNumber -notin $Present) {
+            $NumberElementId = $Id.NumberMatch
+        }
+
+        $Decision.Screen = "ApprovalNumber"
+        $Decision.Action = "ReadNumber"
+        $Decision.ElementId = $NumberElementId
+        if (-not [string]::IsNullOrWhiteSpace([string]$Value["displaySign"])) {
+            $Decision.Value = [string]$Value["displaySign"]
+        }
+
+        return $Decision
+    }
+
+    # 6. A one-time code has to be read off a device and typed, so there is nothing to automate -
+    #    but saying so beats a window that looks frozen.
+    if ($Id.OneTimeCode -in $Visible) {
+        $Decision.Screen = "OneTimeCode"
+        $Decision.Action = "Wait"
+        $Decision.Reason = "Entra ID is asking for a one-time code, which has to be entered by hand."
+        return $Decision
+    }
+
+    # 7. 'Choose a way to sign in'. The proofs array names the offered methods; the container holds
+    #    one clickable option per entry, in the same order.
+    $Proof = @()
+    if ($null -ne $Value["proofs"]) {
+        $Proof = @($Value["proofs"])
+    }
+
+    $HasProofScreen = ($Id.ProofsContainer -in $Present) -or ($Id.MethodPicker -in $Present) -or $Proof.Count -gt 0
+    if ($HasProofScreen) {
+        $Decision.Screen = "MethodPicker"
+
+        $OptionCount = 0
+        if ($null -ne $Value["proofOptionCount"]) {
+            $OptionCount = [int]$Value["proofOptionCount"]
+        }
+
+        $Chosen = Select-EntraMfaMethod -Proof $Proof -PreferredMethod $PreferredMfaMethod
+        if ($null -eq $Chosen) {
+            $Decision.Reason = "Entra ID is asking which verification method to use, but the page did not say which methods are offered."
+            return $Decision
+        }
+
+        # The option that gets clicked is identified only by its position, so a page whose list of
+        # options no longer lines up with its list of methods is a page to leave alone.
+        if ($OptionCount -ne $Proof.Count -or $Chosen.Index -ge $OptionCount) {
+            $Decision.Reason = "Entra ID offered {0} verification methods but {1} options to click, so the method cannot be selected safely." -f $Proof.Count, $OptionCount
+            return $Decision
+        }
+
+        $Decision.Action = "ClickProofOption"
+        $Decision.Index = $Chosen.Index
+        $Decision.Value = $Chosen.AuthMethodId
+        $Decision.Reason = "Selecting verification method '{0}'." -f $Chosen.AuthMethodId
+        return $Decision
+    }
+
+    # 8. 'Pick an account'. Tested before the username screen, which that screen does not show.
+    $Tile = @()
+    if ($null -ne $Value["accountTiles"]) {
+        $Tile = @($Value["accountTiles"])
+    }
+
+    $HasOtherTile = $false
+    if ($null -ne $Value["hasOtherTile"]) {
+        $HasOtherTile = [bool]$Value["hasOtherTile"]
+    }
+
+    if (($Tile.Count -gt 0 -or $HasOtherTile) -and $Id.UserName -notin $Visible) {
+        $Decision.Screen = "AccountPicker"
+
+        $WantedUserName = ""
+        if (-not [string]::IsNullOrWhiteSpace($UserName)) {
+            $WantedUserName = $UserName.Trim()
+        }
+
+        $Match = @($Tile | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_.testId) -and [string]$_.testId -eq $WantedUserName })
+        if ($Match.Count -gt 0) {
+            $Decision.Action = "ClickAccountTile"
+            $Decision.Value = [string]$Match[0].testId
+            $Decision.Reason = "Selecting the tile of the account the credential names."
+            return $Decision
+        }
+
+        if ($HasOtherTile) {
+            $Decision.Action = "ClickUseAnotherAccount"
+            $Decision.Reason = "The account the credential names is not among the tiles, so another account is entered instead."
+            return $Decision
+        }
+
+        $Decision.Reason = "Entra ID is asking which account to use, but neither a matching tile nor the option to use another account is on the page."
+        return $Decision
+    }
+
+    # 9. The username screen, the most generic of the sign-in screens and therefore the last one.
+    if ($Id.UserName -in $Visible -and $Id.Submit -in $Present) {
+        $Decision.Screen = "UsernameEntry"
+        $Decision.Action = "SetValueAndClick"
+        $Decision.ElementId = $Id.UserName
+        $Decision.SubmitId = $Id.Submit
+        $Decision.ValueSource = "UserName"
+        $Decision.Value = $UserName
+        return $Decision
+    }
+
+    # 10. Nothing was recognized by id. The shape of the form still says which screen this is, which
+    #     turns "no scenario matched" into a diagnostic naming the element that has been renamed -
+    #     the single most useful thing to report when Microsoft changes the sign-in app.
+    if ($Value["hasVisiblePasswordInput"]) {
+        $Decision.Screen = "UnrecognizedPasswordScreen"
+        $Decision.Reason = "This is a password screen - it has a visible password field - but the field is not the one this module knows as '{0}'." -f $Id.Password
+        return $Decision
+    }
+
+    if ($Value["hasVisibleEmailInput"]) {
+        $Decision.Screen = "UnrecognizedUserNameScreen"
+        $Decision.Reason = "This is an account screen - it has a visible e-mail field - but the field is not the one this module knows as '{0}'." -f $Id.UserName
+        return $Decision
+    }
+
+    $Decision.Reason = "The page carries none of the elements this module recognizes."
+    return $Decision
+}

--- a/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
+++ b/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
@@ -141,9 +141,16 @@ function Resolve-EntraSignInScreen {
         $Decision.Code = $ErrorVerdict.Code
         $Decision.Reason = $ErrorVerdict.Reason
         $Decision.IsTerminal = $ErrorVerdict.IsTerminal
+
+        # The verdict's own answer is carried through rather than flattened into "wait and see".
+        # Waiting is the right response to a page this module does not recognize, because it might
+        # only be mid-navigation - but a screen that has named its own error is not that page. It
+        # will not turn into something drivable, so making the user watch a still window for the
+        # length of the stall timeout before being told what happened is a minute spent saying
+        # nothing. 'Manual' hands over at once, with the code in the message.
         $Decision.Action = "Wait"
-        if ($ErrorVerdict.Action -eq "Stop") {
-            $Decision.Action = "Stop"
+        if ($ErrorVerdict.Action -eq "Stop" -or $ErrorVerdict.Action -eq "Manual") {
+            $Decision.Action = $ErrorVerdict.Action
         }
 
         return $Decision

--- a/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
+++ b/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
@@ -197,8 +197,11 @@ function Resolve-EntraSignInScreen {
         # The credential names an account but carries no password, so this account signs in another
         # way. Submitting an empty password would spend one of the attempts before smart lockout on
         # a value that cannot be right.
+        # Visible, not merely present: this link is what gets clicked, and Entra keeps elements in
+        # the markup after hiding them. Clicking a hidden one does nothing while reporting success,
+        # which is the shape of every silent stall on this screen.
         foreach ($SwitchId in @($Id.SwitchToCredPicker, $Id.SignInAnotherWay)) {
-            if ($SwitchId -in $Present) {
+            if ($SwitchId -in $Visible) {
                 $Decision.Screen = "SwitchToPasswordless"
                 $Decision.Action = "Click"
                 $Decision.ElementId = $SwitchId

--- a/OmadaWeb.PS/Private/Select-EntraMfaMethod.ps1
+++ b/OmadaWeb.PS/Private/Select-EntraMfaMethod.ps1
@@ -74,12 +74,11 @@ function Select-EntraMfaMethod {
             $AuthMethodId = [string]$Offered[$Index].authMethodId
         }
 
+        # A hashtable lookup rather than a scan of its keys. PowerShell hashtables match keys
+        # case-insensitively, which is the same comparison the scan did.
         $MethodRank = 999
-        foreach ($Known in $Rank.Keys) {
-            if ($AuthMethodId -eq $Known) {
-                $MethodRank = $Rank[$Known]
-                break
-            }
+        if ($Rank.ContainsKey($AuthMethodId)) {
+            $MethodRank = $Rank[$AuthMethodId]
         }
 
         $IsDefault = $false

--- a/OmadaWeb.PS/Private/Select-EntraMfaMethod.ps1
+++ b/OmadaWeb.PS/Private/Select-EntraMfaMethod.ps1
@@ -1,0 +1,119 @@
+function Select-EntraMfaMethod {
+    <#
+    .SYNOPSIS
+        Picks which verification method to use on the Entra ID 'choose a way to sign in' screen.
+
+    .DESCRIPTION
+        When an account has more than one verification method registered, Entra ID renders a picker
+        and waits. Left alone the sign-in simply stops there, which is one of the silent stalls issue
+        #18 exists to remove. The page ships the offered methods as the 'arrUserProofs' array in its
+        embedded $Config object, and each entry names its method in 'authMethodId' - a fixed
+        identifier such as 'PhoneAppNotification', not the localized sentence shown to the user. That
+        identifier is what this function chooses by, so the choice is the same on a tenant served in
+        Dutch as on one served in English.
+
+        The default is the most secure method the account actually offers, in the order below. An
+        Authenticator push - the number-match approval - is preferred over a code the user has to
+        read and type, which is preferred over a code sent by SMS, which is preferred over a voice
+        call. Weaker methods are not skipped, only ranked last, so an account that has nothing else
+        registered still signs in.
+
+        A method this function does not know is ranked behind every method it does. That is
+        deliberate: Microsoft adds methods, and an unknown identifier is at least as likely to be
+        something better as something worse, but choosing it would mean automating a screen whose
+        behavior has never been seen here.
+
+        -PreferredMethod overrides the ranking. When the account does not offer that method the
+        override is reported once and the ranking decides instead, because failing a sign-in over a
+        preference would be a worse answer than signing in by the best available means.
+
+    .PARAMETER Proof
+        The arrUserProofs entries read off the page. Each is expected to carry an authMethodId.
+
+    .PARAMETER PreferredMethod
+        The authMethodId the caller asked for through -PreferredMfaMethod, when there was one.
+
+    .OUTPUTS
+        PSCustomObject with the members Index, AuthMethodId, IsPreferred and IsDefault, or $null when
+        the page offered no methods to choose from.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    param(
+        [Parameter(Position = 0)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [object[]]$Proof,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$PreferredMethod
+    )
+
+    $Offered = @($Proof | Where-Object { $null -ne $_ })
+    if ($Offered.Count -eq 0) {
+        return $null
+    }
+
+    # Most secure first. The numbers are only an ordering, so a method added between two of these
+    # later can be given a rank without renumbering the rest.
+    $Rank = @{
+        "PhoneAppNotification"       = 10
+        "PhoneAppOTP"                = 20
+        "OneWaySMS"                  = 30
+        "TwoWayVoiceMobile"          = 40
+        "TwoWayVoiceAlternateMobile" = 50
+        "TwoWayVoiceOffice"          = 60
+        "ConsolidatedTelephony"      = 70
+    }
+
+    $Candidate = [System.Collections.Generic.List[psobject]]::new()
+    for ($Index = 0; $Index -lt $Offered.Count; $Index++) {
+        $AuthMethodId = ""
+        if ($null -ne $Offered[$Index].authMethodId) {
+            $AuthMethodId = [string]$Offered[$Index].authMethodId
+        }
+
+        $MethodRank = 999
+        foreach ($Known in $Rank.Keys) {
+            if ($AuthMethodId -eq $Known) {
+                $MethodRank = $Rank[$Known]
+                break
+            }
+        }
+
+        $IsDefault = $false
+        if ($null -ne $Offered[$Index].isDefault) {
+            $IsDefault = [bool]$Offered[$Index].isDefault
+        }
+
+        $Candidate.Add([pscustomobject]@{
+                Index        = $Index
+                AuthMethodId = $AuthMethodId
+                IsPreferred  = $false
+                IsDefault    = $IsDefault
+                Rank         = $MethodRank
+            })
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($PreferredMethod)) {
+        $Wanted = @($Candidate | Where-Object { $_.AuthMethodId -eq $PreferredMethod })
+        if ($Wanted.Count -gt 0) {
+            $Wanted[0].IsPreferred = $true
+            return ($Wanted[0] | Select-Object -Property Index, AuthMethodId, IsPreferred, IsDefault)
+        }
+
+        # The timer that drives this ticks every 150 ms, so the warning is issued once per sign-in
+        # rather than once per look at the page.
+        if (-not $Script:PreferredMfaMethodWarningIssued) {
+            $Script:PreferredMfaMethodWarningIssued = $true
+            "The verification method '{0}' asked for with -PreferredMfaMethod is not offered by this account. Available: {1}. Continuing with the most secure method that is offered." -f $PreferredMethod, (($Candidate.AuthMethodId | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ", ") | Write-Warning
+        }
+    }
+
+    # Sorting on Index as well keeps the choice reproducible when two methods share a rank, which is
+    # what an account with two unknown methods produces.
+    $Chosen = $Candidate | Sort-Object -Property Rank, Index | Select-Object -First 1
+
+    return ($Chosen | Select-Object -Property Index, AuthMethodId, IsPreferred, IsDefault)
+}

--- a/OmadaWeb.PS/Private/Select-EntraMfaMethod.ps1
+++ b/OmadaWeb.PS/Private/Select-EntraMfaMethod.ps1
@@ -110,9 +110,19 @@ function Select-EntraMfaMethod {
         }
     }
 
+    # An entry that does not say which method it is cannot be chosen. Ranking it merely as "unknown"
+    # would let it win on position alone, and the caller would then click a method by index without
+    # anything having decided it was the right one - the guessing this whole function exists not to
+    # do. When that leaves nothing, nothing is what is returned: Resolve-EntraSignInScreen reads
+    # that as a page it cannot drive and hands the sign-in over.
+    $Identified = @($Candidate | Where-Object { -not [string]::IsNullOrWhiteSpace($_.AuthMethodId) })
+    if ($Identified.Count -eq 0) {
+        return $null
+    }
+
     # Sorting on Index as well keeps the choice reproducible when two methods share a rank, which is
     # what an account with two unknown methods produces.
-    $Chosen = $Candidate | Sort-Object -Property Rank, Index | Select-Object -First 1
+    $Chosen = $Identified | Sort-Object -Property Rank, Index | Select-Object -First 1
 
     return ($Chosen | Select-Object -Property Index, AuthMethodId, IsPreferred, IsDefault)
 }

--- a/OmadaWeb.PS/Private/Set-DynamicParameter.ps1
+++ b/OmadaWeb.PS/Private/Set-DynamicParameter.ps1
@@ -1,4 +1,4 @@
-﻿function Set-DynamicParameter {
+function Set-DynamicParameter {
     [CmdletBinding()]
     param(
         $FunctionName
@@ -100,6 +100,20 @@ IMPORTANT: Due to the requirements of Selenium, the selected Edge profile needs 
     New-DynamicParam -Name "UseWebView2" -Type "System.Management.Automation.SwitchParameter" -ParameterSetName $ParameterObjectSetNames -DPDictionary $Dictionary -HelpMessage "Use WebView2 instead of Selenium WebDriver for browser-based authentication.
 
 IMPORTANT: This parameter is deprecated and obsolete. The default is AuthenticationType WebView2, so this parameter is not needed anymore and will be removed in a future release."
+    New-DynamicParam -Name "PreferredMfaMethod" -Type "string" -ValidateSet ("PhoneAppNotification", "PhoneAppOTP", "OneWaySMS", "TwoWayVoiceMobile", "TwoWayVoiceAlternateMobile", "TwoWayVoiceOffice", "ConsolidatedTelephony") -ParameterSetName $ParameterObjectSetNames -DPDictionary $Dictionary -HelpMessage 'The multi-factor authentication method to select when Entra ID asks which way to sign in, and the account has more than one method registered. Without this parameter the most secure method the account offers is chosen automatically, preferring an Authenticator approval over a code that has to be typed, a code over a text message, and a text message over a voice call.
+
+The values are the method identifiers Entra ID itself uses, so they mean the same thing whatever language the sign-in page is served in:
+- ''PhoneAppNotification'': Microsoft Authenticator approval, including number matching.
+- ''PhoneAppOTP'': A verification code from Microsoft Authenticator.
+- ''OneWaySMS'': A code sent by text message.
+- ''TwoWayVoiceMobile'': A call to the registered mobile number.
+- ''TwoWayVoiceAlternateMobile'': A call to the registered alternate mobile number.
+- ''TwoWayVoiceOffice'': A call to the registered office number.
+- ''ConsolidatedTelephony'': The consolidated telephony method.
+
+When the account does not offer the requested method, a warning is written and the most secure method it does offer is used instead, so a preference never fails a sign-in that would otherwise succeed.
+
+IMPORTANT: This parameter only applies to -AuthenticationType WebView2, and to -AuthenticationType Browser once that runs on WebView2. Supplying it with any other authentication type raises a terminating error.'
     New-DynamicParam -Name "DebugWebView2" -Type "System.Management.Automation.SwitchParameter" -ParameterSetName $ParameterObjectSetNames -DPDictionary $Dictionary -HelpMessage "Use this parameter to enable WebView2 browser debugging options like Developer Tools"
     New-DynamicParam -Name "SessionKey" -Type "string" -ParameterSetName $ParameterObjectSetNames -DPDictionary $Dictionary -HelpMessage "Explicitly discriminate the reusable authentication session (cookie, base URL, WebView2/Selenium profile) to use for this call, in addition to the base URL, -AuthenticationType and -Credential (when supplied). Use this to keep multiple concurrent sessions apart when they would otherwise share the same base URL, authentication type and credential - for example two interactive Browser/WebView2 logins to the same tenant before either has a known user identity. Has no effect on which cookie/base URL etc. is used beyond distinguishing sessions from each other; defaults to an empty value, which reproduces prior single-session-per-(base URL, AuthenticationType, Credential) behavior."
 

--- a/OmadaWeb.PS/Private/Set-RequestParameter.ps1
+++ b/OmadaWeb.PS/Private/Set-RequestParameter.ps1
@@ -27,7 +27,7 @@
         # cmdlets would accept them: the retry policy is implemented by Invoke-OmadaRetryableRequest
         # around the call, so passing them on as well would nest a second, differently behaving
         # retry loop inside each attempt of the first.
-        $ExcludedParameters = @("SkipCookieCache", "CookiePath", "InPrivate", "ForceAuthentication", "AuthenticationType", "EntraIdTenantId", "RequestType", "EdgeProfile", "UseWebView2", "EntraApplicationIdUri", "OAuthUri", "OAuthScope", "DebugWebView2", "Paged", "SessionKey", "MaximumRetryCount", "RetryIntervalSec")
+        $ExcludedParameters = @("SkipCookieCache", "CookiePath", "InPrivate", "ForceAuthentication", "AuthenticationType", "EntraIdTenantId", "RequestType", "EdgeProfile", "UseWebView2", "EntraApplicationIdUri", "OAuthUri", "OAuthScope", "DebugWebView2", "PreferredMfaMethod", "Paged", "SessionKey", "MaximumRetryCount", "RetryIntervalSec")
     }
 
     $Parameters = @{}

--- a/OmadaWeb.PS/Private/Show-EntraApprovalNumber.ps1
+++ b/OmadaWeb.PS/Private/Show-EntraApprovalNumber.ps1
@@ -1,0 +1,77 @@
+function Show-EntraApprovalNumber {
+    <#
+    .SYNOPSIS
+        Tells the user which number to match in their authenticator app, and then keeps saying that
+        the sign-in is still waiting for them.
+
+    .DESCRIPTION
+        Two Entra ID screens show a number the user has to match on their phone: passwordless sign-in
+        and Authenticator number match. They are different elements on different screens but the same
+        thing to the person in front of them, so both arrive here.
+
+        When Phone Link is running the number is put on the clipboard as well, because the phone can
+        then be driven from the same desktop and the value pasted straight into the app.
+
+        The rest of this exists because of what happens next: nothing, for a long time. Approving a
+        request takes as long as it takes someone to pick up their phone, unlock it and read - a
+        minute is unremarkable and several are possible. The window looks frozen for all of it, which
+        is one of the silent stalls issue #18 is about, and it is also why Test-LoginAutomationStalled
+        is told not to count this as a page that stopped making progress. So the wait reports itself
+        every $Script:MfaWaitReportInterval seconds instead of going quiet - often enough to show
+        that something is still happening, rarely enough not to fill the verbose stream from a timer
+        that ticks every 150 ms.
+
+    .PARAMETER Number
+        The number read off the page.
+
+    .OUTPUTS
+        System.Boolean. True when this call showed the number for the first time, false while the
+        sign-in is merely still waiting to be approved.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [Parameter(Position = 0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Number
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Number)) {
+        return $false
+    }
+
+    if ($Script:MfaRequestDisplayed) {
+        if ($null -eq $Script:MfaWaitLastReported -or ([DateTime]::Now - $Script:MfaWaitLastReported).TotalSeconds -ge $Script:MfaWaitReportInterval) {
+            $Script:MfaWaitLastReported = [DateTime]::Now
+            "Show-EntraApprovalNumber - Still waiting for sign-in request {0} to be approved" -f $Number | Write-Verbose
+        }
+
+        return $false
+    }
+
+    $Message = "`nWaiting for you to approve this sign-in request"
+
+    $PhoneLinkActive = (Get-Process | Where-Object { $_.ProcessName -eq "PhoneExperienceHost" } | Measure-Object).Count -gt 0
+    if ($PhoneLinkActive) {
+        try {
+            $Number | Set-Clipboard
+            $Message = "{0}: {1} (This value is now in your clipboard so you can paste it into your Authenticator app using PhoneLink)." -f $Message, $Number
+        }
+        catch {
+            # The number is the part that matters; failing to reach the clipboard must not cost the
+            # user the one piece of information they need.
+            $Message = "{0}: {1} (The clipboard could not be set: {2})." -f $Message, $Number, $_.Exception.Message
+        }
+    }
+    else {
+        $Message = "{0}: {1}" -f $Message, $Number
+    }
+
+    $Message | Write-Host -ForegroundColor Yellow
+
+    $Script:MfaRequestDisplayed = $true
+    $Script:MfaWaitLastReported = [DateTime]::Now
+
+    return $true
+}

--- a/OmadaWeb.PS/Private/Show-EntraApprovalNumber.ps1
+++ b/OmadaWeb.PS/Private/Show-EntraApprovalNumber.ps1
@@ -52,7 +52,10 @@ function Show-EntraApprovalNumber {
 
     $Message = "`nWaiting for you to approve this sign-in request"
 
-    $PhoneLinkActive = (Get-Process | Where-Object { $_.ProcessName -eq "PhoneExperienceHost" } | Measure-Object).Count -gt 0
+    # Asking for the one process by name rather than filtering the whole table: this runs on the
+    # WebView2 UI thread, and enumerating every process on the machine to answer a yes/no question
+    # about one of them is work the timer does not need to do.
+    $PhoneLinkActive = (Get-Process -Name "PhoneExperienceHost" -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
     if ($PhoneLinkActive) {
         try {
             $Number | Set-Clipboard

--- a/README.md
+++ b/README.md
@@ -228,49 +228,49 @@ Clear-OmadaWebCache [-Scope {All | Cookies | BrowserProfiles | Binaries | Sessio
 ### Invoke-OmadaRestMethod (StandardMethod)
 
 ```powershell
-Invoke-OmadaRestMethod -Uri <uri> [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-Paged <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-SessionKey <string>] [<Invoke-RestMethod Parameters>]
+Invoke-OmadaRestMethod -Uri <uri> [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-Paged <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-PreferredMfaMethod {PhoneAppNotification | PhoneAppOTP | OneWaySMS | TwoWayVoiceMobile | TwoWayVoiceAlternateMobile | TwoWayVoiceOffice | ConsolidatedTelephony}] [-SessionKey <string>] [<Invoke-RestMethod Parameters>]
 ```
 
 ### Invoke-OmadaRestMethod (StandardMethodNoProxy)
 
 ```powershell
-Invoke-OmadaRestMethod -Uri <uri> -NoProxy [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-Paged <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-SessionKey <string>] [<Invoke-RestMethod Parameters>]
+Invoke-OmadaRestMethod -Uri <uri> -NoProxy [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-Paged <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-PreferredMfaMethod {PhoneAppNotification | PhoneAppOTP | OneWaySMS | TwoWayVoiceMobile | TwoWayVoiceAlternateMobile | TwoWayVoiceOffice | ConsolidatedTelephony}] [-SessionKey <string>] [<Invoke-RestMethod Parameters>]
 ```
 
 ### Invoke-OmadaRestMethod (CustomMethod)
 
 ```powershell
-Invoke-OmadaRestMethod -Uri <uri> -CustomMethod <string> [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-Paged <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-SessionKey <string>] [<Invoke-RestMethod Parameters>]
+Invoke-OmadaRestMethod -Uri <uri> -CustomMethod <string> [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-Paged <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-PreferredMfaMethod {PhoneAppNotification | PhoneAppOTP | OneWaySMS | TwoWayVoiceMobile | TwoWayVoiceAlternateMobile | TwoWayVoiceOffice | ConsolidatedTelephony}] [-SessionKey <string>] [<Invoke-RestMethod Parameters>]
 ```
 
 ### Invoke-OmadaRestMethod (CustomMethodNoProxy)
 
 ```powershell
-Invoke-OmadaRestMethod -Uri <uri> -CustomMethod <string> -NoProxy [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-Paged <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-SessionKey <string>] [<Invoke-RestMethod Parameters>]
+Invoke-OmadaRestMethod -Uri <uri> -CustomMethod <string> -NoProxy [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-Paged <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-PreferredMfaMethod {PhoneAppNotification | PhoneAppOTP | OneWaySMS | TwoWayVoiceMobile | TwoWayVoiceAlternateMobile | TwoWayVoiceOffice | ConsolidatedTelephony}] [-SessionKey <string>] [<Invoke-RestMethod Parameters>]
 ```
 
 ### Invoke-OmadaWebRequest (StandardMethod)
 
 ```powershell
-Invoke-OmadaWebRequest -Uri <uri> [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-SessionKey <string>] [<Invoke-WebRequest Parameters>]
+Invoke-OmadaWebRequest -Uri <uri> [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-PreferredMfaMethod {PhoneAppNotification | PhoneAppOTP | OneWaySMS | TwoWayVoiceMobile | TwoWayVoiceAlternateMobile | TwoWayVoiceOffice | ConsolidatedTelephony}] [-SessionKey <string>] [<Invoke-WebRequest Parameters>]
 ```
 
 ### Invoke-OmadaWebRequest (StandardMethodNoProxy)
 
 ```powershell
-Invoke-OmadaWebRequest -Uri <uri> -NoProxy [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-SessionKey <string>] [<Invoke-WebRequest Parameters>]
+Invoke-OmadaWebRequest -Uri <uri> -NoProxy [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-PreferredMfaMethod {PhoneAppNotification | PhoneAppOTP | OneWaySMS | TwoWayVoiceMobile | TwoWayVoiceAlternateMobile | TwoWayVoiceOffice | ConsolidatedTelephony}] [-SessionKey <string>] [<Invoke-WebRequest Parameters>]
 ```
 
 ### Invoke-OmadaWebRequest (CustomMethod)
 
 ```powershell
-Invoke-OmadaWebRequest -Uri <uri> -CustomMethod <string> [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-SessionKey <string>] [<Invoke-WebRequest Parameters>]
+Invoke-OmadaWebRequest -Uri <uri> -CustomMethod <string> [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-PreferredMfaMethod {PhoneAppNotification | PhoneAppOTP | OneWaySMS | TwoWayVoiceMobile | TwoWayVoiceAlternateMobile | TwoWayVoiceOffice | ConsolidatedTelephony}] [-SessionKey <string>] [<Invoke-WebRequest Parameters>]
 ```
 
 ### Invoke-OmadaWebRequest (CustomMethodNoProxy)
 
 ```powershell
-Invoke-OmadaWebRequest -Uri <uri> -CustomMethod <string> -NoProxy [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-SessionKey <string>] [<Invoke-WebRequest Parameters>]
+Invoke-OmadaWebRequest -Uri <uri> -CustomMethod <string> -NoProxy [-AuthenticationType {OAuth | Integrated | Basic | Browser | WebView2 | Windows | None}] [-EntraIdTenantId <string>] [-EntraApplicationIdUri <string>] [-OAuthScope <string>] [-OAuthUri <string>] [-CookiePath <string>] [-SkipCookieCache <switch>] [-ForceAuthentication <switch>] [-EdgeProfile <string>] [-InPrivate <switch>] [-UseWebView2 <switch>] [-DebugWebView2 <switch>] [-MaximumRetryCount <int>] [-RetryIntervalSec <int>] [-PreferredMfaMethod {PhoneAppNotification | PhoneAppOTP | OneWaySMS | TwoWayVoiceMobile | TwoWayVoiceAlternateMobile | TwoWayVoiceOffice | ConsolidatedTelephony}] [-SessionKey <string>] [<Invoke-WebRequest Parameters>]
 ```
 
 <!-- END GENERATED SYNTAX -->
@@ -682,6 +682,34 @@ The wait in seconds before the first retry, doubled for each attempt after that.
 
 ```yaml
         Type: System.Int32
+        Required: false
+        Position: Named
+        Accept pipeline input: false
+        Parameter set name: (All)
+        Aliases: None
+        Dynamic: true
+        Accept wildcard characters: false
+```
+
+#### -PreferredMfaMethod <string>
+The multi-factor authentication method to select when Entra ID asks which way to sign in, and the account has more than one method registered. Without this parameter the most secure method the account offers is chosen automatically, preferring an Authenticator approval over a code that has to be typed, a code over a text message, and a text message over a voice call.
+
+The values are the method identifiers Entra ID itself uses, so they mean the same thing whatever language the sign-in page is served in:
+- `PhoneAppNotification`: Microsoft Authenticator approval, including number matching.
+- `PhoneAppOTP`: A verification code from Microsoft Authenticator.
+- `OneWaySMS`: A code sent by text message.
+- `TwoWayVoiceMobile`: A call to the registered mobile number.
+- `TwoWayVoiceAlternateMobile`: A call to the registered alternate mobile number.
+- `TwoWayVoiceOffice`: A call to the registered office number.
+- `ConsolidatedTelephony`: The consolidated telephony method.
+
+When the account does not offer the requested method, a warning is written and the most secure method it does offer is used instead, so a preference never fails a sign-in that would otherwise succeed.
+
+> [!IMPORTANT]
+> This parameter only applies to -AuthenticationType WebView2, and to -AuthenticationType Browser once that runs on WebView2. Supplying it with any other authentication type raises a terminating error.
+
+```yaml
+        Type: System.String
         Required: false
         Position: Named
         Accept pipeline input: false

--- a/Tests/Integration/EntraSignInScript.Browser.Tests.ps1
+++ b/Tests/Integration/EntraSignInScript.Browser.Tests.ps1
@@ -87,8 +87,12 @@ $Body
     }
 
     try {
-        $Core = Join-Path $env:LOCALAPPDATA "OmadaWeb.PS\Bin\Core"
-        $WebDriverAssembly = Join-Path $Core "WebDriver.dll"
+        # Asked of the module rather than guessed, because the binaries live in a per-edition folder
+        # - Bin\Core under PowerShell 7, Bin\Desktop under Windows PowerShell 5.1. Hardcoding either
+        # makes this suite skip silently on the other engine, which reads exactly like passing.
+        $WebDriverAssembly = InModuleScope 'OmadaWeb.PS' { $Script:WebDriverPath }
+        $Core = Split-Path $WebDriverAssembly -Parent
+
         if (-not (Test-Path $WebDriverAssembly) -or -not (Test-Path (Join-Path $Core "msedgedriver.exe"))) {
             throw "Edge WebDriver is not installed in '$Core'."
         }

--- a/Tests/Integration/EntraSignInScript.Browser.Tests.ps1
+++ b/Tests/Integration/EntraSignInScript.Browser.Tests.ps1
@@ -1,0 +1,359 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+<#
+    Runs the JavaScript this module actually ships against pages shaped like the Entra ID sign-in
+    screens, in a real browser.
+
+    Every other test of the sign-in automation feeds Resolve-EntraSignInScreen a snapshot written by
+    hand, which proves the rules but assumes the snapshot. That assumption is where the automation
+    has been wrong before: whether an element counts as visible is decided by the browser's computed
+    style, not by the fixture author, and several defects lived exactly in the gap between what the
+    probe reported and what the click helpers then did with it.
+
+    So these tests take the shipping script out of the module - the probe from
+    Get-EntraSignInProbeScript, the click helpers out of the here-strings inside
+    Invoke-WebView2MicrosoftLogin - run it in headless Edge against file:// fixtures, and feed the
+    real output to the real resolver. What is asserted is the whole chain: page -> probe -> decision,
+    and page -> click -> what the page did about it.
+
+    They are skipped rather than failed when Edge WebDriver cannot start, so a machine without it
+    does not break the build. CI warms the driver up before running this, so it does run there.
+#>
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    $Script:DriverSkipReason = $null
+    $Script:Driver = $null
+    $Script:FixtureDir = Join-Path ([System.IO.Path]::GetTempPath()) ("EntraSignInFixtures_{0}" -f ([guid]::NewGuid().ToString('N')))
+
+    # The page-level state each fixture needs, with the parts every Entra page carries filled in.
+    function Script:New-Fixture {
+        param(
+            [Parameter(Mandatory)][string]$Name,
+            [Parameter(Mandatory)][string]$Body,
+            [string]$Config = '{ iErrorCode: 0, sErrorCode: "", arrUserProofs: [] }'
+        )
+
+        $Html = @"
+<!doctype html><html><head><meta charset="utf-8"><title>Sign in</title>
+<script>window.`$Config = $Config;</script>
+<style>.offscreen { position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0 0 0 0); }</style>
+</head><body>
+$Body
+</body></html>
+"@
+
+        $Path = Join-Path $Script:FixtureDir ("{0}.html" -f $Name)
+        Set-Content -Path $Path -Value $Html -Encoding UTF8
+        return ([System.Uri]$Path).AbsoluteUri
+    }
+
+    function Script:Get-PageSnapshot {
+        param([Parameter(Mandatory)][string]$Url)
+
+        $Script:Driver.Navigate().GoToUrl($Url)
+        $ProbeScript = InModuleScope 'OmadaWeb.PS' { Get-EntraSignInProbeScript }
+
+        return ($Script:Driver.ExecuteScript("return " + $ProbeScript) | ConvertFrom-Json)
+    }
+
+    # The click helpers live in here-strings inside the function, so they are lifted out through the
+    # AST and evaluated in module scope - which is what expands the shared visibility predicate into
+    # them. Reading them any other way would test a copy instead of what ships.
+    function Script:Get-ShippedSnippet {
+        param([Parameter(Mandatory)][string]$Name)
+
+        $Definition = InModuleScope 'OmadaWeb.PS' { (Get-Command Invoke-WebView2MicrosoftLogin).Definition }
+        $Ast = [System.Management.Automation.Language.Parser]::ParseInput($Definition, [ref]$null, [ref]$null)
+
+        $Assignment = $Ast.FindAll({
+                param($Node)
+                $Node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                $Node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                $Node.Left.VariablePath.UserPath -eq $Name
+            }, $true) | Select-Object -First 1
+
+        if ($null -eq $Assignment) {
+            throw "The snippet '$Name' is no longer assigned in Invoke-WebView2MicrosoftLogin."
+        }
+
+        return (InModuleScope 'OmadaWeb.PS' -Parameters @{ Text = $Assignment.Right.Extent.Text } {
+                Invoke-Expression $Text
+            })
+    }
+
+    try {
+        $Core = Join-Path $env:LOCALAPPDATA "OmadaWeb.PS\Bin\Core"
+        $WebDriverAssembly = Join-Path $Core "WebDriver.dll"
+        if (-not (Test-Path $WebDriverAssembly) -or -not (Test-Path (Join-Path $Core "msedgedriver.exe"))) {
+            throw "Edge WebDriver is not installed in '$Core'."
+        }
+
+        Add-Type -Path $WebDriverAssembly
+
+        New-Item -ItemType Directory -Path $Script:FixtureDir -Force | Out-Null
+
+        $Service = [OpenQA.Selenium.Edge.EdgeDriverService]::CreateDefaultService($Core, "msedgedriver.exe")
+        $Service.HideCommandPromptWindow = $true
+        $Options = [OpenQA.Selenium.Edge.EdgeOptions]::new()
+        $Options.AddArgument("--headless=new")
+        $Options.AddArgument("--allow-file-access-from-files")
+        $Options.AddArgument("--no-sandbox")
+
+        $Script:Driver = [OpenQA.Selenium.Edge.EdgeDriver]::new($Service, $Options)
+    }
+    catch {
+        $Script:DriverSkipReason = "Edge WebDriver could not be started: {0}" -f $_.Exception.Message
+    }
+}
+
+Describe 'Entra sign-in scripts against a real browser' -Tag 'Integration' {
+
+    BeforeEach {
+        if ($null -ne $Script:DriverSkipReason) {
+            Set-ItResult -Skipped -Because $Script:DriverSkipReason
+        }
+    }
+
+    Context 'The probe, against elements a real browser has laid out' {
+        It 'Reports a left-over username field as present but not visible' {
+            # The shape that makes presence useless as a signal: Entra keeps i0116 in the markup on
+            # the password screen. Every hand-written snapshot in the other tests asserts this; here
+            # the browser decides it.
+            $Url = New-Fixture -Name 'password' -Body @'
+  <input id="i0116" type="email" name="loginfmt" value="someone@contoso.com" style="display:none">
+  <input id="i0118" type="password" name="passwd">
+  <input id="idSIButton9" type="submit" value="Sign in">
+'@
+
+            $Snapshot = Get-PageSnapshot -Url $Url
+
+            $Snapshot.ids | Should -Contain 'i0116'
+            $Snapshot.visibleIds | Should -Not -Contain 'i0116'
+            $Snapshot.visibleIds | Should -Contain 'i0118'
+            $Snapshot.hasVisiblePasswordInput | Should -BeTrue
+        }
+
+        It 'Treats a field hidden by <Technique> as not visible' -TestCases @(
+            @{ Technique = 'display:none'; Style = 'style="display:none"' }
+            @{ Technique = 'visibility:hidden'; Style = 'style="visibility:hidden"' }
+            @{ Technique = 'zero opacity'; Style = 'style="opacity:0"' }
+            @{ Technique = 'an off-screen clip'; Style = 'class="offscreen"' }
+            @{ Technique = 'aria-hidden'; Style = 'aria-hidden="true"' }
+            @{ Technique = 'the disabled attribute'; Style = 'disabled' }
+            @{ Technique = 'the readonly attribute'; Style = 'readonly' }
+        ) {
+            # Each of these is a different mechanism and only the browser knows what they compute to.
+            # readonly is in the list because a field that cannot be typed into is as useless to this
+            # module as one that cannot be seen.
+            $Url = New-Fixture -Name ('hidden-{0}' -f ($Technique -replace '[^a-z]', '')) -Body @"
+  <input id="i0118" type="password" name="passwd" $Style>
+  <input id="idSIButton9" type="submit" value="Sign in">
+"@
+
+            $Snapshot = Get-PageSnapshot -Url $Url
+
+            $Snapshot.ids | Should -Contain 'i0118'
+            $Snapshot.visibleIds | Should -Not -Contain 'i0118'
+        }
+
+        It 'Reads the error code out of the page $Config' {
+            $Url = New-Fixture -Name 'blocked' -Config '{ iErrorCode: 53003, sErrorCode: "53003", arrUserProofs: [] }' -Body '<div id="idBtn_Back">Back</div>'
+
+            (Get-PageSnapshot -Url $Url).errorCode | Should -Be '53003'
+        }
+
+        It 'Reads the passwordless approval number' {
+            $Url = New-Fixture -Name 'approval' -Body '<div id="idRemoteNGC_DisplaySign">42</div>'
+
+            (Get-PageSnapshot -Url $Url).displaySign | Should -Be '42'
+        }
+    }
+
+    Context 'The whole chain, from page to decision' {
+        It 'Decides the password screen from a page that still carries the username field' {
+            $Url = New-Fixture -Name 'chain-password' -Body @'
+  <input id="i0116" type="email" name="loginfmt" style="display:none">
+  <input id="i0118" type="password" name="passwd">
+  <input id="idSIButton9" type="submit" value="Sign in">
+'@
+
+            $Snapshot = Get-PageSnapshot -Url $Url
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Snapshot = $Snapshot } {
+                $Decision = Resolve-EntraSignInScreen -PageState $Snapshot -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'PasswordEntry'
+                $Decision.ElementId | Should -Be 'i0118'
+                $Decision.ValueSource | Should -Be 'Password'
+            }
+        }
+
+        It 'Decides the same screen when the page is served in Dutch' {
+            # The defect this whole change exists for. The markup is identical apart from the words,
+            # and the words are what the previous implementation read.
+            $Url = New-Fixture -Name 'chain-password-nl' -Body @'
+  <input id="i0116" type="email" name="loginfmt" style="display:none">
+  <input id="i0118" type="password" name="passwd" placeholder="Wachtwoord">
+  <input id="idSIButton9" type="submit" value="Aanmelden">
+'@
+
+            $Snapshot = Get-PageSnapshot -Url $Url
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Snapshot = $Snapshot } {
+                (Resolve-EntraSignInScreen -PageState $Snapshot -UserName 'someone@contoso.com' -HasPassword).Screen | Should -Be 'PasswordEntry'
+            }
+        }
+
+        It 'Recognizes "stay signed in" when its checkbox is styled out of sight' {
+            # The one rule that deliberately asks for presence rather than visibility. A styled
+            # checkbox hides the real input behind its label, and this is the fixture that proves the
+            # exception is needed rather than merely asserted in a comment.
+            $Url = New-Fixture -Name 'chain-kmsi' -Body @'
+  <input id="KmsiCheckboxField" type="checkbox" class="offscreen">
+  <label for="KmsiCheckboxField">Don't show this again</label>
+  <input id="idBtn_Back" type="button" value="No">
+  <input id="idSIButton9" type="submit" value="Yes">
+'@
+
+            $Snapshot = Get-PageSnapshot -Url $Url
+
+            $Snapshot.visibleIds | Should -Not -Contain 'KmsiCheckboxField' -Because 'the styled checkbox really is invisible to the browser'
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Snapshot = $Snapshot } {
+                $Decision = Resolve-EntraSignInScreen -PageState $Snapshot -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'StaySignedIn'
+                $Decision.ElementId | Should -Be 'idBtn_Back'
+            }
+        }
+
+        It 'Ends the sign-in on a Conditional Access block' {
+            $Url = New-Fixture -Name 'chain-blocked' -Config '{ iErrorCode: 53003, sErrorCode: "53003", arrUserProofs: [] }' -Body @'
+  <input id="i0118" type="password" name="passwd">
+  <input id="idSIButton9" type="submit" value="Sign in">
+'@
+
+            $Snapshot = Get-PageSnapshot -Url $Url
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Snapshot = $Snapshot } {
+                $Decision = Resolve-EntraSignInScreen -PageState $Snapshot -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Action | Should -Be 'Stop'
+                $Decision.Code | Should -Be 'AADSTS53003'
+                $Decision.ValueSource | Should -Not -Be 'Password' -Because 'the password must not be sent to a page that already refused it'
+            }
+        }
+
+        It 'Does not offer a passwordless account a hidden way out of the password screen' {
+            $Url = New-Fixture -Name 'chain-passwordless-hidden-link' -Body @'
+  <input id="i0118" type="password" name="passwd">
+  <input id="idSIButton9" type="submit" value="Sign in">
+  <a id="idA_PWD_SwitchToCredPicker" href="#" style="display:none">Sign in another way</a>
+'@
+
+            $Snapshot = Get-PageSnapshot -Url $Url
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Snapshot = $Snapshot } {
+                $Decision = Resolve-EntraSignInScreen -PageState $Snapshot -UserName 'someone@contoso.com'
+
+                $Decision.Screen | Should -Be 'PasswordRequired'
+                $Decision.ValueSource | Should -Not -Be 'Password'
+            }
+        }
+    }
+
+    Context 'The click helpers, against a page that answers back' {
+        It 'Clicks the visible account tile and not its hidden namesake' {
+            # Copilot found this by reading. Here the browser settles it: two elements carry the same
+            # data-test-id and only one of them can be clicked by a person.
+            $Url = New-Fixture -Name 'tiles' -Body @'
+  <div id="hiddenTile" data-test-id="someone@contoso.com" style="display:none" onclick="window.__clicked='hidden'">someone@contoso.com</div>
+  <div id="visibleTile" data-test-id="someone@contoso.com" onclick="window.__clicked='visible'">someone@contoso.com</div>
+'@
+
+            $Script:Driver.Navigate().GoToUrl($Url)
+            $Snippet = Get-ShippedSnippet -Name 'ClickAccountTileScript'
+
+            $Clicked = $Script:Driver.ExecuteScript(("return ({0})('someone@contoso.com');" -f $Snippet))
+
+            $Clicked | Should -BeTrue
+            $Script:Driver.ExecuteScript("return window.__clicked;") | Should -Be 'visible'
+        }
+
+        It 'Answers false rather than clicking an element the page is hiding' {
+            $Url = New-Fixture -Name 'hidden-button' -Body '<input id="idSIButton9" type="submit" value="Sign in" style="display:none" onclick="window.__clicked=1">'
+
+            $Script:Driver.Navigate().GoToUrl($Url)
+            $Snippet = Get-ShippedSnippet -Name 'ClickElementScript'
+
+            $Clicked = $Script:Driver.ExecuteScript(("return ({0})('idSIButton9');" -f $Snippet))
+
+            $Clicked | Should -BeFalse -Because 'the driver reads this answer as "the page moved", and it did not'
+            $Script:Driver.ExecuteScript("return window.__clicked;") | Should -BeNullOrEmpty
+        }
+
+        It 'Answers false rather than typing into a field the page is hiding' {
+            $Url = New-Fixture -Name 'hidden-field' -Body '<input id="i0118" type="password" style="display:none">'
+
+            $Script:Driver.Navigate().GoToUrl($Url)
+            $Snippet = Get-ShippedSnippet -Name 'SetElementValueScript'
+
+            $Written = $Script:Driver.ExecuteScript(("return ({0})('i0118', 'secret');" -f $Snippet))
+
+            $Written | Should -BeFalse
+            $Script:Driver.ExecuteScript("return document.getElementById('i0118').value;") | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'The verification-method picker, counted and clicked the same way' {
+        It 'Counts only the options a user could click, and clicks the one that was chosen' {
+            # The count is the only thing linking a method to an option, so a hidden template option
+            # counted on one side and not the other selects a different method than the one chosen -
+            # and the click still succeeds, so nothing reports it.
+            $Config = '{ iErrorCode: 0, sErrorCode: "", arrUserProofs: [ { authMethodId: "OneWaySMS", isDefault: true }, { authMethodId: "PhoneAppNotification", isDefault: false } ] }'
+            $Url = New-Fixture -Name 'proofs' -Config $Config -Body @'
+  <div id="idDiv_SAOTCS_Proofs">
+    <div data-value="template" style="display:none" onclick="window.__clicked='template'">template</div>
+    <div data-value="sms" onclick="window.__clicked='sms'">Text me</div>
+    <div data-value="app" onclick="window.__clicked='app'">Approve a request</div>
+  </div>
+'@
+
+            $Snapshot = Get-PageSnapshot -Url $Url
+
+            $Snapshot.proofOptionCount | Should -Be 2 -Because 'the hidden template option is not one a user could choose'
+
+            $Index = InModuleScope 'OmadaWeb.PS' -Parameters @{ Snapshot = $Snapshot } {
+                $Decision = Resolve-EntraSignInScreen -PageState $Snapshot -UserName 'someone@contoso.com'
+
+                $Decision.Action | Should -Be 'ClickProofOption'
+                $Decision.Value | Should -Be 'PhoneAppNotification'
+                return $Decision.Index
+            }
+
+            $Snippet = Get-ShippedSnippet -Name 'ClickProofOptionScript'
+            $Clicked = $Script:Driver.ExecuteScript(("return ({0})('idDiv_SAOTCS_Proofs', {1});" -f $Snippet, $Index))
+
+            $Clicked | Should -BeTrue
+            $Script:Driver.ExecuteScript("return window.__clicked;") | Should -Be 'app' -Because 'the most secure offered method is the one that must be selected'
+        }
+    }
+}
+
+AfterAll {
+    if ($null -ne $Script:Driver) {
+        $Script:Driver.Quit()
+        $Script:Driver = $null
+    }
+
+    if (Test-Path $Script:FixtureDir) {
+        Remove-Item $Script:FixtureDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Get-EntraErrorVerdict.Tests.ps1
+++ b/Tests/Unit/Get-EntraErrorVerdict.Tests.ps1
@@ -1,0 +1,115 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Get-EntraErrorVerdict' -Tag 'Unit' {
+
+    Context 'Pages that report no failure' {
+        It 'Reports no error for <Description>' -TestCases @(
+            @{ Description = 'a healthy page, which writes iErrorCode 0'; ErrorCode = '0' }
+            @{ Description = 'an empty value'; ErrorCode = '' }
+            @{ Description = 'a missing value'; ErrorCode = $null }
+            @{ Description = 'a value carrying no digits at all'; ErrorCode = 'none' }
+        ) {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ ErrorCode = $ErrorCode } {
+                $Verdict = Get-EntraErrorVerdict -ErrorCode $ErrorCode
+
+                $Verdict.IsError | Should -BeFalse
+                $Verdict.Action | Should -Be 'None'
+                $Verdict.IsTerminal | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'Failures that a retry cannot turn into a success' {
+        # Every one of these ends the sign-in through Stop-OmadaLogin instead of opening another
+        # browser window. 50126 is in this group on purpose: resubmitting a credential Entra ID has
+        # just refused is what drives an account into smart lockout.
+        It 'Stops the sign-in on <ErrorCode>' -TestCases @(
+            @{ ErrorCode = '50126' }
+            @{ ErrorCode = '50053' }
+            @{ ErrorCode = '50055' }
+            @{ ErrorCode = '53003' }
+        ) {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ ErrorCode = $ErrorCode } {
+                $Verdict = Get-EntraErrorVerdict -ErrorCode $ErrorCode
+
+                $Verdict.IsError | Should -BeTrue
+                $Verdict.IsTerminal | Should -BeTrue
+                $Verdict.Action | Should -Be 'Stop'
+                $Verdict.Code | Should -Be ("AADSTS{0}" -f $ErrorCode)
+                $Verdict.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Explains a Conditional Access block as one that will be refused every time' {
+            InModuleScope 'OmadaWeb.PS' {
+                (Get-EntraErrorVerdict -ErrorCode '53003').Reason | Should -BeLike '*Conditional Access*'
+            }
+        }
+
+        It 'Explains that a wrong password is not sent again, to avoid smart lockout' {
+            InModuleScope 'OmadaWeb.PS' {
+                (Get-EntraErrorVerdict -ErrorCode '50126').Reason | Should -BeLike '*smart lockout*'
+            }
+        }
+    }
+
+    Context 'Failures the user can still resolve in the open browser window' {
+        It 'Hands <ErrorCode> back to the user without ending the sign-in' -TestCases @(
+            @{ ErrorCode = '50072' }
+            @{ ErrorCode = '50074' }
+            @{ ErrorCode = '50158' }
+            @{ ErrorCode = '50076' }
+            @{ ErrorCode = '50079' }
+        ) {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ ErrorCode = $ErrorCode } {
+                $Verdict = Get-EntraErrorVerdict -ErrorCode $ErrorCode
+
+                $Verdict.IsError | Should -BeTrue
+                $Verdict.Action | Should -Be 'Manual'
+                $Verdict.IsTerminal | Should -BeFalse
+                $Verdict.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Codes this module has never seen' {
+        # Microsoft adds error codes, so the list above cannot be exhaustive. An unrecognized code
+        # has to fail safe and name itself, not be treated as a healthy page.
+        It 'Fails safe and names the code' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Verdict = Get-EntraErrorVerdict -ErrorCode '90210'
+
+                $Verdict.IsError | Should -BeTrue
+                $Verdict.Action | Should -Be 'Manual'
+                $Verdict.IsTerminal | Should -BeFalse
+                $Verdict.Reason | Should -BeLike '*AADSTS90210*'
+            }
+        }
+    }
+
+    Context 'The shapes the page writes the code in' {
+        It 'Reads the same failure from <ErrorCode>' -TestCases @(
+            @{ ErrorCode = '53003' }
+            @{ ErrorCode = 'AADSTS53003' }
+            @{ ErrorCode = '  53003  ' }
+        ) {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ ErrorCode = $ErrorCode } {
+                $Verdict = Get-EntraErrorVerdict -ErrorCode $ErrorCode
+
+                $Verdict.Numeric | Should -Be 53003
+                $Verdict.Action | Should -Be 'Stop'
+            }
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Get-EntraSignInProbeScript.Tests.ps1
+++ b/Tests/Unit/Get-EntraSignInProbeScript.Tests.ps1
@@ -33,6 +33,31 @@ Describe 'Get-EntraSignInProbeScript' -Tag 'Unit' {
         }
     }
 
+    Context 'Built once' {
+        It 'Hands out the same script rather than building it again' {
+            # It is built from the selector table and from nothing else, and the sign-in reads the
+            # page again and again on the WebView2 UI thread while a user works through it.
+            InModuleScope 'OmadaWeb.PS' {
+                $Script:EntraSignInProbeScript = $null
+
+                $First = Get-EntraSignInProbeScript
+                $Second = Get-EntraSignInProbeScript
+
+                $Script:EntraSignInProbeScript | Should -Not -BeNullOrEmpty -Because 'the cache is populated before the first call returns'
+                [object]::ReferenceEquals($First, $Second) | Should -BeTrue
+            }
+        }
+
+        It 'Rebuilds from the selector table when that table changes' {
+            InModuleScope 'OmadaWeb.PS' {
+                # Import-Module -Force re-runs the module file, which clears the cache. Without that
+                # an edited selector table would keep serving the script made from the old one.
+                $Script:EntraSignInProbeScript = $null
+                Get-EntraSignInProbeScript | Should -BeLike '*i0116*'
+            }
+        }
+    }
+
     Context 'One selector table, not two' {
         It 'Looks for every element id the rules are written against' {
             # The script and the rules would drift apart the moment either kept its own copy of the

--- a/Tests/Unit/Get-EntraSignInProbeScript.Tests.ps1
+++ b/Tests/Unit/Get-EntraSignInProbeScript.Tests.ps1
@@ -1,0 +1,74 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Get-EntraSignInProbeScript' -Tag 'Unit' {
+
+    Context 'The shape the call site expects' {
+        It 'Is a self-invoking expression, because it is passed to ExecuteScriptAsync unchanged' {
+            InModuleScope 'OmadaWeb.PS' {
+                (Get-EntraSignInProbeScript).TrimEnd() | Should -BeLike '*})();'
+            }
+        }
+
+        It 'Leaves no placeholder unreplaced' {
+            InModuleScope 'OmadaWeb.PS' {
+                Get-EntraSignInProbeScript | Should -Not -BeLike '*__*__*'
+            }
+        }
+
+        It 'Reports every member the rules read from it' {
+            InModuleScope 'OmadaWeb.PS' {
+                $ProbeScript = Get-EntraSignInProbeScript
+
+                foreach ($Member in 'ids', 'visibleIds', 'errorCode', 'errorCodeText', 'proofs', 'proofOptionCount', 'accountTiles', 'hasOtherTile', 'displaySign', 'hasVisiblePasswordInput', 'hasVisibleEmailInput') {
+                    $ProbeScript | Should -BeLike ("*{0}:*" -f $Member) -Because "Resolve-EntraSignInScreen reads $Member off the snapshot"
+                }
+            }
+        }
+    }
+
+    Context 'One selector table, not two' {
+        It 'Looks for every element id the rules are written against' {
+            # The script and the rules would drift apart the moment either kept its own copy of the
+            # selectors, so both read $Script:EntraSignInElementId and this proves the script does.
+            InModuleScope 'OmadaWeb.PS' {
+                $ProbeScript = Get-EntraSignInProbeScript
+
+                foreach ($ElementId in $Script:EntraSignInElementId.Values) {
+                    $ProbeScript | Should -BeLike ("*{0}*" -f $ElementId) -Because "$ElementId is in the selector table"
+                }
+            }
+        }
+    }
+
+    Context 'Language independence' {
+        It 'Never compares anything on the page against the English word <Word>' {
+            # This is the regression guard for the defect at the heart of issue #18: the previous
+            # implementation identified the 'Stay signed in?' screen by comparing its buttons to
+            # 'Yes' and 'No', and looked for sign-in failures by searching the page for 'incorrect'
+            # and 'wrong password'. On any tenant not served in English those comparisons match
+            # nothing, and credential autofill silently did nothing at all.
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Word = $Word } {
+                Get-EntraSignInProbeScript | Should -Not -BeLike ("*{0}*" -f $Word)
+            }
+        } -TestCases @(
+            @{ Word = 'Next' }
+            @{ Word = 'Sign in' }
+            @{ Word = "'Yes'" }
+            @{ Word = 'incorrect' }
+            @{ Word = 'wrong password' }
+            @{ Word = 'not recognized' }
+            @{ Word = 'ComputedAccessibleLabel' }
+        )
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Invoke-BrowserAuthentication.Tests.ps1
+++ b/Tests/Unit/Invoke-BrowserAuthentication.Tests.ps1
@@ -138,6 +138,77 @@ Describe 'Invoke-BrowserAuthentication' -Tag 'Unit' {
             }
         }
     }
+
+    Context 'Preferred MFA method' {
+        It 'Should carry -PreferredMfaMethod onto the session context the sign-in reads' {
+            InModuleScope 'OmadaWeb.PS' {
+                # The WebView2 sign-in runs inside a blocking WinForm dialog whose event handlers
+                # cannot see the call stack, so the session context is the only way the choice
+                # reaches Resolve-EntraSignInScreen.
+                Mock Get-DataFromWebView2 { $SessionContext.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' } }
+
+                $RequestContext = New-TestRequestContext -Key 'unit-test-preferred-mfa-method' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    SkipCookieCache    = $true
+                    PreferredMfaMethod = 'PhoneAppOTP'
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.SessionContext.PreferredMfaMethod | Should -Be 'PhoneAppOTP'
+            }
+        }
+
+        It 'Should clear a preference left over from an earlier call' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-DataFromWebView2 { $SessionContext.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' } }
+
+                $RequestContext = New-TestRequestContext -Key 'unit-test-preferred-mfa-method-cleared' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    SkipCookieCache    = $true
+                    PreferredMfaMethod = 'PhoneAppOTP'
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.SessionContext.AuthCookie = $null
+                $RequestContext.BoundParams.Remove('PreferredMfaMethod')
+                $RequestContext.BoundParams.Headers = @{}
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.SessionContext.PreferredMfaMethod | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Should not forward -PreferredMfaMethod to the underlying web cmdlet' {
+            InModuleScope 'OmadaWeb.PS' {
+                # It configures this module's sign-in automation; Invoke-RestMethod has never heard
+                # of it and would fail the call.
+                $RequestContext = New-TestRequestContext -Key 'unit-test-preferred-mfa-not-forwarded' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    PreferredMfaMethod = 'PhoneAppOTP'
+                    Uri                = 'http://localhost:19000/'
+                }
+
+                (Set-RequestParameter -RequestContext $RequestContext).Keys | Should -Not -Contain 'PreferredMfaMethod'
+            }
+        }
+
+        It 'Should offer only the method identifiers Entra ID uses' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Parameter = (Set-DynamicParameter -FunctionName 'Invoke-RestMethod')['PreferredMfaMethod']
+                $ValidateSet = $Parameter.Attributes.Where({ $_ -is [System.Management.Automation.ValidateSetAttribute] })[0]
+
+                $ValidateSet.ValidValues | Should -Contain 'PhoneAppNotification'
+                $ValidateSet.ValidValues | Should -Contain 'PhoneAppOTP'
+                $ValidateSet.ValidValues | Should -Contain 'OneWaySMS'
+            }
+        }
+    }
 }
 
 AfterAll {

--- a/Tests/Unit/Invoke-OmadaRequest.PreferredMfaMethod.Tests.ps1
+++ b/Tests/Unit/Invoke-OmadaRequest.PreferredMfaMethod.Tests.ps1
@@ -35,6 +35,36 @@ Describe 'Invoke-OmadaRequest -PreferredMfaMethod validation' -Tag 'Unit' {
         } | Should -Throw -ExpectedMessage "*got 'Basic'*"
     }
 
+    It 'Accepts it on a Browser session that is already running on WebView2' {
+        # -AuthenticationType Browser keeps using WebView2 once a session has used it, without
+        # -UseWebView2 being supplied again - so refusing the parameter on that call would refuse it
+        # on exactly the sign-in it applies to. The sign-in itself is stubbed out; all this asserts
+        # is that the parameter check is not what stops the call.
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-DataFromWebView2 {}
+            Mock Write-OmadaDeprecationWarning {}
+
+            $Uri = [System.Uri]::new('http://localhost:19999/api/unit-test')
+            $Credential = New-Object System.Management.Automation.PSCredential('someone@contoso.com', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+
+            # The same key the request will compute for itself, so the seeded state is the state it
+            # finds.
+            $SessionKey = Get-OmadaSessionKey -Uri $Uri -AuthenticationType 'Browser' -Credential $Credential -SessionKey $null
+            (Get-OmadaSessionContext -Key $SessionKey -AuthorityHost $Uri.Host).WebView2Used = $true
+
+            $Failure = $null
+            try {
+                Invoke-OmadaRestMethod -Uri $Uri.AbsoluteUri -AuthenticationType 'Browser' -Credential $Credential -PreferredMfaMethod 'PhoneAppOTP' -ErrorAction Stop
+            }
+            catch {
+                $Failure = $_.Exception.Message
+            }
+
+            # It still fails - nothing is listening on that port - but not on the parameter.
+            $Failure | Should -Not -BeLike '*-PreferredMfaMethod only applies*'
+        }
+    }
+
     It 'Refuses before any request is made' {
         # Nothing listens on the port above, so a call that got as far as the network would fail
         # with a connection error rather than with the parameter error.

--- a/Tests/Unit/Invoke-OmadaRequest.PreferredMfaMethod.Tests.ps1
+++ b/Tests/Unit/Invoke-OmadaRequest.PreferredMfaMethod.Tests.ps1
@@ -1,0 +1,49 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    $Script:Credential = New-Object System.Management.Automation.PSCredential('someone@contoso.com', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+
+    # No listener is started on purpose. The check under test runs before any request is made, so a
+    # test that reached the network would be testing something else.
+    $Script:Uri = 'http://localhost:19999/api/unit-test'
+}
+
+Describe 'Invoke-OmadaRequest -PreferredMfaMethod validation' -Tag 'Unit' {
+
+    # -PreferredMfaMethod drives the Entra ID sign-in screens, which only the WebView2 engine
+    # automates. Every other authentication type would accept the parameter and quietly do nothing
+    # with it, and a preference that silently does nothing is worse than one that is refused.
+    It 'Refuses -PreferredMfaMethod with -AuthenticationType <AuthenticationType>' -TestCases @(
+        @{ AuthenticationType = 'Basic' }
+        @{ AuthenticationType = 'Windows' }
+        @{ AuthenticationType = 'Integrated' }
+        @{ AuthenticationType = 'None' }
+    ) {
+        {
+            Invoke-OmadaRestMethod -Uri $Script:Uri -AuthenticationType $AuthenticationType -Credential $Script:Credential -PreferredMfaMethod 'PhoneAppOTP' -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage '*-PreferredMfaMethod only applies to -AuthenticationType WebView2*'
+    }
+
+    It 'Names the authentication type that was supplied' {
+        {
+            Invoke-OmadaRestMethod -Uri $Script:Uri -AuthenticationType 'Basic' -Credential $Script:Credential -PreferredMfaMethod 'PhoneAppOTP' -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage "*got 'Basic'*"
+    }
+
+    It 'Refuses before any request is made' {
+        # Nothing listens on the port above, so a call that got as far as the network would fail
+        # with a connection error rather than with the parameter error.
+        {
+            Invoke-OmadaRestMethod -Uri $Script:Uri -AuthenticationType 'Basic' -Credential $Script:Credential -PreferredMfaMethod 'PhoneAppOTP' -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage '*-PreferredMfaMethod*'
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Invoke-WebView2MicrosoftLogin.Scripts.Tests.ps1
+++ b/Tests/Unit/Invoke-WebView2MicrosoftLogin.Scripts.Tests.ps1
@@ -68,18 +68,30 @@ Describe 'Invoke-WebView2MicrosoftLogin JavaScript snippets' -Tag 'Unit' {
     }
 
     Context 'Agreement with the page probe' {
-        It 'Clicks only an account tile it can see' {
-            # Get-EntraSignInProbeScript reports only visible tiles, so the resolver can only ever
-            # choose a visible one. Clicking the first element carrying that data-test-id regardless
-            # would let a hidden namesake take the click - and that failure is invisible from here,
-            # because the click reports success and so restarts the stall clock. The driver would sit
-            # on the same page clicking nothing for as long as the window stayed open.
-            $Snippet = $Script:Snippets['ClickAccountTileScript']
+        # The probe reports only what a user could see and act on, so a click that does not apply the
+        # same test acts on something the resolver never chose. That failure is invisible from here -
+        # the click reports success, which restarts the stall clock - so the driver would sit on the
+        # same page doing nothing for as long as the window stayed open. Worse on the method picker,
+        # where a miscount shifts every index and silently selects a different verification method.
+        It 'Filters <Name> through the shared visibility test' -TestCases @(
+            @{ Name = 'ClickAccountTileScript'; Applied = 'isVisible(elements[i])' }
+            @{ Name = 'ClickProofOptionScript'; Applied = 'isVisible(options[i])' }
+        ) {
+            $Snippet = $Script:Snippets[$Name]
 
             $Snippet | Should -Not -BeNullOrEmpty
-            $Snippet | Should -Match 'getComputedStyle'
-            $Snippet | Should -Match "aria-hidden"
-            $Snippet | Should -Match 'isVisible\(elements\[i\]\)'
+            $Snippet | Should -BeLike '*Get-EntraElementVisibilityScript*' -Because 'the definition must be the shared one, not a copy that can drift'
+            # Contains, not -BeLike: the square brackets of an array index are wildcard character
+            # classes, so the pattern would silently look for something else entirely.
+            $Snippet.Contains($Applied) | Should -BeTrue -Because "$Name must apply isVisible as '$Applied'"
+        }
+
+        It 'Uses one definition of visibility everywhere it is needed' {
+            InModuleScope 'OmadaWeb.PS' {
+                # The probe injects it too, so all three agree by construction rather than by review.
+                Get-EntraSignInProbeScript | Should -BeLike '*function isVisible(element)*'
+                (Get-EntraElementVisibilityScript) | Should -BeLike '*getComputedStyle*'
+            }
         }
     }
 

--- a/Tests/Unit/Invoke-WebView2MicrosoftLogin.Scripts.Tests.ps1
+++ b/Tests/Unit/Invoke-WebView2MicrosoftLogin.Scripts.Tests.ps1
@@ -14,6 +14,7 @@ Describe 'Invoke-WebView2MicrosoftLogin JavaScript snippets' -Tag 'Unit' {
         # command keeps this test working against both the source module and the built one.
         $Definition = InModuleScope 'OmadaWeb.PS' { (Get-Command Invoke-WebView2MicrosoftLogin).Definition }
 
+        $Script:Definition = $Definition
         $Script:Snippets = @{}
 
         foreach ($Match in [regex]::Matches($Definition, '\$(?<Name>\w+Script)\s*=\s*@"\r?\n(?<Body>.*?)\r?\n"@', 'Singleline')) {
@@ -23,16 +24,15 @@ Describe 'Invoke-WebView2MicrosoftLogin JavaScript snippets' -Tag 'Unit' {
 
     Context 'Snippets that the call sites invoke with arguments' {
         # These are appended with an argument list, for example
-        # "$clickElementScript($(ConvertTo-JavaScriptLiteral $SubmitButtonId))". They must therefore
+        # "$ClickElementScript($(ConvertTo-JavaScriptLiteral $SubmitId))". They must therefore
         # stay bare function expressions. A snippet that self-invokes turns the argument list into a
         # second, separate expression statement, and ExecuteScriptAsync then returns the value of
         # that trailing expression instead of the function result.
         It 'Leaves <Name> a bare function expression' -TestCases @(
-            @{ Name = 'setElementValueScript' }
-            @{ Name = 'clickElementScript' }
-            @{ Name = 'isElementVisibleScript' }
-            @{ Name = 'getElementByDataTestIdScript' }
-            @{ Name = 'getElementPropertyScript' }
+            @{ Name = 'SetElementValueScript' }
+            @{ Name = 'ClickElementScript' }
+            @{ Name = 'ClickAccountTileScript' }
+            @{ Name = 'ClickProofOptionScript' }
         ) {
             $Snippet = $Script:Snippets[$Name]
 
@@ -46,10 +46,7 @@ Describe 'Invoke-WebView2MicrosoftLogin JavaScript snippets' -Tag 'Unit' {
         # These take no arguments and are passed to ExecuteScriptAsync unchanged, so they have to
         # invoke themselves.
         It 'Keeps <Name> self-invoking' -TestCases @(
-            @{ Name = 'getAllIdsScript' }
-            @{ Name = 'getMfaElementPropertyScript' }
-            @{ Name = 'clickUseAnotherAccountScript' }
-            @{ Name = 'checkForErrorScript' }
+            @{ Name = 'ClickUseAnotherAccountScript' }
         ) {
             $Snippet = $Script:Snippets[$Name]
 
@@ -58,15 +55,35 @@ Describe 'Invoke-WebView2MicrosoftLogin JavaScript snippets' -Tag 'Unit' {
         }
     }
 
-    Context 'Composed property lookup' {
-        It 'Builds a single call expression for the stay-signed-in button labels' {
-            InModuleScope 'OmadaWeb.PS' -Parameters @{ Snippet = $Script:Snippets['getElementPropertyScript'] } {
-                $ComposedScript = "$Snippet($(ConvertTo-JavaScriptLiteral 'idBtn_Back'), $(ConvertTo-JavaScriptLiteral 'textContent'))"
+    Context 'Composed call expressions' {
+        It 'Builds a single call expression for a click' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Snippet = $Script:Snippets['ClickElementScript'] } {
+                $ComposedScript = "$Snippet($(ConvertTo-JavaScriptLiteral 'idBtn_Back'))"
 
-                # One statement: the function expression immediately applied to its two arguments.
-                $ComposedScript | Should -BeLike '*})("idBtn_Back", "textContent")'
+                # One statement: the function expression immediately applied to its argument.
+                $ComposedScript | Should -BeLike '*})("idBtn_Back")'
                 $ComposedScript | Should -Not -BeLike '*})();*'
             }
+        }
+    }
+
+    Context 'Language independence' {
+        # The defect at the heart of issue #18: the 'Stay signed in?' screen used to be recognized by
+        # reading the text of its two buttons and comparing it to 'Yes' and 'No', and sign-in
+        # failures by sweeping the page for 'incorrect' and 'wrong password'. On a tenant served in
+        # any other language those comparisons match nothing, and credential autofill silently did
+        # nothing at all. The screen is now recognized by KmsiCheckboxField and failures by the
+        # numeric error code, so nothing in this function may read rendered text again.
+        It 'Does not compare rendered button text against a literal, as the old <Description> did' -TestCases @(
+            @{ Description = "'Stay signed in?' button comparison"; Pattern = '-like\s+"\*(Yes|No)\*"' }
+            @{ Description = 'button-label reader'; Pattern = 'BackButtonText' }
+            @{ Description = 'textContent lookup'; Pattern = 'textContent|innerText' }
+            # Quoted, so that describing the old behavior in a comment does not fail the test that
+            # guards against it.
+            @{ Description = 'English error-word sweep'; Pattern = "(?i)[`"']wrong password[`"']|[`"']not recognized[`"']|[`"']incorrect[`"']" }
+            @{ Description = 'accessible-label comparison'; Pattern = 'ComputedAccessibleLabel' }
+        ) {
+            $Script:Definition | Should -Not -Match $Pattern
         }
     }
 }

--- a/Tests/Unit/Invoke-WebView2MicrosoftLogin.Scripts.Tests.ps1
+++ b/Tests/Unit/Invoke-WebView2MicrosoftLogin.Scripts.Tests.ps1
@@ -67,6 +67,22 @@ Describe 'Invoke-WebView2MicrosoftLogin JavaScript snippets' -Tag 'Unit' {
         }
     }
 
+    Context 'Agreement with the page probe' {
+        It 'Clicks only an account tile it can see' {
+            # Get-EntraSignInProbeScript reports only visible tiles, so the resolver can only ever
+            # choose a visible one. Clicking the first element carrying that data-test-id regardless
+            # would let a hidden namesake take the click - and that failure is invisible from here,
+            # because the click reports success and so restarts the stall clock. The driver would sit
+            # on the same page clicking nothing for as long as the window stayed open.
+            $Snippet = $Script:Snippets['ClickAccountTileScript']
+
+            $Snippet | Should -Not -BeNullOrEmpty
+            $Snippet | Should -Match 'getComputedStyle'
+            $Snippet | Should -Match "aria-hidden"
+            $Snippet | Should -Match 'isVisible\(elements\[i\]\)'
+        }
+    }
+
     Context 'Language independence' {
         # The defect at the heart of issue #18: the 'Stay signed in?' screen used to be recognized by
         # reading the text of its two buttons and comparing it to 'Yes' and 'No', and sign-in

--- a/Tests/Unit/Invoke-WebView2MicrosoftLogin.Scripts.Tests.ps1
+++ b/Tests/Unit/Invoke-WebView2MicrosoftLogin.Scripts.Tests.ps1
@@ -86,6 +86,21 @@ Describe 'Invoke-WebView2MicrosoftLogin JavaScript snippets' -Tag 'Unit' {
             $Snippet.Contains($Applied) | Should -BeTrue -Because "$Name must apply isVisible as '$Applied'"
         }
 
+        It 'Leaves no snippet that acts on the page without the shared visibility test' {
+            # The general rule, asserted over whatever snippets exist rather than over a list that
+            # has to be remembered: anything that types into the page or clicks it must answer false
+            # when the element is not actionable, because the driver reads that answer as "the page
+            # moved" and restarts the stall clock on it. Four snippets were found missing this one
+            # at a time; this is what stops a fifth being added.
+            $Acting = $Script:Snippets.Keys | Where-Object { $_ -match 'Click|SetElementValue' }
+
+            ($Acting | Measure-Object).Count | Should -BeGreaterThan 0
+            foreach ($Name in $Acting) {
+                $Script:Snippets[$Name] | Should -BeLike '*Get-EntraElementVisibilityScript*' -Because "$Name acts on the page, so it must apply the shared visibility test"
+                $Script:Snippets[$Name] | Should -BeLike '*isVisible(*' -Because "$Name must actually call it, not merely include it"
+            }
+        }
+
         It 'Uses one definition of visibility everywhere it is needed' {
             InModuleScope 'OmadaWeb.PS' {
                 # The probe injects it too, so all three agree by construction rather than by review.

--- a/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
+++ b/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
@@ -536,6 +536,38 @@ Describe 'Resolve-EntraSignInScreen' -Tag 'Unit' {
         }
     }
 
+    Context 'Elements the page is not showing' {
+        # The sign-in app leaves elements behind after hiding them - the username field is still in
+        # the markup on the password screen - so presence says nothing about which screen this is.
+        # Acting on a hidden element does nothing while reporting success, which restarts the stall
+        # clock, so the driver cannot tell that apart from working. Every screen below is therefore
+        # given its own elements as present-but-hidden, and none of them may produce an action.
+        It 'Does not act on a hidden <Screen>' -TestCases @(
+            @{ Screen = 'username screen'; Ids = @('i0116', 'idSIButton9') }
+            @{ Screen = 'password screen'; Ids = @('i0118', 'idSIButton9') }
+            @{ Screen = 'one-time code screen'; Ids = @('idTxtBx_SAOTCC_OTC', 'idSubmit_SAOTCC_Continue') }
+            @{ Screen = 'method picker'; Ids = @('idDiv_SAOTCS_Proofs') }
+            @{ Screen = 'approval number'; Ids = @('idRemoteNGC_DisplaySign') }
+            @{ Screen = 'stay signed in button'; Ids = @('KmsiCheckboxField', 'idBtn_Back') }
+        ) {
+            $PageState = New-PageState @{ ids = $Ids; visibleIds = @() }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Action | Should -Be 'Wait' -Because 'nothing on this page can be clicked or typed into'
+            }
+        }
+
+        It 'Does not report a hidden resend link as a failed approval' {
+            $PageState = New-PageState @{ ids = @('idA_SAASDS_Resend'); visibleIds = @() }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                (Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -MfaRequestDisplayed).Screen | Should -Not -Be 'MfaRetry'
+            }
+        }
+    }
+
     Context 'Language independence' {
         It 'Decides identically for every screen whatever language the tenant is served in' {
             # The snapshot the decision is made from carries no rendered text at all, so a tenant

--- a/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
+++ b/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
@@ -364,6 +364,28 @@ Describe 'Resolve-EntraSignInScreen' -Tag 'Unit' {
             }
         }
 
+        It 'Refuses to click when no offered method says which method it is' {
+            # The count check passes here - two methods, two options - so this is the case that
+            # check cannot catch. Clicking anyway would select a method by position alone.
+            $PageState = New-PageState @{
+                ids              = @('idDiv_SAOTCS_Proofs')
+                visibleIds       = @('idDiv_SAOTCS_Proofs')
+                proofs           = @(
+                    [pscustomobject]@{ authMethodId = ''; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = ''; isDefault = $false }
+                )
+                proofOptionCount = 2
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Screen | Should -Be 'MethodPicker'
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+
         It 'Refuses to click by position when the options and the methods do not line up' {
             # The option elements carry no identifier naming the method, so position is the only
             # link between them. A page where that link is broken is a page to leave alone.

--- a/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
+++ b/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
@@ -1,0 +1,480 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    # Every snapshot the probe script produces carries all of these members, so the helper does too:
+    # a test built on a half-populated object would pass for reasons the real page never reproduces.
+    function New-PageState {
+        param([hashtable]$Override = @{})
+
+        $State = [ordered]@{
+            ids                     = @()
+            visibleIds              = @()
+            errorCode               = '0'
+            errorCodeText           = ''
+            proofs                  = @()
+            proofOptionCount        = 0
+            accountTiles            = @()
+            hasOtherTile            = $false
+            displaySign             = $null
+            hasVisiblePasswordInput = $false
+            hasVisibleEmailInput    = $false
+            path                    = '/common/login'
+        }
+
+        foreach ($Key in $Override.Keys) {
+            $State[$Key] = $Override[$Key]
+        }
+
+        return [pscustomobject]$State
+    }
+}
+
+Describe 'Resolve-EntraSignInScreen' -Tag 'Unit' {
+
+    BeforeEach {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:PreferredMfaMethodWarningIssued = $false
+        }
+    }
+
+    Context 'Username and account discovery' {
+        It 'Fills in the user name and submits it' {
+            $PageState = New-PageState @{ ids = @('i0116', 'idSIButton9'); visibleIds = @('i0116', 'idSIButton9') }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'UsernameEntry'
+                $Decision.Action | Should -Be 'SetValueAndClick'
+                $Decision.ElementId | Should -Be 'i0116'
+                $Decision.SubmitId | Should -Be 'idSIButton9'
+                $Decision.ValueSource | Should -Be 'UserName'
+                $Decision.Value | Should -Be 'someone@contoso.com'
+            }
+        }
+
+        It 'Ignores a username field the page renders but hides' {
+            # The password screen keeps i0116 in the markup, hidden. Acting on it there would retype
+            # the user name over the password step.
+            $PageState = New-PageState @{ ids = @('i0116', 'idSIButton9'); visibleIds = @('idSIButton9') }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                (Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword).Screen | Should -Not -Be 'UsernameEntry'
+            }
+        }
+    }
+
+    Context 'Pick an account' {
+        It 'Selects the tile of the account the credential names' {
+            $PageState = New-PageState @{
+                ids          = @('idSIButton9')
+                visibleIds   = @('idSIButton9')
+                accountTiles = @(
+                    [pscustomobject]@{ index = 0; testId = 'other@contoso.com' }
+                    [pscustomobject]@{ index = 1; testId = 'someone@contoso.com' }
+                )
+                hasOtherTile = $true
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'AccountPicker'
+                $Decision.Action | Should -Be 'ClickAccountTile'
+                $Decision.Value | Should -Be 'someone@contoso.com'
+            }
+        }
+
+        It 'Falls back to "use another account" when no tile matches' {
+            $PageState = New-PageState @{
+                accountTiles = @([pscustomobject]@{ index = 0; testId = 'other@contoso.com' })
+                hasOtherTile = $true
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'AccountPicker'
+                $Decision.Action | Should -Be 'ClickUseAnotherAccount'
+            }
+        }
+
+        It 'Waits and explains itself when neither a matching tile nor the fallback exists' {
+            $PageState = New-PageState @{
+                accountTiles = @([pscustomobject]@{ index = 0; testId = 'other@contoso.com' })
+                hasOtherTile = $false
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Password' {
+        It 'Fills in the password without ever putting it in the decision' {
+            # The decision object reaches the verbose stream; the secret must not travel with it.
+            $PageState = New-PageState @{ ids = @('i0118', 'idSIButton9'); visibleIds = @('i0118', 'idSIButton9') }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'PasswordEntry'
+                $Decision.Action | Should -Be 'SetValueAndClick'
+                $Decision.ElementId | Should -Be 'i0118'
+                $Decision.SubmitId | Should -Be 'idSIButton9'
+                $Decision.ValueSource | Should -Be 'Password'
+                $Decision.Value | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Passwordless credentials' {
+        It 'Switches to another sign-in method rather than submitting an empty password' {
+            $PageState = New-PageState @{
+                ids        = @('i0118', 'idSIButton9', 'idA_PWD_SwitchToCredPicker')
+                visibleIds = @('i0118', 'idSIButton9', 'idA_PWD_SwitchToCredPicker')
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Screen | Should -Be 'SwitchToPasswordless'
+                $Decision.Action | Should -Be 'Click'
+                $Decision.ElementId | Should -Be 'idA_PWD_SwitchToCredPicker'
+            }
+        }
+
+        It 'Uses the signInAnotherWay link when the credential picker link is absent' {
+            $PageState = New-PageState @{
+                ids        = @('i0118', 'idSIButton9', 'signInAnotherWay')
+                visibleIds = @('i0118', 'idSIButton9', 'signInAnotherWay')
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                (Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com').ElementId | Should -Be 'signInAnotherWay'
+            }
+        }
+
+        It 'Never submits a blank password, whatever the page offers' {
+            # The negative criterion of issue #18: an empty-password credential must not spend one of
+            # the attempts before smart lockout on a value that cannot be right.
+            $Variant = @(
+                @('i0118', 'idSIButton9')
+                @('i0118', 'idSIButton9', 'idA_PWD_SwitchToCredPicker')
+                @('i0118', 'idSIButton9', 'signInAnotherWay')
+                @('i0118', 'idSIButton9', 'idA_PWD_ForgotPassword')
+            )
+
+            foreach ($Ids in $Variant) {
+                $PageState = New-PageState @{ ids = $Ids; visibleIds = $Ids }
+
+                InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                    $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                    $Decision.ValueSource | Should -Not -Be 'Password'
+                    ($Decision.Action -eq 'SetValueAndClick' -and $Decision.ElementId -eq 'i0118') | Should -BeFalse
+                }
+            }
+        }
+
+        It 'Waits, saying so, when a password is required and none can be supplied' {
+            $PageState = New-PageState @{ ids = @('i0118', 'idSIButton9'); visibleIds = @('i0118', 'idSIButton9') }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Screen | Should -Be 'PasswordRequired'
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.Reason | Should -BeLike '*empty password*'
+            }
+        }
+    }
+
+    Context 'Approval numbers' {
+        It 'Reads the number from <ElementId>' -TestCases @(
+            @{ ElementId = 'idRemoteNGC_DisplaySign' }
+            @{ ElementId = 'idRichContext_DisplaySign' }
+        ) {
+            # Passwordless sign-in uses the first, Authenticator number match the second. Only the
+            # second was ever read before, which is why passwordless sign-in stalled silently.
+            $PageState = New-PageState @{ ids = @($ElementId); visibleIds = @($ElementId); displaySign = '42' }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState; ElementId = $ElementId } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Screen | Should -Be 'ApprovalNumber'
+                $Decision.Action | Should -Be 'ReadNumber'
+                $Decision.ElementId | Should -Be $ElementId
+                $Decision.Value | Should -Be '42'
+            }
+        }
+
+        It 'Reports a failed approval as one to retry' {
+            $PageState = New-PageState @{ ids = @('idA_SAASDS_Resend'); visibleIds = @('idA_SAASDS_Resend') }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -MfaRequestDisplayed
+
+                $Decision.Screen | Should -Be 'MfaRetry'
+                $Decision.Action | Should -Be 'Retry'
+            }
+        }
+
+        It 'Does not mistake a resend link next to a live request for a failed one' {
+            $PageState = New-PageState @{
+                ids         = @('idA_SAASDS_Resend', 'idRichContext_DisplaySign')
+                visibleIds  = @('idA_SAASDS_Resend', 'idRichContext_DisplaySign')
+                displaySign = '42'
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                (Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -MfaRequestDisplayed).Screen | Should -Be 'ApprovalNumber'
+            }
+        }
+    }
+
+    Context 'One-time code' {
+        It 'Waits for a code that only a person can supply, and says so' {
+            $PageState = New-PageState @{
+                ids        = @('idTxtBx_SAOTCC_OTC', 'idSubmit_SAOTCC_Continue')
+                visibleIds = @('idTxtBx_SAOTCC_OTC', 'idSubmit_SAOTCC_Continue')
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Screen | Should -Be 'OneTimeCode'
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Choose a way to sign in' {
+        It 'Clicks the option of the most secure offered method' {
+            $PageState = New-PageState @{
+                ids              = @('idDiv_SAOTCS_Proofs')
+                visibleIds       = @('idDiv_SAOTCS_Proofs')
+                proofs           = @(
+                    [pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'PhoneAppNotification'; isDefault = $false }
+                )
+                proofOptionCount = 2
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Screen | Should -Be 'MethodPicker'
+                $Decision.Action | Should -Be 'ClickProofOption'
+                $Decision.Index | Should -Be 1
+                $Decision.Value | Should -Be 'PhoneAppNotification'
+            }
+        }
+
+        It 'Honours -PreferredMfaMethod' {
+            $PageState = New-PageState @{
+                ids              = @('idDiv_SAOTCS_Proofs')
+                visibleIds       = @('idDiv_SAOTCS_Proofs')
+                proofs           = @(
+                    [pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'PhoneAppNotification'; isDefault = $false }
+                )
+                proofOptionCount = 2
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                (Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -PreferredMfaMethod 'OneWaySMS').Index | Should -Be 0
+            }
+        }
+
+        It 'Refuses to click by position when the options and the methods do not line up' {
+            # The option elements carry no identifier naming the method, so position is the only
+            # link between them. A page where that link is broken is a page to leave alone.
+            $PageState = New-PageState @{
+                ids              = @('idDiv_SAOTCS_Proofs')
+                visibleIds       = @('idDiv_SAOTCS_Proofs')
+                proofs           = @(
+                    [pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'PhoneAppNotification'; isDefault = $false }
+                )
+                proofOptionCount = 5
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.Reason | Should -BeLike '*cannot be selected safely*'
+            }
+        }
+    }
+
+    Context 'Stay signed in' {
+        It 'Declines by clicking the back button, with no button text read at all' {
+            # This is the screen that used to be recognized by comparing its buttons to the words
+            # 'Yes' and 'No', which is why credential autofill did nothing on a tenant served in any
+            # other language. The checkbox is on no other screen and is not localized.
+            $PageState = New-PageState @{
+                ids        = @('KmsiCheckboxField', 'idBtn_Back', 'idSIButton9')
+                visibleIds = @('KmsiCheckboxField', 'idBtn_Back', 'idSIButton9')
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'StaySignedIn'
+                $Decision.Action | Should -Be 'Click'
+                $Decision.ElementId | Should -Be 'idBtn_Back'
+            }
+        }
+    }
+
+    Context 'Errors the server reports' {
+        It 'Ends the sign-in on <ErrorCode> instead of retrying it' -TestCases @(
+            @{ ErrorCode = '53003' }
+            @{ ErrorCode = '50126' }
+            @{ ErrorCode = '50053' }
+            @{ ErrorCode = '50055' }
+        ) {
+            $PageState = New-PageState @{
+                ids        = @('i0118', 'idSIButton9')
+                visibleIds = @('i0118', 'idSIButton9')
+                errorCode  = $ErrorCode
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState; ErrorCode = $ErrorCode } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'SignInError'
+                $Decision.Action | Should -Be 'Stop'
+                $Decision.IsTerminal | Should -BeTrue
+                $Decision.Code | Should -Be ("AADSTS{0}" -f $ErrorCode)
+            }
+        }
+
+        It 'Reads the code from sErrorCode when iErrorCode is absent' {
+            $PageState = New-PageState @{ errorCode = ''; errorCodeText = '53003' }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                (Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com').Action | Should -Be 'Stop'
+            }
+        }
+
+        It 'Hands a registration interrupt back to the user without ending the sign-in' {
+            $PageState = New-PageState @{ errorCode = '50072' }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.IsTerminal | Should -BeFalse
+                $Decision.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Reads the error before acting on a password field that is on the same page' {
+            # A refused password screen is rendered again, with the field intact. Filling it in
+            # before reading the code is exactly how an account reaches smart lockout.
+            $PageState = New-PageState @{
+                ids        = @('i0118', 'idSIButton9', 'passwordError')
+                visibleIds = @('i0118', 'idSIButton9', 'passwordError')
+                errorCode  = '50126'
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.ValueSource | Should -Not -Be 'Password'
+                $Decision.Action | Should -Be 'Stop'
+            }
+        }
+    }
+
+    Context 'Pages this module does not recognize' {
+        It 'Waits rather than guessing, so a page mid-navigation is not mistaken for a broken one' {
+            $PageState = New-PageState
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'Unknown'
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Names the renamed field when a password screen no longer carries the id it used to' {
+            $PageState = New-PageState @{ hasVisiblePasswordInput = $true }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'UnrecognizedPasswordScreen'
+                $Decision.Reason | Should -BeLike '*i0118*'
+            }
+        }
+
+        It 'Names the renamed field when an account screen no longer carries the id it used to' {
+            $PageState = New-PageState @{ hasVisibleEmailInput = $true }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'UnrecognizedUserNameScreen'
+                $Decision.Reason | Should -BeLike '*i0116*'
+            }
+        }
+
+        It 'Says the page could not be read when there is no snapshot at all' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Decision = Resolve-EntraSignInScreen -PageState $null -UserName 'someone@contoso.com'
+
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Language independence' {
+        It 'Decides identically for every screen whatever language the tenant is served in' {
+            # The snapshot the decision is made from carries no rendered text at all, so a tenant
+            # served in Dutch or German produces byte-identical input for the same screen. This
+            # asserts the property that makes that true: no member of the snapshot is prose.
+            $Screen = @(
+                @{ ids = @('i0116', 'idSIButton9') }
+                @{ ids = @('i0118', 'idSIButton9') }
+                @{ ids = @('KmsiCheckboxField', 'idBtn_Back', 'idSIButton9') }
+                @{ ids = @('idRemoteNGC_DisplaySign') }
+            )
+
+            foreach ($Definition in $Screen) {
+                $PageState = New-PageState @{ ids = $Definition.ids; visibleIds = $Definition.ids }
+
+                InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                    $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                    $Decision.Screen | Should -Not -Be 'Unknown'
+
+                    # Nothing the decision was made from is text a translator would have touched.
+                    foreach ($Property in $PageState.PSObject.Properties) {
+                        $Property.Name | Should -Not -BeIn @('title', 'buttonText', 'message', 'label')
+                    }
+                }
+            }
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
+++ b/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
@@ -205,6 +205,23 @@ Describe 'Resolve-EntraSignInScreen' -Tag 'Unit' {
             }
         }
 
+        It 'Does not click a "sign in another way" link the page is not showing' {
+            # Entra keeps elements in the markup after hiding them. Clicking a hidden link does
+            # nothing while reporting success, which is the shape of every silent stall on this
+            # screen - and here it would also leave a passwordless account stuck on a password
+            # prompt it can never answer.
+            $Ids = @('i0118', 'idSIButton9', 'idA_PWD_SwitchToCredPicker', 'signInAnotherWay')
+            $PageState = New-PageState @{ ids = $Ids; visibleIds = @('i0118', 'idSIButton9') }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Screen | Should -Be 'PasswordRequired'
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.ValueSource | Should -Not -Be 'Password'
+            }
+        }
+
         It 'Waits, saying so, when a password is required and none can be supplied' {
             $PageState = New-PageState @{ ids = @('i0118', 'idSIButton9'); visibleIds = @('i0118', 'idSIButton9') }
 

--- a/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
+++ b/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
@@ -90,6 +90,25 @@ Describe 'Resolve-EntraSignInScreen' -Tag 'Unit' {
             }
         }
 
+        It 'Matches the tile whatever case Entra ID wrote the account name in' {
+            # PowerShell's -eq is case-insensitive for strings, which is what this relies on, and
+            # what the click helper's own toLowerCase comparison agrees with. Asserted rather than
+            # assumed: -ceq is one character away, and the failure it would cause - falling through
+            # to "use another account" on a tile that was right there - is not obvious from reading
+            # the code.
+            $PageState = New-PageState @{
+                accountTiles = @([pscustomobject]@{ index = 0; testId = 'Someone@Contoso.com' })
+                hasOtherTile = $true
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Action | Should -Be 'ClickAccountTile'
+                $Decision.Value | Should -Be 'Someone@Contoso.com'
+            }
+        }
+
         It 'Falls back to "use another account" when no tile matches' {
             $PageState = New-PageState @{
                 accountTiles = @([pscustomobject]@{ index = 0; testId = 'other@contoso.com' })
@@ -370,15 +389,35 @@ Describe 'Resolve-EntraSignInScreen' -Tag 'Unit' {
             }
         }
 
-        It 'Hands a registration interrupt back to the user without ending the sign-in' {
-            $PageState = New-PageState @{ errorCode = '50072' }
+        It 'Hands <ErrorCode> back to the user at once, without ending the sign-in' -TestCases @(
+            @{ ErrorCode = '50072' }
+            @{ ErrorCode = '50074' }
+            @{ ErrorCode = '50158' }
+        ) {
+            # 'Manual', not 'Wait'. Waiting is the right answer to a page this module does not
+            # recognize, because it might only be mid-navigation; a screen that has named its own
+            # error is not that page, and making the user watch a still window for the length of the
+            # stall timeout before being told what happened is a minute spent saying nothing.
+            $PageState = New-PageState @{ errorCode = $ErrorCode }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState; ErrorCode = $ErrorCode } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
+
+                $Decision.Action | Should -Be 'Manual'
+                $Decision.IsTerminal | Should -BeFalse
+                $Decision.Code | Should -Be ("AADSTS{0}" -f $ErrorCode)
+                $Decision.Reason | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Hands an error code it does not recognize back to the user rather than guessing' {
+            $PageState = New-PageState @{ errorCode = '90210' }
 
             InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
                 $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com'
 
-                $Decision.Action | Should -Be 'Wait'
+                $Decision.Action | Should -Be 'Manual'
                 $Decision.IsTerminal | Should -BeFalse
-                $Decision.Reason | Should -Not -BeNullOrEmpty
             }
         }
 

--- a/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
+++ b/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
@@ -156,6 +156,37 @@ Describe 'Resolve-EntraSignInScreen' -Tag 'Unit' {
         }
     }
 
+    Context 'A screen that is not finished rendering' {
+        It 'Does not type the password until the button that submits it is there' {
+            # Filling the field and submitting it are two steps. Taking the first before the second
+            # is possible retypes the password once per cycle with nothing to submit it, and waits
+            # out the whole stall timeout instead of the tick or two the page needed.
+            $PageState = New-PageState @{
+                ids        = @('i0118', 'idSIButton9')
+                visibleIds = @('i0118')
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'PasswordEntry'
+                $Decision.Action | Should -Be 'Wait'
+                $Decision.ValueSource | Should -Not -Be 'Password'
+            }
+        }
+
+        It 'Does not type the user name until the button that submits it is there' {
+            $PageState = New-PageState @{
+                ids        = @('i0116', 'idSIButton9')
+                visibleIds = @('i0116')
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                (Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword).Action | Should -Be 'Wait'
+            }
+        }
+    }
+
     Context 'Passwordless credentials' {
         It 'Switches to another sign-in method rather than submitting an empty password' {
             $PageState = New-PageState @{

--- a/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
+++ b/Tests/Unit/Resolve-EntraSignInScreen.Tests.ps1
@@ -358,6 +358,41 @@ Describe 'Resolve-EntraSignInScreen' -Tag 'Unit' {
         }
     }
 
+    Context 'Stay signed in, when the page only looks like it' {
+        It 'Does not act on a back button the page is not showing' {
+            # Clicking an element that is in the markup but not actionable does nothing, and this
+            # rule is tested before the username and password screens - so a stale checkbox left in
+            # the DOM would shadow the screen the user is actually on.
+            $PageState = New-PageState @{
+                ids        = @('KmsiCheckboxField', 'idBtn_Back', 'i0116', 'idSIButton9')
+                visibleIds = @('i0116', 'idSIButton9')
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'UsernameEntry'
+            }
+        }
+
+        It 'Still recognizes the screen when the checkbox itself is styled out of sight' {
+            # The real input of a styled checkbox is routinely hidden behind its label. The checkbox
+            # is the marker for this screen, so requiring it to be visible would risk not
+            # recognizing the screen at all; only the button that gets clicked has to be actionable.
+            $PageState = New-PageState @{
+                ids        = @('KmsiCheckboxField', 'idBtn_Back', 'idSIButton9')
+                visibleIds = @('idBtn_Back', 'idSIButton9')
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PageState = $PageState } {
+                $Decision = Resolve-EntraSignInScreen -PageState $PageState -UserName 'someone@contoso.com' -HasPassword
+
+                $Decision.Screen | Should -Be 'StaySignedIn'
+                $Decision.ElementId | Should -Be 'idBtn_Back'
+            }
+        }
+    }
+
     Context 'Errors the server reports' {
         It 'Ends the sign-in on <ErrorCode> instead of retrying it' -TestCases @(
             @{ ErrorCode = '53003' }

--- a/Tests/Unit/Select-EntraMfaMethod.Tests.ps1
+++ b/Tests/Unit/Select-EntraMfaMethod.Tests.ps1
@@ -64,6 +64,33 @@ Describe 'Select-EntraMfaMethod' -Tag 'Unit' {
             }
         }
 
+        It 'Returns nothing when no offered method says which method it is' {
+            # Clicking one of these would be choosing by position alone - the guessing this function
+            # exists not to do - and the caller cannot tell a bad choice from a good one afterwards.
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @(
+                    [pscustomobject]@{ authMethodId = ''; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = $null; isDefault = $false }
+                )
+
+                Select-EntraMfaMethod -Proof $Proof | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Ignores an unidentifiable entry rather than letting it win on position' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @(
+                    [pscustomobject]@{ authMethodId = ''; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $false }
+                )
+
+                $Chosen = Select-EntraMfaMethod -Proof $Proof
+
+                $Chosen.AuthMethodId | Should -Be 'OneWaySMS'
+                $Chosen.Index | Should -Be 1
+            }
+        }
+
         It 'Returns nothing when the page offered no methods' {
             InModuleScope 'OmadaWeb.PS' {
                 Select-EntraMfaMethod -Proof @() | Should -BeNullOrEmpty

--- a/Tests/Unit/Select-EntraMfaMethod.Tests.ps1
+++ b/Tests/Unit/Select-EntraMfaMethod.Tests.ps1
@@ -1,0 +1,132 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Select-EntraMfaMethod' -Tag 'Unit' {
+
+    BeforeEach {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:PreferredMfaMethodWarningIssued = $false
+        }
+    }
+
+    Context 'Choosing without an override' {
+        It 'Prefers the Authenticator approval over a code that has to be typed' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @(
+                    [pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'PhoneAppOTP'; isDefault = $false }
+                    [pscustomobject]@{ authMethodId = 'PhoneAppNotification'; isDefault = $false }
+                )
+
+                $Chosen = Select-EntraMfaMethod -Proof $Proof
+
+                $Chosen.AuthMethodId | Should -Be 'PhoneAppNotification'
+                $Chosen.Index | Should -Be 2
+            }
+        }
+
+        It 'Overrides the account default when a more secure method is offered' {
+            # isDefault is the user's convenience setting, not a security ranking, so it does not win.
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @(
+                    [pscustomobject]@{ authMethodId = 'TwoWayVoiceMobile'; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'PhoneAppOTP'; isDefault = $false }
+                )
+
+                (Select-EntraMfaMethod -Proof $Proof).AuthMethodId | Should -Be 'PhoneAppOTP'
+            }
+        }
+
+        It 'Still signs in with the only method an account has registered' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @([pscustomobject]@{ authMethodId = 'TwoWayVoiceOffice'; isDefault = $true })
+
+                (Select-EntraMfaMethod -Proof $Proof).AuthMethodId | Should -Be 'TwoWayVoiceOffice'
+            }
+        }
+
+        It 'Ranks a method it has never seen behind every method it knows' {
+            # An unknown identifier may well be something better, but automating a screen whose
+            # behavior has never been seen here is the one thing that must not happen by default.
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @(
+                    [pscustomobject]@{ authMethodId = 'SomethingBrandNew'; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'TwoWayVoiceOffice'; isDefault = $false }
+                )
+
+                (Select-EntraMfaMethod -Proof $Proof).AuthMethodId | Should -Be 'TwoWayVoiceOffice'
+            }
+        }
+
+        It 'Returns nothing when the page offered no methods' {
+            InModuleScope 'OmadaWeb.PS' {
+                Select-EntraMfaMethod -Proof @() | Should -BeNullOrEmpty
+                Select-EntraMfaMethod -Proof $null | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Choosing with -PreferredMfaMethod' {
+        It 'Uses the method the caller asked for, even when a more secure one is offered' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @(
+                    [pscustomobject]@{ authMethodId = 'PhoneAppNotification'; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $false }
+                )
+
+                $Chosen = Select-EntraMfaMethod -Proof $Proof -PreferredMethod 'OneWaySMS'
+
+                $Chosen.AuthMethodId | Should -Be 'OneWaySMS'
+                $Chosen.IsPreferred | Should -BeTrue
+                $Chosen.Index | Should -Be 1
+            }
+        }
+
+        It 'Falls back to the most secure offered method when the account does not offer the one asked for' {
+            # Failing the whole sign-in over a preference would be a worse answer than signing in.
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @(
+                    [pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $true }
+                    [pscustomobject]@{ authMethodId = 'PhoneAppNotification'; isDefault = $false }
+                )
+
+                $Chosen = Select-EntraMfaMethod -Proof $Proof -PreferredMethod 'PhoneAppOTP' -WarningAction SilentlyContinue
+
+                $Chosen.AuthMethodId | Should -Be 'PhoneAppNotification'
+                $Chosen.IsPreferred | Should -BeFalse
+            }
+        }
+
+        It 'Says which methods the account does offer when the preference cannot be honoured' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @([pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $true })
+
+                Select-EntraMfaMethod -Proof $Proof -PreferredMethod 'PhoneAppOTP' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                ($Warnings -join "`n") | Should -BeLike '*OneWaySMS*'
+            }
+        }
+
+        It 'Reports an unhonoured preference once per sign-in, not once per timer tick' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Proof = @([pscustomobject]@{ authMethodId = 'OneWaySMS'; isDefault = $true })
+
+                Select-EntraMfaMethod -Proof $Proof -PreferredMethod 'PhoneAppOTP' -WarningVariable First -WarningAction SilentlyContinue | Out-Null
+                Select-EntraMfaMethod -Proof $Proof -PreferredMethod 'PhoneAppOTP' -WarningVariable Second -WarningAction SilentlyContinue | Out-Null
+
+                ($First | Measure-Object).Count | Should -Be 1
+                ($Second | Measure-Object).Count | Should -Be 0
+            }
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Show-EntraApprovalNumber.Tests.ps1
+++ b/Tests/Unit/Show-EntraApprovalNumber.Tests.ps1
@@ -1,0 +1,115 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Show-EntraApprovalNumber' -Tag 'Unit' {
+
+    BeforeEach {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:MfaRequestDisplayed = $false
+            $Script:MfaWaitLastReported = $null
+            $Script:MfaWaitReportInterval = 10
+        }
+    }
+
+    Context 'Showing the number' {
+        It 'Shows the number once and records that it has been shown' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-Process { @() }
+                Mock Write-Host {}
+
+                Show-EntraApprovalNumber -Number '42' | Should -BeTrue
+
+                $Script:MfaRequestDisplayed | Should -BeTrue
+                Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter { $Object -like '*42*' }
+            }
+        }
+
+        It 'Puts the number on the clipboard when Phone Link is running' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-Process { @([PSCustomObject]@{ ProcessName = 'PhoneExperienceHost' }) }
+                Mock Set-Clipboard {}
+                Mock Write-Host {}
+
+                Show-EntraApprovalNumber -Number '42' | Out-Null
+
+                Should -Invoke Set-Clipboard -Times 1 -Exactly
+                Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter { $Object -like '*clipboard*' }
+            }
+        }
+
+        It 'Still shows the number when the clipboard cannot be set' {
+            # The number is the one piece of information the user needs; a clipboard failure must
+            # not cost them it.
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-Process { @([PSCustomObject]@{ ProcessName = 'PhoneExperienceHost' }) }
+                Mock Set-Clipboard { throw 'clipboard unavailable' }
+                Mock Write-Host {}
+
+                Show-EntraApprovalNumber -Number '42' | Should -BeTrue
+
+                Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter { $Object -like '*42*' }
+            }
+        }
+
+        It 'Does nothing when the page carried no number' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Write-Host {}
+
+                Show-EntraApprovalNumber -Number '' | Should -BeFalse
+                Show-EntraApprovalNumber -Number $null | Should -BeFalse
+
+                $Script:MfaRequestDisplayed | Should -BeFalse
+                Should -Invoke Write-Host -Times 0 -Exactly
+            }
+        }
+    }
+
+    Context 'Waiting for the approval' {
+        It 'Does not show the number again on every timer tick' {
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-Process { @() }
+                Mock Write-Host {}
+
+                Show-EntraApprovalNumber -Number '42' | Out-Null
+                Show-EntraApprovalNumber -Number '42' | Should -BeFalse
+                Show-EntraApprovalNumber -Number '42' | Should -BeFalse
+
+                Should -Invoke Write-Host -Times 1 -Exactly
+            }
+        }
+
+        It 'Reports that it is still waiting, so a multi-minute wait does not look frozen' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Script:MfaRequestDisplayed = $true
+                # Last reported longer ago than the interval, which is what a real wait produces
+                # between two heartbeats.
+                $Script:MfaWaitLastReported = [DateTime]::Now.AddSeconds(-($Script:MfaWaitReportInterval + 1))
+
+                $Verbose = @(Show-EntraApprovalNumber -Number '42' -Verbose 4>&1 | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] })
+
+                ($Verbose -join "`n") | Should -BeLike '*Still waiting*42*'
+            }
+        }
+
+        It 'Holds the heartbeat back until the interval has passed' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Script:MfaRequestDisplayed = $true
+                $Script:MfaWaitLastReported = [DateTime]::Now
+
+                $Verbose = @(Show-EntraApprovalNumber -Number '42' -Verbose 4>&1 | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] })
+
+                ($Verbose | Measure-Object).Count | Should -Be 0
+            }
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Show-EntraApprovalNumber.Tests.ps1
+++ b/Tests/Unit/Show-EntraApprovalNumber.Tests.ps1
@@ -43,6 +43,19 @@ Describe 'Show-EntraApprovalNumber' -Tag 'Unit' {
             }
         }
 
+        It 'Asks for the one process by name instead of enumerating every process' {
+            # This runs on the WebView2 UI thread. Filtering the whole process table to answer a
+            # yes/no question about a single process is work the timer does not need to do.
+            InModuleScope 'OmadaWeb.PS' {
+                Mock Get-Process { @() }
+                Mock Write-Host {}
+
+                Show-EntraApprovalNumber -Number '42' | Out-Null
+
+                Should -Invoke Get-Process -Times 1 -Exactly -ParameterFilter { $Name -eq 'PhoneExperienceHost' }
+            }
+        }
+
         It 'Still shows the number when the clipboard cannot be set' {
             # The number is the one piece of information the user needs; a clipboard failure must
             # not cost them it.

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -272,13 +272,24 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
                 CoreWebView2 = [PSCustomObject]@{}
             }
 
+            # What a snippet answers is not the same as whether it ran: the probe returns the page
+            # snapshot, and every acting snippet returns "true" when it found its element and
+            # "false" when it did not. The fake has to keep those apart, or a test would never
+            # exercise the difference. $Script:NextClickResult lets a test say the click found
+            # nothing.
+            $Script:NextClickResult = 'true'
             $Script:WebView2.CoreWebView2 | Add-Member -MemberType ScriptMethod -Name ExecuteScriptAsync -Value {
                 param($ScriptText)
+
+                $Result = $Script:NextClickResult
+                if ($ScriptText -like '*knownIds*') {
+                    $Result = $Script:NextScriptResult
+                }
 
                 [PSCustomObject]@{
                     IsCompleted = $true
                     IsFaulted   = $false
-                    Result      = $Script:NextScriptResult
+                    Result      = $Result
                 }
             }
 
@@ -429,6 +440,58 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
 
             $Script:MicrosoftOnlineLogin | Should -BeFalse
             $Warning | Should -BeLike '*Script execution is disabled*'
+        }
+    }
+
+    It 'Hands over when the page is recognized but does not respond to being driven' {
+        InModuleScope 'OmadaWeb.PS' {
+            # A screen this module recognizes, whose element has been renamed underneath it: the
+            # script executes perfectly and does nothing, answering false. Counting that as progress
+            # would clear the stall clock on every tick, so the driver would re-issue the same
+            # useless click for as long as the window stayed open and never hand over.
+            $Script:NextScriptResult = Script:New-SnapshotResult @{ ids = @('i0116', 'idSIButton9'); visibleIds = @('i0116', 'idSIButton9') }
+            $Script:NextClickResult = 'false'
+
+            $Warning = Script:Invoke-LoginTick -Count 8
+
+            $Script:MicrosoftOnlineLogin | Should -BeFalse
+            $Warning | Should -BeLike '*Deciding/UsernameEntry*'
+        }
+    }
+
+    It 'Does not submit a field it could not fill in' {
+        InModuleScope 'OmadaWeb.PS' {
+            # Writing the value and clicking submit are two scripts. If the first found no field,
+            # clicking submit would send whatever the field already held - nothing - and spend one
+            # of the attempts before Entra ID smart lockout on it.
+            $Script:LoginAutomationFallbackTimeout = 60
+            $Script:NextScriptResult = Script:New-SnapshotResult @{ ids = @('i0118', 'idSIButton9'); visibleIds = @('i0118', 'idSIButton9') }
+            $Script:NextClickResult = 'false'
+
+            $Script:ClickedElementId = @()
+            $Script:WebView2.CoreWebView2 | Add-Member -MemberType ScriptMethod -Name ExecuteScriptAsync -Force -Value {
+                param($ScriptText)
+
+                $Result = $Script:NextClickResult
+                if ($ScriptText -like '*knownIds*') {
+                    $Result = $Script:NextScriptResult
+                }
+                else {
+                    $Script:ClickedElementId += $ScriptText
+                }
+
+                [PSCustomObject]@{
+                    IsCompleted = $true
+                    IsFaulted   = $false
+                    Result      = $Result
+                }
+            }
+
+            Script:Invoke-LoginTick -Count 8 | Out-Null
+
+            # The password field was written to; the submit button never was.
+            ($Script:ClickedElementId | Where-Object { $_ -like '*"i0118"*' } | Measure-Object).Count | Should -BeGreaterThan 0
+            ($Script:ClickedElementId | Where-Object { $_ -like '*("idSIButton9")*' } | Measure-Object).Count | Should -Be 0
         }
     }
 

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -123,6 +123,27 @@ Describe 'Reset-LoginAutomationState' -Tag 'Unit' {
         }
     }
 
+    It 'Lets a new browser window show its own approval number' {
+        InModuleScope 'OmadaWeb.PS' {
+            # The number belongs to one sign-in request, and a new window means a new request with a
+            # new number. Carrying the flag over would suppress the only thing the user needs in
+            # order to approve it - leaving them looking at a window waiting for something it never
+            # told them about - and would let a resend link on the new page read as a failed
+            # approval that never happened.
+            Mock Get-Process { @() }
+            Mock Write-Host {}
+
+            Show-EntraApprovalNumber -Number '42' | Should -BeTrue
+            $Script:MfaRequestDisplayed | Should -BeTrue
+
+            Reset-LoginAutomationState
+
+            $Script:MfaRequestDisplayed | Should -BeFalse
+            Show-EntraApprovalNumber -Number '73' | Should -BeTrue
+            Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter { $Object -like '*73*' }
+        }
+    }
+
     It 'Clears the stall clock' {
         InModuleScope 'OmadaWeb.PS' {
             $Script:UnmatchedPageSignature = 'i0116'

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -234,14 +234,38 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
 
     BeforeEach {
         InModuleScope 'OmadaWeb.PS' {
-            # A page that carries none of the element IDs any scenario acts on - what a Microsoft
-            # sign-in redesign looks like from here. getAllIdsScript only ever reports IDs from its
-            # own list, so an unrecognized page reaches ProcessingScenarios either empty or carrying
-            # one of the IDs that list looks for but no scenario handles. i0281 is such an ID, and
-            # using it keeps this fixture the shape the state machine really receives.
-            $Script:UnknownPageAttributes = @(
-                [PSCustomObject]@{ id = 'i0281'; tagName = 'DIV'; outerHTML = '<div id="i0281"></div>' }
-            )
+            # The sign-in automation reads the page once per step, as one JSON snapshot. The fake
+            # CoreWebView2 below returns whatever snapshot a test puts in $Script:NextScriptResult,
+            # encoded the way ExecuteScriptAsync encodes a return value: the script's JSON document,
+            # itself JSON-encoded.
+            function Script:New-SnapshotResult {
+                param([hashtable]$Override = @{})
+
+                $State = [ordered]@{
+                    ids                     = @()
+                    visibleIds              = @()
+                    errorCode               = '0'
+                    errorCodeText           = ''
+                    proofs                  = @()
+                    proofOptionCount        = 0
+                    accountTiles            = @()
+                    hasOtherTile            = $false
+                    displaySign             = $null
+                    hasVisiblePasswordInput = $false
+                    hasVisibleEmailInput    = $false
+                    path                    = '/common/login'
+                }
+
+                foreach ($Key in $Override.Keys) {
+                    $State[$Key] = $Override[$Key]
+                }
+
+                return (ConvertTo-Json -InputObject (ConvertTo-Json -InputObject $State -Depth 5 -Compress) -Compress)
+            }
+
+            # A page carrying one element the module knows of but no screen is recognized by - what a
+            # Microsoft sign-in redesign looks like from here.
+            $Script:NextScriptResult = Script:New-SnapshotResult @{ ids = @('idA_PWD_ForgotPassword'); visibleIds = @('idA_PWD_ForgotPassword') }
 
             $Script:WebView2 = [PSCustomObject]@{
                 Source       = [System.Uri]::New('https://login.microsoftonline.com/common/oauth2/authorize?client_id=abc')
@@ -249,31 +273,50 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
             }
 
             $Script:WebView2.CoreWebView2 | Add-Member -MemberType ScriptMethod -Name ExecuteScriptAsync -Value {
-                param($Script)
+                param($ScriptText)
 
                 [PSCustomObject]@{
                     IsCompleted = $true
                     IsFaulted   = $false
-                    Result      = 'null'
+                    Result      = $Script:NextScriptResult
                 }
             }
 
             $Script:CurrentWebView2Session = [PSCustomObject]@{
-                Credential = New-Object System.Management.Automation.PSCredential('user@contoso.com', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+                Credential         = New-Object System.Management.Automation.PSCredential('user@contoso.com', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+                PreferredMfaMethod = $null
             }
 
             $Script:MicrosoftOnlineLogin = $true
             $Script:LoginFailed = $false
             $Script:ManualLoginFallbackActive = $false
             $Script:MfaRequestDisplayed = $false
-            $Script:LoginState = 'ProcessingScenarios'
-            $Script:LoginSubState = $null
+            $Script:MfaWaitLastReported = $null
+            $Script:LoginState = $null
             $Script:LoginTask = $null
-            $Script:IdAttributes = $Script:UnknownPageAttributes
-            $Script:PreviousAttributes = $Script:UnknownPageAttributes
+            $Script:PageState = $null
+            $Script:PendingSubmitId = $null
+            $Script:CurrentScenario = $null
+            $Script:PreviousScenario = $null
             $Script:UnmatchedPageSignature = $null
             $Script:UnmatchedPageSince = $null
             $Script:LoginAutomationFallbackTimeout = 0
+
+            # Reading the page, deciding, and acting each take their own tick, so a test that wants
+            # to see what several ticks produce has to run several. Warnings raised inside the state
+            # machine do not reach an outer -WarningVariable, so the warning stream is redirected and
+            # only warning records are kept - folding every stream together would let the verbose
+            # logging satisfy the assertions on its own.
+            function Script:Invoke-LoginTick {
+                param([int]$Count = 6)
+
+                $Warnings = @()
+                for ($Tick = 0; $Tick -lt $Count; $Tick++) {
+                    $Warnings += @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+                }
+
+                return ($Warnings -join "`n")
+            }
         }
     }
 
@@ -281,135 +324,83 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
         InModuleScope 'OmadaWeb.PS' {
             $Script:WebView2 = $null
             $Script:CurrentWebView2Session = $null
-            $Script:IdAttributes = $null
-            $Script:PreviousAttributes = $null
+            $Script:PageState = $null
             $Script:LoginAutomationFallbackTimeout = 60
         }
     }
 
     It 'Falls back to manual login when the page matches no known sign-in step' {
         InModuleScope 'OmadaWeb.PS' {
-            # First pass arms the stall clock, second pass hits the timeout. Warnings raised inside
-            # the state machine do not reach an outer -WarningVariable, so redirect the warning
-            # stream and keep only warning records - a fold of every stream would let the verbose
-            # logging satisfy these assertions on its own.
-            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
-            $Script:LoginState = 'ProcessingScenarios'
-            $Script:IdAttributes = $Script:UnknownPageAttributes
-            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+            $Warning = Script:Invoke-LoginTick
 
             $Script:MicrosoftOnlineLogin | Should -BeFalse
-            ($Warnings -join "`n") | Should -BeLike '*ProcessingScenarios*'
+            $Warning | Should -BeLike '*Deciding*'
         }
     }
 
     It 'Names the missing selectors and the page in the diagnostic' {
         InModuleScope 'OmadaWeb.PS' {
-            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
-            $Script:LoginState = 'ProcessingScenarios'
-            $Script:IdAttributes = $Script:UnknownPageAttributes
-            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
-
-            $Warning = $Warnings -join "`n"
+            $Warning = Script:Invoke-LoginTick
 
             $Warning | Should -BeLike '*i0116*'
             $Warning | Should -BeLike '*i0118*'
             $Warning | Should -BeLike '*idSIButton9*'
-            $Warning | Should -BeLike '*Elements present : i0281*'
+            $Warning | Should -BeLike '*Elements present : idA_PWD_ForgotPassword*'
             $Warning | Should -BeLike '*https://login.microsoftonline.com/common/oauth2/authorize*'
         }
     }
 
     It 'Does not fall back while the page still matches a known sign-in step' {
         InModuleScope 'OmadaWeb.PS' {
-            # Working through the sub-states of a recognized page takes several ticks, which is why
-            # the timeout is generous in the module. Use the real one here.
+            # Working through a recognized page takes several ticks, which is why the timeout is
+            # generous in the module. Use the real one here.
             $Script:LoginAutomationFallbackTimeout = 60
+            $Script:NextScriptResult = Script:New-SnapshotResult @{ ids = @('i0116', 'idSIButton9'); visibleIds = @('i0116', 'idSIButton9') }
 
-            $KnownPage = @(
-                [PSCustomObject]@{ id = 'i0116'; outerHTML = '<input id="i0116">' }
-                [PSCustomObject]@{ id = 'idSIButton9'; outerHTML = '<input id="idSIButton9">' }
-            )
-
-            $Script:IdAttributes = $KnownPage
-            $Script:PreviousAttributes = $KnownPage
-
-            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
-            $Script:LoginState = 'ProcessingScenarios'
-            $Script:IdAttributes = $KnownPage
-            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+            $Warning = Script:Invoke-LoginTick
 
             $Script:MicrosoftOnlineLogin | Should -BeTrue
-            ($Warnings | Measure-Object).Count | Should -Be 0
+            $Warning | Should -BeNullOrEmpty
         }
     }
 
     It 'Does not fall back while waiting for the user to approve the sign-in request' {
         InModuleScope 'OmadaWeb.PS' {
-            $MfaPage = @(
-                [PSCustomObject]@{ id = 'idRichContext_DisplaySign'; outerHTML = '<div id="idRichContext_DisplaySign">42</div>' }
-            )
-
             $Script:MfaRequestDisplayed = $true
-            $Script:IdAttributes = $MfaPage
-            $Script:PreviousAttributes = $MfaPage
+            $Script:NextScriptResult = Script:New-SnapshotResult @{
+                ids         = @('idRichContext_DisplaySign')
+                visibleIds  = @('idRichContext_DisplaySign')
+                displaySign = '42'
+            }
 
-            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
-            $Script:LoginState = 'ProcessingScenarios'
-            $Script:IdAttributes = $MfaPage
-            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+            $Warning = Script:Invoke-LoginTick -Count 10
 
             $Script:MicrosoftOnlineLogin | Should -BeTrue
-            ($Warnings | Measure-Object).Count | Should -Be 0
+            $Warning | Should -BeNullOrEmpty
         }
     }
 
-    It 'Does not report a scenario the previous page was in' {
+    It 'Reports the screen it could not act on rather than the previous one' {
         InModuleScope 'OmadaWeb.PS' {
-            # The username page matched a scenario, then the sign-in moved to a page nothing
-            # recognizes. Naming UsernameEntry in the diagnostic would send a reader looking at the
-            # wrong code.
-            #
-            # A page with only the back button reaches the "no scenario matched" branch: the
-            # stay-signed-in scenario needs a submit button too, and account selection needs the
-            # back button to be absent.
-            $BackButtonOnlyPage = @(
-                [PSCustomObject]@{ id = 'idBtn_Back'; outerHTML = '<input id="idBtn_Back">' }
-            )
-
+            # The username screen was recognized, then the sign-in moved to a page nothing
+            # recognizes. Naming UsernameEntry in the diagnostic would send a reader to the wrong
+            # code.
             $Script:CurrentScenario = 'UsernameEntry'
-            $Script:IdAttributes = $BackButtonOnlyPage
-            $Script:PreviousAttributes = $BackButtonOnlyPage
 
-            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
-
-            $Script:CurrentScenario | Should -BeNullOrEmpty -Because 'no scenario is acting on this page'
-
-            $Script:LoginState = 'ProcessingScenarios'
-            $Script:IdAttributes = $BackButtonOnlyPage
-            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
-
-            $Warning = $Warnings -join "`n"
+            $Warning = Script:Invoke-LoginTick
 
             $Warning | Should -Not -BeLike '*UsernameEntry*'
-            $Warning | Should -BeLike '*ProcessingScenarios/NoMatchingScenario*'
+            $Warning | Should -BeLike '*Deciding/NoMatchingScreen*'
         }
     }
 
-    It 'Names every known selector when the page carries none of them' {
+    It 'Names every known selector when the page cannot be read at all' {
         InModuleScope 'OmadaWeb.PS' {
-            # getAllIds found nothing at all - the loudest form of a selector break. The diagnostic
-            # has to list what was looked for, since the page itself offers nothing to report.
-            $Script:LoginState = 'GettingIds'
-            $Script:LoginTask = [PSCustomObject]@{ IsCompleted = $true; IsFaulted = $false; Result = '"[]"' }
+            # The probe answered with nothing usable - the loudest form of a selector break. The
+            # diagnostic has to list what was looked for, since the page offers nothing to report.
+            $Script:NextScriptResult = 'null'
 
-            Invoke-WebView2MicrosoftLogin -WarningAction SilentlyContinue | Out-Null
-
-            $Script:LoginState = 'GettingIds'
-            $Script:LoginTask = [PSCustomObject]@{ IsCompleted = $true; IsFaulted = $false; Result = '"[]"' }
-            $Warnings = @(Invoke-WebView2MicrosoftLogin 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
-
-            $Warning = $Warnings -join "`n"
+            $Warning = Script:Invoke-LoginTick
 
             $Warning | Should -BeLike '*i0116*'
             $Warning | Should -BeLike '*KmsiCheckboxField*'
@@ -428,6 +419,49 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
 
             $Script:ManualLoginFallbackActive | Should -BeFalse
             $Script:UnmatchedPageSince | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Ends the sign-in without retrying when Entra ID reports a Conditional Access block' {
+        InModuleScope 'OmadaWeb.PS' {
+            # Issue #18: a 53003 page is terminal. Re-opening the window lands on it again, and the
+            # driver has to be told that rather than spending its retries discovering it.
+            $Script:LoginAbortReason = $null
+            $Script:LoginAutomationFallbackTimeout = 60
+            $Script:WebView2 | Add-Member -MemberType ScriptMethod -Name FindForm -Value { return $null } -Force
+            $Script:NextScriptResult = Script:New-SnapshotResult @{ errorCode = '53003' }
+
+            $Warning = Script:Invoke-LoginTick -Count 4
+
+            $Script:LoginAbortReason | Should -Not -BeNullOrEmpty
+            $Script:LoginAbortReason.Code | Should -Be 'AADSTS53003'
+            $Script:LoginFailed | Should -BeTrue
+            $Script:MicrosoftOnlineLogin | Should -BeFalse
+            $Warning | Should -BeLike '*will not be retried*'
+
+            $Script:LoginAbortReason = $null
+        }
+    }
+
+    It 'Does not resubmit a credential Entra ID has just refused' {
+        InModuleScope 'OmadaWeb.PS' {
+            # The refused password screen is rendered again with the field intact. Filling it in is
+            # what drives an account into smart lockout, so the sign-in stops instead.
+            $Script:LoginAbortReason = $null
+            $Script:LoginAutomationFallbackTimeout = 60
+            $Script:WebView2 | Add-Member -MemberType ScriptMethod -Name FindForm -Value { return $null } -Force
+            $Script:NextScriptResult = Script:New-SnapshotResult @{
+                ids        = @('i0118', 'idSIButton9', 'passwordError')
+                visibleIds = @('i0118', 'idSIButton9', 'passwordError')
+                errorCode  = '50126'
+            }
+
+            Script:Invoke-LoginTick -Count 4 | Out-Null
+
+            $Script:LoginAbortReason.Code | Should -Be 'AADSTS50126'
+            $Script:LoginFailed | Should -BeTrue
+
+            $Script:LoginAbortReason = $null
         }
     }
 }

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -495,6 +495,22 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
         }
     }
 
+    It 'Reports a registration interrupt at once instead of after the stall timeout' {
+        InModuleScope 'OmadaWeb.PS' {
+            # The real timeout, not zero: the point is that this screen does not wait for it. Entra
+            # ID has already said what is wrong, and only the person at the keyboard can fix it, so
+            # a silent minute before the message would be a minute wasted.
+            $Script:LoginAutomationFallbackTimeout = 60
+            $Script:NextScriptResult = Script:New-SnapshotResult @{ errorCode = '50072' }
+
+            $Warning = Script:Invoke-LoginTick -Count 3
+
+            $Script:MicrosoftOnlineLogin | Should -BeFalse
+            $Warning | Should -BeLike '*AADSTS50072*'
+            $Warning | Should -BeLike '*security information*'
+        }
+    }
+
     It 'Resets the fallback when the browser leaves the Microsoft sign-in page' {
         InModuleScope 'OmadaWeb.PS' {
             $Script:ManualLoginFallbackActive = $true

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -409,6 +409,29 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
         }
     }
 
+    It 'Hands over when the page cannot be read at all, instead of retrying for ever' {
+        InModuleScope 'OmadaWeb.PS' {
+            # A script that will not execute is no different from a page that answers nothing: both
+            # have to arm the stall clock. Without that the driver re-issues the same failing script
+            # every 150 ms and never hands the sign-in back, however long the timeout is.
+            $Script:WebView2.CoreWebView2 | Add-Member -MemberType ScriptMethod -Name ExecuteScriptAsync -Force -Value {
+                param($ScriptText)
+
+                [PSCustomObject]@{
+                    IsCompleted = $true
+                    IsFaulted   = $true
+                    Exception   = [PSCustomObject]@{ Message = 'Script execution is disabled' }
+                    Result      = $null
+                }
+            }
+
+            $Warning = Script:Invoke-LoginTick
+
+            $Script:MicrosoftOnlineLogin | Should -BeFalse
+            $Warning | Should -BeLike '*Script execution is disabled*'
+        }
+    }
+
     It 'Resets the fallback when the browser leaves the Microsoft sign-in page' {
         InModuleScope 'OmadaWeb.PS' {
             $Script:ManualLoginFallbackActive = $true


### PR DESCRIPTION
Closes #18

## What was broken

Credential autofill on the Entra ID sign-in page had three defects, all of which
failed silently:

| | Where |
|---|---|
| **Not language agnostic.** The "Stay signed in?" screen was recognized by reading its two buttons and comparing them to `"Yes"` / `"No"`; sign-in failures by sweeping the page for `incorrect` / `wrong password`. On any non-English tenant these match nothing, and autofill does nothing — with no diagnostic. | `Invoke-WebView2MicrosoftLogin.ps1:605`, `:199` (before this PR) |
| **Passwordless credentials unsupported.** A `[PSCredential]` with a user name but no password fell into the password scenario and submitted a blank password. `idRemoteNGC_DisplaySign` was probed but never read. | `:473`, `:52` |
| **Terminal screens unrecognized.** Wrong password, smart-lockout, expired password, proof-up and a Conditional Access block all looked like "no scenario matched", so the module kept polling and re-opening windows — resubmitting a possibly-wrong credential, which is what triggers Entra ID smart lockout. | scenarios 1–6 |

## What changed

The page reading and the decision are now separate, which is what makes the
decision testable without a browser at all.

| New private function | Role |
|---|---|
| `Get-EntraSignInProbeScript` | One script that reads the page into a single JSON snapshot carrying **no rendered text**: which known element ids are present and visible, `iErrorCode` / `sErrorCode` / `arrUserProofs` from the page's own `$Config`, account tiles' `data-test-id`, the approval number, and whether a password/e-mail field is visible at all. |
| `Resolve-EntraSignInScreen` | Turns that snapshot into one decision. Pure PowerShell, no browser. Covers every screen in the issue's state table. |
| `Get-EntraErrorVerdict` | AADSTS code → stop / hand to user / no error. |
| `Select-EntraMfaMethod` | Picks the most secure offered method by `authMethodId`. |
| `Show-EntraApprovalNumber` | Shows the number (both elements), clipboard via Phone Link, and a ten-second heartbeat while waiting. |

`Invoke-WebView2MicrosoftLogin` keeps its shape — one small piece of work per 150 ms
tick, because it runs on the UI thread of an open window — but its six inline
scenarios are replaced by executing the decision. Its existing safety net is
unchanged: an unrecognized page still *waits* rather than guessing, and only
`Test-LoginAutomationStalled` decides when waiting has gone on long enough to hand
over through `Switch-ToManualLogin`.

Selectors live in one `$Script:EntraSignInElementId` table read by both the script
and the rules, so they cannot drift apart on one.

`-PreferredMfaMethod` is added for callers who want to override the default choice.

## Acceptance criteria

Scope was limited to **WebView2 only**, at the maintainer's instruction, because the
Selenium engine is deprecated (#50, supported until 1 March 2027).

- [x] Passwordless credentials — an empty-password credential drives the passwordless flow, and `idRemoteNGC_DisplaySign` is read
- [x] A password screen for an empty-password credential offers "sign in another way" rather than submitting blank
- [x] Account selection on "Pick an account", with the "use another account" fallback
- [x] Access-denied / Conditional Access (53003) is terminal — cancels the sign-in, no retry
- [x] Language-agnostic screen detection: stable element ids, then `$Config`, then AADSTS codes, then structural fallbacks
- [x] Method selection prefers the most secure available; `-PreferredMfaMethod` overrides
- [x] Interrupt-screen handling — 50126 / 50053 / 50055 / 53003 / 50072 / 50074 / 50158 and KMSI all reported with an actionable message
- [x] Account-lockout safety — a refused credential is never resubmitted
- [x] Fail safe on any unrecognized screen
- [ ] **Engine parity (WebView2 ↔ Selenium)** — **out of scope.** `Get-DataFromWebDriver.ps1` is unchanged, so its `ComputedAccessibleLabel -eq "Next"` / `"Sign in"` and `"Yes"` / `"No"` comparisons, its dead account-selection code and its missing `idRemoteNGC_DisplaySign` remain.

## Decisions worth reviewing

- **`-PreferredMfaMethod` is declared across the inherited parameter sets**, like every
  other module-owned parameter (`-DebugWebView2`, `-EdgeProfile`, `-CookiePath`), and
  documented as WebView2-only. The module has no per-engine parameter sets — they are
  inherited from `Invoke-RestMethod`/`Invoke-WebRequest`. To give it the *effect* of a
  WebView2-only parameter, supplying it with any other `-AuthenticationType` is a
  **terminating error** rather than a warning. Building real per-engine sets would mean
  restructuring `Set-DynamicParameter` for every existing parameter, well beyond this issue.
- **The values are the raw `authMethodId` identifiers** (`PhoneAppNotification`, …), not
  friendly names. They are unlovely, but they are the locale-independent contract, and a
  translation layer would itself be a guess about screens we cannot see.
- **A wrong password (50126) is treated as terminal.** Retrying it cannot succeed and can
  lock the account, so the sign-in stops rather than re-opening the window. This is a
  behavior change for anyone who relied on the old retry loop to let them correct a typo —
  they now get a named error instead of three browser windows.
- **`Resolve-EntraSignInScreen` never carries the password.** It returns
  `ValueSource = "Password"` and the call site reads the secret from the credential, so the
  decision object — which is written to the verbose stream — cannot leak it (consistent with
  #19 / #43).
- **Verification-method options are clicked by position.** The option elements carry nothing
  naming which method they are, so the resolver refuses to click when `arrUserProofs` and the
  option count disagree, rather than clicking the wrong one.
- **No `WebResourceRequested` hook.** The issue comment suggests reading `SAS/BeginAuth` →
  `EndAuth` → `ProcessAuth` for approval progress. That would add a second undocumented
  Microsoft dependency; the DOM-based ten-second heartbeat removes the perceived stall
  without it.
- **The existing `Switch-ToManualLogin` state strings changed** from `ProcessingScenarios/*`
  to `Deciding/*`, since the state machine's states are genuinely different now.

## Verification

`Build/build.ps1 -Task TestBuildOnly` (PSScriptAnalyzer + build + comment-based help +
full Pester run), against a baseline of the same task on `origin/main`:

| | Passed | Failed |
|---|---|---|
| `origin/main` (baseline) | 511 | 26 |
| this branch | 601 | 26 |

The 26 failures are identical in both runs, by name: the WebView2 integration tests,
which need a real interactive browser and cannot run on this machine.

**Not verified:** end-to-end sign-in against a real Entra ID tenant. No tenant is
available here, so passwordless sign-in, the account picker, the method picker and the
53003 page have **not** been exercised against live Microsoft markup — only against the
snapshots the unit tests supply. The element ids and `$Config` members come from the
issue's own state table.

README is generated from the module (`Build/Update-ReadmeHelp.ps1`); it was regenerated,
not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C7oFA3axk8mXX8aixe9Rs
