### PR TITLE
Fix the unassigned-variable reads in the Selenium login flow and run the tests under StrictMode (roadmap B4)

### DIFF
--- a/Build/psakeBuild.ps1
+++ b/Build/psakeBuild.ps1
@@ -331,9 +331,17 @@ Task ImportModule -depends Build {
             try {
                 Test-ModuleManifest -Path "$OutputDir\$ModuleName.psd1"
 
-                Set-StrictMode -Version Latest
+                # Set-StrictMode here would only cover this scope. The module runs in its own session
+                # state, so neither its load-time code nor its functions inherit it - the module reads
+                # OMADAWEBPS_STRICTMODE and sets StrictMode on itself instead.
+                $Env:OMADAWEBPS_STRICTMODE = "1"
+                try {
+                    $Test = Import-Module "$OutputDir\$ModuleName.psd1" -Force -PassThru
+                }
+                finally {
+                    $Env:OMADAWEBPS_STRICTMODE = $null
+                }
 
-                $Test = Import-Module "$OutputDir\$ModuleName.psd1" -Force -PassThru
                 if ($Test) {
                     "Module loaded successfully" | Write-Verbose
                     Remove-Module -name $Test.Name -Force
@@ -341,7 +349,6 @@ Task ImportModule -depends Build {
                 else {
                     "Module failed to load" | Write-Error -ErrorAction Stop
                 }
-                Set-StrictMode -Off
             }
             catch {
                 $PSCmdlet.ThrowTerminatingError($PSItem)
@@ -385,7 +392,18 @@ Task Test -depends ImportModule {
     # E2E tests need a real Edge/WebView2 install and are slow; they are opt-in and run on a separate scheduled pipeline instead of every build.
     $PesterConfiguration.Filter.ExcludeTag = 'E2E'
 
-    $Result = Invoke-Pester -Configuration $PesterConfiguration
+    # Every test run exercises the module under Set-StrictMode -Version Latest. The module picks this
+    # up itself (see OmadaWeb.PS.psm1) because StrictMode does not cross into a module's session
+    # state from here. It covers the InModuleScope blocks in the tests as well, so a test fixture that
+    # reads a member no real caller would get is caught too.
+    $Env:OMADAWEBPS_STRICTMODE = "1"
+    try {
+        $Result = Invoke-Pester -Configuration $PesterConfiguration
+    }
+    finally {
+        $Env:OMADAWEBPS_STRICTMODE = $null
+    }
+
     if ($Result.FailedCount -gt 0) {
         Write-Error -Message ("{0} Pester test(s) failed." -f $Result.FailedCount) -ErrorAction Stop
     }

--- a/Build/psakeBuild.ps1
+++ b/Build/psakeBuild.ps1
@@ -334,12 +334,13 @@ Task ImportModule -depends Build {
                 # Set-StrictMode here would only cover this scope. The module runs in its own session
                 # state, so neither its load-time code nor its functions inherit it - the module reads
                 # OMADAWEBPS_STRICTMODE and sets StrictMode on itself instead.
+                $PreviousStrictMode = $Env:OMADAWEBPS_STRICTMODE
                 $Env:OMADAWEBPS_STRICTMODE = "1"
                 try {
                     $Test = Import-Module "$OutputDir\$ModuleName.psd1" -Force -PassThru
                 }
                 finally {
-                    $Env:OMADAWEBPS_STRICTMODE = $null
+                    $Env:OMADAWEBPS_STRICTMODE = $PreviousStrictMode
                 }
 
                 if ($Test) {
@@ -396,12 +397,15 @@ Task Test -depends ImportModule {
     # up itself (see OmadaWeb.PS.psm1) because StrictMode does not cross into a module's session
     # state from here. It covers the InModuleScope blocks in the tests as well, so a test fixture that
     # reads a member no real caller would get is caught too.
+    # Restored rather than cleared: the build runs in the developer's own session, so blanking it
+    # would discard a value they had set for themselves.
+    $PreviousStrictMode = $Env:OMADAWEBPS_STRICTMODE
     $Env:OMADAWEBPS_STRICTMODE = "1"
     try {
         $Result = Invoke-Pester -Configuration $PesterConfiguration
     }
     finally {
-        $Env:OMADAWEBPS_STRICTMODE = $null
+        $Env:OMADAWEBPS_STRICTMODE = $PreviousStrictMode
     }
 
     if ($Result.FailedCount -gt 0) {

--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -4,6 +4,21 @@ param(
     [hashtable]$Parameters
 )
 
+# StrictMode has to be set here rather than by the caller: it is scoped to the session state it is
+# set in, so a Set-StrictMode in the build script or in a Pester test reaches neither this file's
+# load-time code nor any function defined below. Without this line the module runs unstrict no
+# matter what the caller does, which is how the undefined-variable reads this guards against
+# survived for so long.
+#
+# Opt-in rather than always-on, because the browser login flows are the module's largest code paths
+# and CI cannot exercise them (they need a real interactive WebView2/Edge). Turning an unset-variable
+# read there into a terminating error in front of a user, without CI ever having run that path, trades
+# a silent null for a broken sign-in. The build sets this for every test run, so the bug class is
+# caught before it ships instead.
+if ($Env:OMADAWEBPS_STRICTMODE -eq "1") {
+    Set-StrictMode -Version Latest
+}
+
 $ModuleName = "OmadaWeb.PS"
 "Loading {0} Module" -f $ModuleName | Write-Verbose
 
@@ -456,25 +471,29 @@ Export-ModuleMember -Function $Public.Basename -Alias *
 "Validate version" | Write-Verbose
 try {
     $InstalledModule = Get-InstalledModuleInfo -ModuleName $ModuleName
-    if (-not $InstalledModule.RepositorySource -or $InstalledModule.RepositorySource -notlike "*powershellgallery.com*") {
+    # Get-InstalledModuleInfo returns $null whenever the module was imported from a path instead of
+    # installed - every build and every test run. Reading a member off that $null is an error under
+    # StrictMode, and the empty catch below swallowed it, so $Script:UserAgent kept its unformatted
+    # "OmadaWeb.PS/{0}" template and every request built from it was rejected as a malformed header.
+    if ($null -eq $InstalledModule -or -not $InstalledModule['RepositorySource'] -or $InstalledModule['RepositorySource'] -notlike "*powershellgallery.com*") {
         "Module '{0}' was not sourced from the PowerShell Gallery. Skipping version check." -f $ModuleName | Write-Verbose
         $Script:UserAgent = $Script:UserAgent -f "Development"
     }
     else {
-        $Script:UserAgent = $Script:UserAgent -f $($InstalledModule.Version)
+        $Script:UserAgent = $Script:UserAgent -f $($InstalledModule['Version'])
         $GalleryVersion = Get-GalleryModuleVersion -ModuleName $ModuleName
 
         if (-not $GalleryVersion) {
         }
         else {
-            if ([System.Version]$InstalledModule.Version -lt [System.Version]$GalleryVersion) {
-                "The installed version {0} of '{1}' is outdated. Latest version: {2}. Execute Update-Module {1} to update to the latest version!" -f ($($InstalledModule.Version)), $ModuleName, $GalleryVersion | Write-Warning
+            if ([System.Version]$InstalledModule['Version'] -lt [System.Version]$GalleryVersion) {
+                "The installed version {0} of '{1}' is outdated. Latest version: {2}. Execute Update-Module {1} to update to the latest version!" -f ($($InstalledModule['Version'])), $ModuleName, $GalleryVersion | Write-Warning
             }
-            elseif ([System.Version]$InstalledModule.Version -eq [System.Version]$GalleryVersion) {
-                "The installed version {0} of '{1}' is up-to-date." -f ($($InstalledModule.Version)) , $ModuleName | Write-Verbose
+            elseif ([System.Version]$InstalledModule['Version'] -eq [System.Version]$GalleryVersion) {
+                "The installed version {0} of '{1}' is up-to-date." -f ($($InstalledModule['Version'])) , $ModuleName | Write-Verbose
             }
             else {
-                "The installed version {0} of '{1}' is newer than the gallery version {2}." -f ($($InstalledModule.Version)), $ModuleName, $GalleryVersion | Write-Warning
+                "The installed version {0} of '{1}' is newer than the gallery version {2}." -f ($($InstalledModule['Version'])), $ModuleName, $GalleryVersion | Write-Warning
             }
         }
     }

--- a/OmadaWeb.PS/Private/ConvertTo-RedactedLogString.ps1
+++ b/OmadaWeb.PS/Private/ConvertTo-RedactedLogString.ps1
@@ -103,7 +103,7 @@ function ConvertTo-RedactedLogValue {
     }
 
     if ($Value -is [Microsoft.PowerShell.Commands.WebRequestSession]) {
-        # $BoundParams.WebSession carries the authentication cookie, and the member name "WebSession"
+        # The WebSession bound parameter carries the authentication cookie, and the member name "WebSession"
         # matches none of the patterns above - so this needs a type rule rather than a name rule.
         # The cookie count and user agent are the diagnostic parts; nothing else here is.
         return "WebRequestSession(Cookies={0}, UserAgent={1})" -f $Value.Cookies.Count, $Value.UserAgent

--- a/OmadaWeb.PS/Private/Get-DataFromWebDriver.ps1
+++ b/OmadaWeb.PS/Private/Get-DataFromWebDriver.ps1
@@ -100,19 +100,14 @@ function Get-DataFromWebDriver {
                             $Script:UnmatchedPageSince = $null
                         }
 
-                        if ($IdAttributes -notcontains $UserNameElementId `
-                                -and $IdAttributes -notcontains $PasswordElementId `
-                                -and $IdAttributes -contains $SelectUserElementId
-                        ) {
-                            "Select logged-in account" | Write-Verbose
-                            if ($AccountElement.GetAttribute("data-test-id") -eq $SessionContext.Credential.UserName.Trim()) {
-                                $AccountElement.Click()
-                            }
-                        }
+                        # A "Select logged-in account" block used to sit here. It tested for an element
+                        # id that was never assigned and then clicked an element variable that was
+                        # never assigned either, so it could not run and would have thrown if it had.
+                        # The "Select logged-in user " block below already does that job, correctly,
+                        # by matching the data-test-id attribute against the supplied user name.
 
                         if ($IdAttributes -notcontains $UserNameElementId `
                                 -and $IdAttributes -notcontains $PasswordElementId `
-                                -and $IdAttributes -notcontains $SelectUserElementId `
                                 -and $IdAttributes -contains $ButtonBackId `
                                 -and $IdAttributes -contains $ButtonSubmitId `
                                 -and $EdgeDriver.FindElement([OpenQA.Selenium.By]::Id($ButtonBackId)).ComputedAccessibleLabel -eq "No" `
@@ -141,7 +136,8 @@ function Get-DataFromWebDriver {
                                 -and $IdAttributes -notcontains $UserNameElementId `
                                 -and $IdAttributes -notcontains $PasswordElementId `
                                 -and $IdAttributes -contains $MFAElementId `
-                                -and $IdAttributes -notcontains $MfaRetryId `
+                                -and $IdAttributes -notcontains $MfaRetryId1 `
+                                -and $IdAttributes -notcontains $MfaRetryId2 `
                                 -and ($EdgeDriver.FindElements([OpenQA.Selenium.By]::XPath("//*[@data-test-id]")) | Measure-Object).Count -eq 0
                         ) {
                             $Message = "`nWaiting for your approve this sign-in request."

--- a/OmadaWeb.PS/Private/Invoke-BasicAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-BasicAuthentication.ps1
@@ -12,9 +12,9 @@ function Invoke-BasicAuthentication {
     if ($BoundParams.keys -notcontains "Credential") {
         $BoundParams.Add("Credential", (Get-Credential -Message "Please enter your authentication credentials"))
     }
-    $CredentialPair = "{0}:{1}" -f $BoundParams.Credential.UserName.Trim(), $BoundParams.Credential.GetNetworkCredential().Password
+    $CredentialPair = "{0}:{1}" -f $BoundParams['Credential'].UserName.Trim(), $BoundParams['Credential'].GetNetworkCredential().Password
     $EncodedCredential = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($CredentialPair))
-    $BoundParams.Headers.Add("Authorization" , ("Basic {0}" -f $EncodedCredential))
+    $BoundParams['Headers'].Add("Authorization" , ("Basic {0}" -f $EncodedCredential))
 
     return $RequestContext
 }

--- a/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
@@ -29,7 +29,7 @@ function Invoke-BrowserAuthentication {
     # everything else - the credential included - reaches them.
     $SessionContext.PreferredMfaMethod = $null
     if ($BoundParams.keys -contains "PreferredMfaMethod") {
-        $SessionContext.PreferredMfaMethod = $BoundParams.PreferredMfaMethod
+        $SessionContext.PreferredMfaMethod = $BoundParams['PreferredMfaMethod']
     }
     switch ($SessionContext.LastSessionType) {
         { $_ -eq "Normal" -and [bool]$BoundParams['InPrivate'] } {

--- a/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
@@ -13,7 +13,7 @@ function Invoke-BrowserAuthentication {
 
     "{0} - Set Browser authentication" -f $MyInvocation.MyCommand | Write-Verbose
 
-    if ($BoundParams.ForceAuthentication) {
+    if ($BoundParams['ForceAuthentication']) {
         "{0} - ForceAuthentication used. Reset OmadaWebAuthCookie and reset Browser authentication engine to default" -f $MyInvocation.MyCommand | Write-Verbose
         $SessionContext.AuthCookie = $null
         $SessionContext.WebView2Used = $false
@@ -21,7 +21,7 @@ function Invoke-BrowserAuthentication {
     }
     $SessionContext.Credential = $null
     if ($BoundParams.keys -contains "Credential") {
-        $SessionContext.Credential = $BoundParams.Credential
+        $SessionContext.Credential = $BoundParams['Credential']
     }
 
     # Carried on the session rather than passed down: the WebView2 sign-in runs inside a blocking
@@ -32,12 +32,16 @@ function Invoke-BrowserAuthentication {
         $SessionContext.PreferredMfaMethod = $BoundParams.PreferredMfaMethod
     }
     switch ($SessionContext.LastSessionType) {
-        { $_ -eq "Normal" -and $($BoundParams.InPrivate).IsPresent -eq $true } {
+        { $_ -eq "Normal" -and [bool]$BoundParams['InPrivate'] } {
             "{0} - Reset OmadaWebAuthCookie because session has changed to InPrivate" -f $MyInvocation.MyCommand | Write-Verbose
             $SessionContext.AuthCookie = $null
             $SessionContext.LastSessionType = "InPrivate"
         }
-        { $_ -eq "InPrivate" -and $($BoundParams.InPrivate).IsPresent -eq $false } {
+        # ContainsKey rather than a plain negation, to keep the asymmetry this branch has always had:
+        # it fires only on an explicit -InPrivate:$false, not on -InPrivate being left off. The reads
+        # here used to go through .IsPresent on the bound value, which is $null when the switch was
+        # never supplied, and $null -eq $false is False - so an omitted switch never reached this arm.
+        { $_ -eq "InPrivate" -and $BoundParams.ContainsKey("InPrivate") -and -not [bool]$BoundParams['InPrivate'] } {
             "{0} - Reset OmadaWebAuthCookie because session has changed from InPrivate to not InPrivate" -f $MyInvocation.MyCommand | Write-Verbose
             $SessionContext.AuthCookie = $null
             $SessionContext.LastSessionType = "Normal"
@@ -47,11 +51,11 @@ function Invoke-BrowserAuthentication {
 
     if ($null -ne $($SessionContext.AuthCookie) -and ([System.Uri]::New($SessionContext.BaseUrl).host -eq $($SessionContext.AuthCookie.domain))) {
         "{0} - Using existing cookie for this domain: {1}" -f $MyInvocation.MyCommand, $SessionContext.BaseUrl | Write-Verbose
-        if ("Cookie" -notin $BoundParams.Headers.Keys) {
-            $BoundParams.Headers.Add("Cookie", ($($SessionContext.AuthCookie).Name, $($SessionContext.AuthCookie).Value -join "="))
+        if ("Cookie" -notin $BoundParams['Headers'].Keys) {
+            $BoundParams['Headers'].Add("Cookie", ($($SessionContext.AuthCookie).Name, $($SessionContext.AuthCookie).Value -join "="))
         }
         else {
-            $BoundParams.Headers.Cookie = ($($SessionContext.AuthCookie).Name, $($SessionContext.AuthCookie).Value -join "=")
+            $BoundParams['Headers'].Cookie = ($($SessionContext.AuthCookie).Name, $($SessionContext.AuthCookie).Value -join "=")
         }
         $Session.Cookies.Add((New-Object System.Net.Cookie("oisauthtoken", $($SessionContext.AuthCookie.Value), "/", $($SessionContext.AuthCookie.domain))))
     }
@@ -60,9 +64,9 @@ function Invoke-BrowserAuthentication {
 
         # Check if WebView2 should be used instead of Selenium
         $WebView2Authentication = $false
-        if (($BoundParams.ContainsKey('UseWebView2') -and $BoundParams.UseWebView2) -or $BoundParams.AuthenticationType -eq "WebView2") {
+        if (($BoundParams.ContainsKey('UseWebView2') -and $BoundParams['UseWebView2']) -or $BoundParams['AuthenticationType'] -eq "WebView2") {
             "{0} - UseWebView2 parameter used" -f $MyInvocation.MyCommand | Write-Verbose
-            if ($BoundParams.ContainsKey('UseWebView2') -and $BoundParams.UseWebView2) {
+            if ($BoundParams.ContainsKey('UseWebView2') -and $BoundParams['UseWebView2']) {
                 "Parameter UseWebView2 is deprecated, please use AuthenticationType WebView2' instead." | Write-Warning
             }
             $WebView2Authentication = $true
@@ -76,39 +80,39 @@ function Invoke-BrowserAuthentication {
             "{0} - Using WebView2 for authentication" -f $MyInvocation.MyCommand | Write-Verbose
             # Get-DataFromWebView2 bridges $SessionContext into $Script:CurrentWebView2Session itself
             # (WebView2's .NET event-handler closures cannot see this call stack to read it directly).
-            Get-DataFromWebView2 -SessionContext $SessionContext -EdgeProfile $BoundParams.EdgeProfile -InPrivate:$($BoundParams.InPrivate).IsPresent
+            Get-DataFromWebView2 -SessionContext $SessionContext -EdgeProfile $BoundParams['EdgeProfile'] -InPrivate:([bool]$BoundParams['InPrivate'])
             $BrowserData = @($SessionContext.AuthCookie, $Script:UserAgent)
             $SessionContext.WebView2Used = $true
         }
         else {
             "{0} - Using Selenium WebDriver for authentication" -f $MyInvocation.MyCommand | Write-Verbose
             Write-OmadaDeprecationWarning -Feature "SeleniumBrowserEngine"
-            $BrowserData = Get-DataFromWebDriver -SessionContext $SessionContext -EdgeProfile $BoundParams.EdgeProfile -InPrivate:$($BoundParams.InPrivate).IsPresent
+            $BrowserData = Get-DataFromWebDriver -SessionContext $SessionContext -EdgeProfile $BoundParams['EdgeProfile'] -InPrivate:([bool]$BoundParams['InPrivate'])
         }
 
         "{0} - Setting OmadaWebAuthCookie and user agent" -f $MyInvocation.MyCommand | Write-Verbose
         $SessionContext.AuthCookie = $BrowserData[0]
-        $BoundParams.UserAgent = $Script:UserAgent
+        $BoundParams['UserAgent'] = $Script:UserAgent
         $Session.UserAgent = $Script:UserAgent
 
-        if ("Cookie" -notin $BoundParams.Headers.Keys) {
-            $BoundParams.Headers.Add("Cookie", ($($SessionContext.AuthCookie).Name, $($SessionContext.AuthCookie).Value -join "="))
+        if ("Cookie" -notin $BoundParams['Headers'].Keys) {
+            $BoundParams['Headers'].Add("Cookie", ($($SessionContext.AuthCookie).Name, $($SessionContext.AuthCookie).Value -join "="))
         }
         else {
-            $BoundParams.Headers.Cookie = ($($SessionContext.AuthCookie).Name, $($SessionContext.AuthCookie).Value -join "=")
+            $BoundParams['Headers'].Cookie = ($($SessionContext.AuthCookie).Name, $($SessionContext.AuthCookie).Value -join "=")
         }
         $Session.Cookies.Add((New-Object System.Net.Cookie("oisauthtoken", $($SessionContext.AuthCookie.Value), "/", $($SessionContext.AuthCookie.domain))))
     }
 
-    if (![string]::IsNullOrEmpty($($BoundParams.CookiePath))) {
-        "{0} - Export cookie to: {1}" -f $MyInvocation.MyCommand, $BoundParams.CookiePath | Write-Verbose
+    if (![string]::IsNullOrEmpty($($BoundParams['CookiePath']))) {
+        "{0} - Export cookie to: {1}" -f $MyInvocation.MyCommand, $BoundParams['CookiePath'] | Write-Verbose
 
         # Uses the same helper as the read path in Invoke-OmadaRequest.ps1 to guarantee an identical
         # filename (previously this used the cookie's own .domain attribute, which may lack the port,
         # producing a different filename than what the read path looked for). Built from
-        # $BoundParams.Uri directly rather than relying on the caller's $Uri local.
-        $CookieFileName = Get-OmadaCookieFileName -Uri ([System.Uri]::new($BoundParams.Uri)) -Credential $BoundParams.Credential -SessionKey $BoundParams.SessionKey
-        $CookiePath = (Join-Path $($BoundParams.CookiePath) -ChildPath $CookieFileName)
+        # $BoundParams['Uri'] directly rather than relying on the caller's $Uri local.
+        $CookieFileName = Get-OmadaCookieFileName -Uri ([System.Uri]::new($BoundParams['Uri'])) -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey']
+        $CookiePath = (Join-Path $($BoundParams['CookiePath']) -ChildPath $CookieFileName)
         $CookieObject = [PSCustomObject]@{
             OmadaWebAuthCookie = $SessionContext.AuthCookie
         }
@@ -118,7 +122,7 @@ function Invoke-BrowserAuthentication {
             "Cookie file exported to: {0}" -f $CookiePath | Write-Verbose
         }
         catch [System.UnauthorizedAccessException] {
-            "Unable to export the cookie file due to insufficient permissions in folder {0}" -f $($BoundParams.CookiePath) | Write-Warning
+            "Unable to export the cookie file due to insufficient permissions in folder {0}" -f $($BoundParams['CookiePath']) | Write-Warning
         }
         catch {
             $PSCmdlet.ThrowTerminatingError($PSItem)

--- a/OmadaWeb.PS/Private/Invoke-OAuthAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OAuthAuthentication.ps1
@@ -11,22 +11,22 @@
     "{0} - Invoking OAuth authentication" -f $MyInvocation.MyCommand | Write-Verbose
 
     "{0} - Request bearer token" -f $MyInvocation.MyCommand | Write-Verbose
-    if ($null -eq $BoundParams.Credential) {
+    if ($null -eq $BoundParams['Credential']) {
         "{0} - Credentials not provided! This mandatory for OAuth authentication!" -f $MyInvocation.MyCommand | Write-Error -ErrorAction "Stop"
     }
-    if ($null -eq $BoundParams.EntraIdTenantId -and -not $BoundParams.Keys.Contains("OAuthUri")) {
+    if ($null -eq $BoundParams['EntraIdTenantId'] -and -not $BoundParams.Keys.Contains("OAuthUri")) {
         "{0} - EntraIdTenantId not provided! This mandatory for Entra based OAuth authentication when no custom OAuthUri is provided!" -f $MyInvocation.MyCommand | Write-Error -ErrorAction "Stop"
     }
 
     $OAuthUri = $null
-    if ($null -ne $BoundParams.EntraIdTenantId) {
-        if ($null -ne $BoundParams.OAuthUri) {
+    if ($null -ne $BoundParams['EntraIdTenantId']) {
+        if ($null -ne $BoundParams['OAuthUri']) {
             "Using OAuth2 authentication with a provided EntraIdTenantId. Parameter OAuthUri is also provided, but will not be used!" -f $MyInvocation.MyCommand | Write-Warning
         }
-        $OAuthUri = ("https://login.microsoftonline.com/{0}/oauth2/v2.0/token" -f $BoundParams.EntraIdTenantId)
+        $OAuthUri = ("https://login.microsoftonline.com/{0}/oauth2/v2.0/token" -f $BoundParams['EntraIdTenantId'])
     }
-    elseif ( $null -ne $BoundParams.OAuthUri) {
-        $OAuthUri = $BoundParams.OAuthUri
+    elseif ( $null -ne $BoundParams['OAuthUri']) {
+        $OAuthUri = $BoundParams['OAuthUri']
     }
     else {
         "{0} - Neither EntraIdTenantId nor OAuthUri provided! Cannot proceed with OAuth authentication!" -f $MyInvocation.MyCommand | Write-Error -ErrorAction "Stop"
@@ -34,23 +34,23 @@
 
     $EntraApplicationIdUri = $SessionContext.BaseUrl
     if ("EntraApplicationIdUri" -in $BoundParams.Keys) {
-        $EntraApplicationIdUri = $BoundParams.EntraApplicationIdUri
+        $EntraApplicationIdUri = $BoundParams['EntraApplicationIdUri']
     }
 
     $OAuthScope = ("{0}/.default" -f $EntraApplicationIdUri )
-    if ($BoundParams.Keys -contains "OAuthScope" -and $null -ne $BoundParams.OAuthScope) {
-        "{0} - OAuthScope parameter used! OAuthScope: {1}" -f $MyInvocation.MyCommand, $BoundParams.OAuthScope | Write-Verbose
-        $OAuthScope = $BoundParams.OAuthScope
+    if ($BoundParams.Keys -contains "OAuthScope" -and $null -ne $BoundParams['OAuthScope']) {
+        "{0} - OAuthScope parameter used! OAuthScope: {1}" -f $MyInvocation.MyCommand, $BoundParams['OAuthScope'] | Write-Verbose
+        $OAuthScope = $BoundParams['OAuthScope']
     }
     else {
-        "{0} - Using custom OAuth2 scope: {1}" -f $MyInvocation.MyCommand, $BoundParams.OAuthScope | Write-Verbose
+        "{0} - Using custom OAuth2 scope: {1}" -f $MyInvocation.MyCommand, $BoundParams['OAuthScope'] | Write-Verbose
     }
 
     $RequestBody = @{
         scope         = $OAuthScope
-        client_id     = $($BoundParams.Credential.UserName.Trim())
+        client_id     = $($BoundParams['Credential'].UserName.Trim())
         grant_type    = 'client_credentials'
-        client_secret = $($BoundParams.Credential.GetNetworkCredential().Password)
+        client_secret = $($BoundParams['Credential'].GetNetworkCredential().Password)
     }
 
     $Arguments = @{
@@ -68,7 +68,21 @@
 
     "{0} - Invoke REST method to get bearer token from OAuth2 endpoint: {1}" -f $MyInvocation.MyCommand, $OAuthUri | Write-Verbose
     $BearerToken = Invoke-RestMethod @Arguments
-    $BoundParams.Headers.Add("Authorization" , "Bearer {0}" -f $BearerToken.access_token)
+
+    # The token request runs with -ErrorAction SilentlyContinue, so a failed call or a response that is
+    # not a token document arrives here as $null, or as an object with no access_token on it, instead
+    # of as a thrown error. That case is passed through as an empty bearer value, which is what this
+    # function has always done - it is deliberately not turned into a terminating error here, because
+    # callers today rely on the request continuing. It is only made explicit so the read cannot fault.
+    $AccessToken = $null
+    if ($null -ne $BearerToken -and $BearerToken.PSObject.Properties['access_token']) {
+        $AccessToken = $BearerToken.access_token
+    }
+    else {
+        "{0} - The OAuth2 endpoint '{1}' returned no access_token. Continuing with an empty bearer value." -f $MyInvocation.MyCommand, $OAuthUri | Write-Verbose
+    }
+
+    $BoundParams['Headers'].Add("Authorization" , "Bearer {0}" -f $AccessToken)
 
     return $RequestContext
 }

--- a/OmadaWeb.PS/Private/Invoke-OAuthAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OAuthAuthentication.ps1
@@ -43,7 +43,11 @@
         $OAuthScope = $BoundParams['OAuthScope']
     }
     else {
-        "{0} - Using custom OAuth2 scope: {1}" -f $MyInvocation.MyCommand, $BoundParams['OAuthScope'] | Write-Verbose
+        # Reports $OAuthScope, the default derived above. This branch is the one where no OAuthScope
+        # was supplied, so it used to announce a "custom" scope and then print the empty value of the
+        # parameter that was not passed - the opposite of what happened, on the path where a reader
+        # most needs to know which scope was actually requested.
+        "{0} - No OAuthScope parameter used, defaulting to: {1}" -f $MyInvocation.MyCommand, $OAuthScope | Write-Verbose
     }
 
     $RequestBody = @{

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -19,7 +19,7 @@ function Invoke-OmadaRequest {
             }
             else {
                 $Script:UserAgentParameterUsed = $true
-                $Script:UserAgent = $BoundParams.UserAgent
+                $Script:UserAgent = $BoundParams['UserAgent']
             }
 
             if ("DebugWebView2" -in $BoundParams.Keys) {
@@ -41,15 +41,15 @@ function Invoke-OmadaRequest {
             }
 
             $RetryPolicy = @{
-                MaximumRetryCount = [int]$BoundParams.MaximumRetryCount
-                RetryIntervalSec  = [int]$BoundParams.RetryIntervalSec
+                MaximumRetryCount = [int]$BoundParams['MaximumRetryCount']
+                RetryIntervalSec  = [int]$BoundParams['RetryIntervalSec']
             }
 
             if ("Headers" -notin $BoundParams.Keys) {
                 $BoundParams.Add("Headers", @{})
             }
 
-            $Uri = [System.Uri]::new($BoundParams.Uri)
+            $Uri = [System.Uri]::new($BoundParams['Uri'])
             if ($null -ne $Uri) {
                 $BaseUrl = $Uri.GetLeftPart([System.UriPartial]::Authority)
 
@@ -79,7 +79,7 @@ function Invoke-OmadaRequest {
                 }
             }
             else {
-                "Could not determine the base URL from '{0}', is the URL correct?" -f $BoundParams.Uri | Write-Error -ErrorAction "Stop"
+                "Could not determine the base URL from '{0}', is the URL correct?" -f $BoundParams['Uri'] | Write-Error -ErrorAction "Stop"
             }
 
             $Session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
@@ -92,7 +92,7 @@ function Invoke-OmadaRequest {
             # Reusable session state (cookie, base URL, WebView2 profile, etc.) is keyed by
             # (tenant base URL, auth type, identity) instead of single unkeyed module variables,
             # so concurrent sessions to different tenants/users don't clobber each other.
-            $SessionKey = Get-OmadaSessionKey -Uri $Uri -AuthenticationType $BoundParams.AuthenticationType -Credential $BoundParams.Credential -SessionKey $BoundParams.SessionKey
+            $SessionKey = Get-OmadaSessionKey -Uri $Uri -AuthenticationType $BoundParams['AuthenticationType'] -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey']
             $SessionContext = Get-OmadaSessionContext -Key $SessionKey -AuthorityHost $Uri.Host
             $SessionContext.BaseUrl = $BaseUrl
             # Computed unconditionally (not just lazily inside the encrypted-cache branch below) so it's
@@ -108,8 +108,8 @@ function Invoke-OmadaRequest {
             if ($BoundParams.Keys -contains "CookiePath") {
                 # -CookiePath is authoritative on every call (not just when no cookie is cached yet),
                 # so callers can force a specific session's cookie to be used for a given call.
-                $CookieFileName = Get-OmadaCookieFileName -Uri $Uri -Credential $BoundParams.Credential -SessionKey $BoundParams.SessionKey
-                $CookiePath = (Join-Path $($BoundParams.CookiePath) -ChildPath $CookieFileName)
+                $CookieFileName = Get-OmadaCookieFileName -Uri $Uri -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey']
+                $CookiePath = (Join-Path $($BoundParams['CookiePath']) -ChildPath $CookieFileName)
                 "{0} - Loading custom cookie: {1}" -f $MyInvocation.MyCommand, $CookiePath | Write-Verbose
                 if (!(Test-Path $CookiePath -PathType Leaf)) {
                     # -CookiePath is authoritative, so a missing file must not leave a stale in-memory
@@ -151,25 +151,25 @@ function Invoke-OmadaRequest {
                 }
             }
 
-            "{0} - Authentication type: {1}" -f $MyInvocation.MyCommand, $($BoundParams.AuthenticationType) | Write-Verbose
+            "{0} - Authentication type: {1}" -f $MyInvocation.MyCommand, $($BoundParams['AuthenticationType']) | Write-Verbose
 
             # -PreferredMfaMethod drives the Entra ID sign-in screens, which only the WebView2 engine
             # automates. Every other authentication type would accept the parameter and quietly do
             # nothing with it, so it is refused here rather than silently ignored.
-            if ("PreferredMfaMethod" -in $BoundParams.Keys -and -not [string]::IsNullOrWhiteSpace($BoundParams.PreferredMfaMethod)) {
+            if ("PreferredMfaMethod" -in $BoundParams.Keys -and -not [string]::IsNullOrWhiteSpace($BoundParams['PreferredMfaMethod'])) {
                 # The three ways a sign-in ends up on WebView2, which is what Invoke-BrowserAuthentication
                 # itself checks: the authentication type, the deprecated switch, and a session that
                 # has already used WebView2 - after which -AuthenticationType Browser keeps using it
                 # without either of the first two being supplied again. Leaving that last one out
                 # refused the parameter on exactly the sign-in it would have applied to.
-                $UsesWebView2 = $BoundParams.AuthenticationType -eq "WebView2" -or
-                    ($BoundParams.AuthenticationType -eq "Browser" -and (($BoundParams.ContainsKey("UseWebView2") -and $BoundParams.UseWebView2) -or $SessionContext.WebView2Used))
+                $UsesWebView2 = $BoundParams['AuthenticationType'] -eq "WebView2" -or
+                    ($BoundParams['AuthenticationType'] -eq "Browser" -and (($BoundParams.ContainsKey("UseWebView2") -and $BoundParams['UseWebView2']) -or $SessionContext.WebView2Used))
                 if (-not $UsesWebView2) {
-                    "{0} - -PreferredMfaMethod only applies to -AuthenticationType WebView2, got '{1}'" -f $MyInvocation.MyCommand, $BoundParams.AuthenticationType | Write-Error -ErrorAction "Stop"
+                    "{0} - -PreferredMfaMethod only applies to -AuthenticationType WebView2, got '{1}'" -f $MyInvocation.MyCommand, $BoundParams['AuthenticationType'] | Write-Error -ErrorAction "Stop"
                 }
             }
 
-            switch ($BoundParams.AuthenticationType) {
+            switch ($BoundParams['AuthenticationType']) {
                 "Windows" {
                     "{0} - {1} Authentication" -f $MyInvocation.MyCommand, $_ | Write-Verbose
                     $RequestContext = Invoke-WindowsAuthentication -RequestContext $RequestContext
@@ -202,8 +202,8 @@ function Invoke-OmadaRequest {
                 }
             }
 
-            if ($BoundParams.Method -in @('PUT', 'POST', 'PATCH')) {
-                "{0} - {1} - Add Body" -f $MyInvocation.MyCommand, $BoundParams.Method | Write-Verbose
+            if ($BoundParams['Method'] -in @('PUT', 'POST', 'PATCH')) {
+                "{0} - {1} - Add Body" -f $MyInvocation.MyCommand, $BoundParams['Method'] | Write-Verbose
                 $RequestContext = Set-Body -RequestContext $RequestContext
             }
 
@@ -215,9 +215,9 @@ function Invoke-OmadaRequest {
             }
 
             $Paged = $false
-            if ("Paged" -in $BoundParams.Keys -and [bool]$BoundParams.Paged) {
-                if ("Method" -in $BoundParams.Keys -and $BoundParams.Method -ne "GET") {
-                    "{0} - -Paged only supports HTTP GET requests, got -Method '{1}'" -f $MyInvocation.MyCommand, $BoundParams.Method | Write-Error -ErrorAction "Stop"
+            if ("Paged" -in $BoundParams.Keys -and [bool]$BoundParams['Paged']) {
+                if ("Method" -in $BoundParams.Keys -and $BoundParams['Method'] -ne "GET") {
+                    "{0} - -Paged only supports HTTP GET requests, got -Method '{1}'" -f $MyInvocation.MyCommand, $BoundParams['Method'] | Write-Error -ErrorAction "Stop"
                 }
                 $Paged = $true
             }
@@ -246,16 +246,16 @@ function Invoke-OmadaRequest {
                 switch ($Script:FunctionName) {
                     "Invoke-RestMethod" {
 
-                        if ("Accept" -notin $BoundParams.Headers.Keys) {
-                            $BoundParams.Headers.Add("Accept", "application/json")
+                        if ("Accept" -notin $BoundParams['Headers'].Keys) {
+                            $BoundParams['Headers'].Add("Accept", "application/json")
                         }
 
                         if ("ContentType" -in $BoundParams.Keys) {
-                            $BoundParams.Headers.Add("Content-Type", $BoundParams.ContentType)
+                            $BoundParams['Headers'].Add("Content-Type", $BoundParams['ContentType'])
                             $BoundParams.Remove("ContentType") | Out-Null
                         }
-                        elseif ("Content-Type" -notin $BoundParams.Headers.Keys) {
-                            $BoundParams.Headers.Add("Content-Type", "application/json")
+                        elseif ("Content-Type" -notin $BoundParams['Headers'].Keys) {
+                            $BoundParams['Headers'].Add("Content-Type", "application/json")
                         }
                         $Parameters = Set-RequestParameter -RequestContext $RequestContext
 
@@ -293,7 +293,11 @@ function Invoke-OmadaRequest {
                                     if ($null -ne $NextPage -and $NextPage.PSObject.Properties['value']) {
                                         $ValueList.AddRange(@($NextPage.value))
                                     }
-                                    $NextLink = if ($null -ne $NextPage) { $NextPage.'@odata.nextLink' } else { $null }
+                                    # The property test matches the guard on the entry condition above.
+                                    # The last page is precisely the one that carries no @odata.nextLink,
+                                    # so reading it unguarded faults on the final iteration of every
+                                    # paged request rather than ending the loop.
+                                    $NextLink = if ($null -ne $NextPage -and $NextPage.PSObject.Properties['@odata.nextLink']) { $NextPage.'@odata.nextLink' } else { $null }
                                 }
                                 $Return.value = $ValueList.ToArray()
                                 $Return.PSObject.Properties.Remove('@odata.nextLink')
@@ -304,7 +308,7 @@ function Invoke-OmadaRequest {
                         }
 
                         #To support -SkipHttpErrorCheck
-                        if ($BoundParams.Keys -contains "SkipHttpErrorCheck" -and ($BoundParams.AuthenticationType) -in ("Browser", "WebView2") -and $Return -is [System.Xml.XmlDocument]) {
+                        if ($BoundParams.Keys -contains "SkipHttpErrorCheck" -and ($BoundParams['AuthenticationType']) -in ("Browser", "WebView2") -and $Return -is [System.Xml.XmlDocument]) {
                             $NamespaceManager = New-Object System.Xml.XmlNamespaceManager($Return.NameTable)
                             $NamespaceManager.AddNamespace("xhtml", "http://www.w3.org/1999/xhtml")
                             if ($Return.SelectSingleNode('//xhtml:html/xhtml:head/xhtml:title', $NamespaceManager).'#text' -like "401 *") {
@@ -327,7 +331,7 @@ function Invoke-OmadaRequest {
                         $Return = Invoke-OmadaRetryableRequest -CommandInfo $CommandInfo -Parameters $Parameters @RetryPolicy
 
                         #To support -SkipHttpErrorCheck
-                        if ($BoundParams.Keys -contains "SkipHttpErrorCheck" -and ($BoundParams.AuthenticationType) -in ("Browser", "WebView2") -and $Return -is [Microsoft.PowerShell.Commands.WebResponseObject] -and $Return.StatusCode -eq 401) {
+                        if ($BoundParams.Keys -contains "SkipHttpErrorCheck" -and ($BoundParams['AuthenticationType']) -in ("Browser", "WebView2") -and $Return -is [Microsoft.PowerShell.Commands.WebResponseObject] -and $Return.StatusCode -eq 401) {
                             throw $CustomErrorTrigger
                         }
                         $SessionContext.LoginCount++
@@ -353,7 +357,7 @@ function Invoke-OmadaRequest {
                     $Script:RecheckEnvironmentSuspended = $true
                     "{0} - Received HTTP 502; environment suspension will be re-checked on the next request." -f $MyInvocation.MyCommand | Write-Verbose
                 }
-                if (($BoundParams.AuthenticationType) -in ("Browser", "WebView2") -and ($StatusCode -eq 401 -or $_.Exception.Message -eq $CustomErrorTrigger)) {
+                if (($BoundParams['AuthenticationType']) -in ("Browser", "WebView2") -and ($StatusCode -eq 401 -or $_.Exception.Message -eq $CustomErrorTrigger)) {
 
                     # The exception comes from Invoke-RestMethod/Invoke-WebRequest or the browser stack
                     # and routinely quotes the request that failed, headers included. There is no
@@ -370,7 +374,7 @@ function Invoke-OmadaRequest {
                         "Re-authentication failed!" | Write-Host
                     }
                     $WebView2Authentication = $false
-                    if ($BoundParams.ContainsKey('UseWebView2') -and $BoundParams.UseWebView2 -or $BoundParams.AuthenticationType -eq "WebView2") {
+                    if ($BoundParams.ContainsKey('UseWebView2') -and $BoundParams['UseWebView2'] -or $BoundParams['AuthenticationType'] -eq "WebView2") {
                         $WebView2Authentication = $true
                     }
                     elseif ($SessionContext.WebView2Used) {
@@ -379,12 +383,12 @@ function Invoke-OmadaRequest {
                     }
                     if ($WebView2Authentication) {
                         "{0} - Using WebView2 for authentication" -f $MyInvocation.MyCommand | Write-Verbose
-                        Get-DataFromWebView2 -SessionContext $SessionContext -EdgeProfile $BoundParams.EdgeProfile -InPrivate:$($BoundParams.InPrivate).IsPresent
+                        Get-DataFromWebView2 -SessionContext $SessionContext -EdgeProfile $BoundParams['EdgeProfile'] -InPrivate:([bool]$BoundParams['InPrivate'])
                         $BrowserData = @($SessionContext.AuthCookie, $Script:UserAgent)
                         $SessionContext.WebView2Used = $true
                     }
                     else {
-                        $BrowserData = Get-DataFromWebDriver -SessionContext $SessionContext -EdgeProfile $BoundParams.EdgeProfile -InPrivate:$($BoundParams.InPrivate).IsPresent
+                        $BrowserData = Get-DataFromWebDriver -SessionContext $SessionContext -EdgeProfile $BoundParams['EdgeProfile'] -InPrivate:([bool]$BoundParams['InPrivate'])
                     }
                     $SessionContext.AuthCookie = $BrowserData[0]
 
@@ -393,8 +397,8 @@ function Invoke-OmadaRequest {
                         # so the freshly re-authenticated cookie must be persisted here first - otherwise the
                         # recursive call below would immediately reload and clobber it with the stale cookie
                         # still on disk (the one that caused this 401 in the first place), looping forever.
-                        $RetryCookieFileName = Get-OmadaCookieFileName -Uri $Uri -Credential $BoundParams.Credential -SessionKey $BoundParams.SessionKey
-                        $RetryCookiePath = Join-Path $BoundParams.CookiePath -ChildPath $RetryCookieFileName
+                        $RetryCookieFileName = Get-OmadaCookieFileName -Uri $Uri -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey']
+                        $RetryCookiePath = Join-Path $BoundParams['CookiePath'] -ChildPath $RetryCookieFileName
                         try {
                             [PSCustomObject]@{ OmadaWebAuthCookie = $SessionContext.AuthCookie } | Export-Clixml $RetryCookiePath -Force
                         }

--- a/OmadaWeb.PS/Private/Invoke-WindowsAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WindowsAuthentication.ps1
@@ -11,8 +11,8 @@ function Invoke-WindowsAuthentication {
     if ($BoundParams.keys -notcontains "Credential") {
         $BoundParams.Add("Credential", (Get-Credential -Message "Please enter your authentication credentials"))
     }
-    if ($BoundParams.Keys -contains "Headers" -and $BoundParams.Headers.ContainsKey("Authorization")) {
-        $BoundParams.Headers.Remove("Authorization")
+    if ($BoundParams.Keys -contains "Headers" -and $BoundParams['Headers'].ContainsKey("Authorization")) {
+        $BoundParams['Headers'].Remove("Authorization")
     }
 
     return $RequestContext

--- a/OmadaWeb.PS/Private/New-OmadaWebCacheItem.ps1
+++ b/OmadaWeb.PS/Private/New-OmadaWebCacheItem.ps1
@@ -52,10 +52,11 @@ function New-OmadaWebCacheItem {
         $Files = @()
     }
 
-    # Measure-Object returns $null for Sum over an empty collection, which would surface as a blank
-    # column instead of a zero.
+    # Over an empty collection Measure-Object emits nothing at all rather than an object whose Sum is
+    # $null, so $Measured itself has to be tested before its Sum is read - otherwise the empty-cache
+    # case, which is the one this guard exists for, faults instead of reporting a zero.
     $Measured = $Files | Measure-Object -Property Length -Sum
-    if ($null -ne $Measured.Sum) {
+    if ($null -ne $Measured -and $null -ne $Measured.Sum) {
         $SizeBytes = $Measured.Sum
     }
 

--- a/OmadaWeb.PS/Private/Set-Body.ps1
+++ b/OmadaWeb.PS/Private/Set-Body.ps1
@@ -7,23 +7,23 @@ function Set-Body {
 
     $BoundParams = $RequestContext.BoundParams
 
-    "{0} - {1} - Add Body" -f $MyInvocation.MyCommand, $BoundParams.Method | Write-Verbose
-    if ($null -eq $BoundParams.Body) {
-        "{0} - Provided -Body is empty this is mandatory for a {1} command" -f $MyInvocation.MyCommand , $BoundParams.Method | Write-Error -ErrorAction "Stop"
+    "{0} - {1} - Add Body" -f $MyInvocation.MyCommand, $BoundParams['Method'] | Write-Verbose
+    if ($null -eq $BoundParams['Body']) {
+        "{0} - Provided -Body is empty this is mandatory for a {1} command" -f $MyInvocation.MyCommand , $BoundParams['Method'] | Write-Error -ErrorAction "Stop"
     }
 
-    if ("Content-Type" -notin $BoundParams.Headers.Keys) {
-        $BoundParams.Headers.Add("Content-Type", "application/json")
+    if ("Content-Type" -notin $BoundParams['Headers'].Keys) {
+        $BoundParams['Headers'].Add("Content-Type", "application/json")
     }
     else {
-        $BoundParams.Headers.'Content-Type' = "application/json"
+        $BoundParams['Headers'].'Content-Type' = "application/json"
     }
-    if ($BoundParams.Body.GetType().FullName -in @("System.Collections.Hashtable", "System.Collections.Specialized.OrderedDictionary", "System.Management.Automation.PSCustomObject")) {
-        "{0} - Provided -Body data type is {1}, converting it to json" -f $MyInvocation.MyCommand, $BoundParams.Body.GetType().FullName | Write-Verbose
+    if ($BoundParams['Body'].GetType().FullName -in @("System.Collections.Hashtable", "System.Collections.Specialized.OrderedDictionary", "System.Management.Automation.PSCustomObject")) {
+        "{0} - Provided -Body data type is {1}, converting it to json" -f $MyInvocation.MyCommand, $BoundParams['Body'].GetType().FullName | Write-Verbose
         # Depth 100 (the maximum PowerShell accepts) so nested request bodies are never
         # silently truncated to their type name. Depth is a ceiling, not a cost: serialization
         # stops when the object graph ends, so a flat body is no slower than at the default.
-        $BoundParams.Body = $BoundParams.Body | ConvertTo-Json -Depth 100
+        $BoundParams['Body'] = $BoundParams['Body'] | ConvertTo-Json -Depth 100
     }
     else {
         "{0} - Provided -Body will be processed directly without converting it." -f $MyInvocation.MyCommand | Write-Verbose

--- a/OmadaWeb.PS/Private/Set-DynamicParameter.ps1
+++ b/OmadaWeb.PS/Private/Set-DynamicParameter.ps1
@@ -36,16 +36,29 @@ function Set-DynamicParameter {
     )
 
     $ParameterObjects = @()
+    # The names are tracked separately rather than read back off $ParameterObjects. Reading a property
+    # from an array enumerates its elements, and doing that to the empty array of the first iteration
+    # is an error under StrictMode - which is how this function used to fail before a single dynamic
+    # parameter had been built.
+    [string[]]$SeenParameterNames = @()
     foreach ($ParameterSet in $FunctionObject.ParameterSets) {
         foreach ($Parameter in $ParameterSet.Parameters) {
             if ($Parameter.Name -notin $ExcludedParameters) {
-                if ($Parameter.Name -notin $ParameterObjects.Name) {
+                if ($Parameter.Name -notin $SeenParameterNames) {
+                    $SeenParameterNames += $Parameter.Name
                     $ParameterSetName = @($($ParameterSet.Name))
                     $ParameterObjects += @{
                         Name                            = $Parameter.Name
                         Type                            = $Parameter.ParameterType
                         Alias                           = $Parameter.Aliases
-                        ValidateSet                     = $Parameter.ValidateSet
+                        # No ValidateSet is copied across. CommandParameterInfo has no such member -
+                        # the validate sets live in its Attributes collection - so the read that used
+                        # to sit here yielded $null for every parameter and no inherited parameter has
+                        # ever carried one. It is left that way deliberately rather than derived from
+                        # Attributes: the value is splatted on to the real Invoke-RestMethod /
+                        # Invoke-WebRequest, which enforces its own validation, so deriving it here
+                        # would only move the same rejection earlier and could reject values the
+                        # module accepts today.
                         Mandatory                       = $Parameter.IsMandatory
                         ParameterSetName                = $ParameterSetName
                         Position                        = $Parameter.Position
@@ -62,12 +75,20 @@ function Set-DynamicParameter {
     }
 
     [string[]]$ParameterObjectSetNames = $null
-    if (($ParameterObjects.ParameterSetName | Select-Object -Unique | Measure-Object).Count -eq 1 -and [string]::IsNullOrWhiteSpace($ParameterObjects.ParameterSetName)) {
+    # Same reason as above: $ParameterObjects is empty when every parameter of the wrapped cmdlet was
+    # excluded, so the set names are materialised once behind a count check rather than read off the
+    # array twice inline.
+    [string[]]$DeclaredParameterSetNames = @()
+    if ($ParameterObjects.Count -gt 0) {
+        $DeclaredParameterSetNames = @($ParameterObjects.ParameterSetName)
+    }
+
+    if (($DeclaredParameterSetNames | Select-Object -Unique | Measure-Object).Count -eq 1 -and [string]::IsNullOrWhiteSpace($DeclaredParameterSetNames)) {
         $ParameterObjectSetNames += "__AllParameterSets"
         $ParameterObjects | ForEach-Object { $_.ParameterSetName = "__AllParameterSets" }
     }
     else {
-        $ParameterObjectSetNames += $ParameterObjects.ParameterSetName | Select-Object -Unique
+        $ParameterObjectSetNames += $DeclaredParameterSetNames | Select-Object -Unique
     }
 
     foreach ($ParameterObject in $ParameterObjects) {

--- a/OmadaWeb.PS/Private/Set-DynamicParameter.ps1
+++ b/OmadaWeb.PS/Private/Set-DynamicParameter.ps1
@@ -83,7 +83,12 @@ function Set-DynamicParameter {
         $DeclaredParameterSetNames = @($ParameterObjects.ParameterSetName)
     }
 
-    if (($DeclaredParameterSetNames | Select-Object -Unique | Measure-Object).Count -eq 1 -and [string]::IsNullOrWhiteSpace($DeclaredParameterSetNames)) {
+    # The uniqued list is indexed rather than passed whole to IsNullOrWhiteSpace, which would rely on
+    # an array-to-string conversion to say anything at all. The Count test in front of it means there
+    # is exactly one element to look at, so this asks the question the condition actually means: the
+    # wrapped cmdlet declared a single, unnamed parameter set.
+    $UniqueParameterSetNames = @($DeclaredParameterSetNames | Select-Object -Unique)
+    if ($UniqueParameterSetNames.Count -eq 1 -and [string]::IsNullOrWhiteSpace($UniqueParameterSetNames[0])) {
         $ParameterObjectSetNames += "__AllParameterSets"
         $ParameterObjects | ForEach-Object { $_.ParameterSetName = "__AllParameterSets" }
     }

--- a/Tests/Unit/StrictMode.Tests.ps1
+++ b/Tests/Unit/StrictMode.Tests.ps1
@@ -53,20 +53,16 @@ Describe 'StrictMode' -Tag 'Unit' {
             # covers everything else. This walks their syntax tree instead, which is what caught the
             # reads that made this file necessary.
             $Script:LoginFlowFiles = @(
-                @{ File = 'Get-DataFromWebDriver.ps1'; Skip = $false; Because = '' }
-                # Invoke-WebView2MicrosoftLogin.ps1 still reads an unassigned $MfaElementIds on line
-                # 789. The fix is already on the branch of PR #67, which rewrites this file, so it is
-                # not duplicated here - two edits to the same 800-line rewrite would only collide.
-                # Flip Skip to $false once #67 has merged; the check itself is ready for it.
-                @{ File = 'Invoke-WebView2MicrosoftLogin.ps1'; Skip = $true; Because = 'fixed by PR #67, which rewrites this file' }
+                @{ File = 'Get-DataFromWebDriver.ps1' }
+                @{ File = 'Invoke-WebView2MicrosoftLogin.ps1' }
+                @{ File = 'Resolve-EntraSignInScreen.ps1' }
+                @{ File = 'Select-EntraMfaMethod.ps1' }
+                @{ File = 'Show-EntraApprovalNumber.ps1' }
+                @{ File = 'Reset-LoginAutomationState.ps1' }
             )
         }
 
         It 'Should not read an unassigned variable in <File>' -ForEach $Script:LoginFlowFiles {
-            if ($Skip) {
-                Set-ItResult -Skipped -Because $Because
-            }
-
             $SourcePath = Join-Path (Split-Path (Split-Path $PSScriptRoot)) -ChildPath ('OmadaWeb.PS\Private\{0}' -f $File)
             Test-Path $SourcePath -PathType Leaf | Should -BeTrue -Because "$SourcePath should exist"
 

--- a/Tests/Unit/StrictMode.Tests.ps1
+++ b/Tests/Unit/StrictMode.Tests.ps1
@@ -95,9 +95,21 @@ Describe 'StrictMode' -Tag 'Unit' {
             Get-ChildItem -Path (Join-Path (Split-Path (Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS') -Recurse -Include '*.ps1', '*.psm1' |
                 ForEach-Object {
                     $ModuleFileAst = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$null)
-                    $ModuleFileAst.FindAll({ $args[0] -is [System.Management.Automation.Language.VariableExpressionAst] }, $true) |
-                        Where-Object { $_.VariablePath.IsScript -or $_.VariablePath.IsGlobal } |
-                        ForEach-Object { $null = $Assigned.Add(($_.VariablePath.UserPath -split ':', 2)[-1]) }
+                    $ModuleFileAst.FindAll({ $args[0] -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true) |
+                        ForEach-Object {
+                            # Assignment targets only, never plain reads: counting a $Script: read as a
+                            # definition would let a module-scoped name that nothing ever assigns vouch
+                            # for an unqualified read of the same name, which is the bug this looks for.
+                            $ScopedTarget = $_.Left
+                            while ($ScopedTarget -is [System.Management.Automation.Language.AttributedExpressionAst]) {
+                                $ScopedTarget = $ScopedTarget.Child
+                            }
+
+                            if ($ScopedTarget -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                                ($ScopedTarget.VariablePath.IsScript -or $ScopedTarget.VariablePath.IsGlobal)) {
+                                $null = $Assigned.Add(($ScopedTarget.VariablePath.UserPath -split ':', 2)[-1])
+                            }
+                        }
                 }
 
             $Ast.FindAll({ $args[0] -is [System.Management.Automation.Language.ForEachStatementAst] }, $true) |

--- a/Tests/Unit/StrictMode.Tests.ps1
+++ b/Tests/Unit/StrictMode.Tests.ps1
@@ -1,0 +1,134 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'StrictMode' -Tag 'Unit' {
+
+    Context 'Opt-in switch' {
+        BeforeAll {
+            $Script:PreviousStrictModeFlag = $Env:OMADAWEBPS_STRICTMODE
+        }
+
+        AfterAll {
+            # Restored, and the module re-imported under it, so the files Pester runs after this one
+            # see the same module state they would have seen had this file never run.
+            $Env:OMADAWEBPS_STRICTMODE = $Script:PreviousStrictModeFlag
+            Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+            Import-Module $ModulePath -Force -ErrorAction Stop
+        }
+
+        It 'Should run module code under StrictMode when OMADAWEBPS_STRICTMODE is 1' {
+            $Env:OMADAWEBPS_STRICTMODE = "1"
+            Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+            Import-Module $ModulePath -Force -ErrorAction Stop
+
+            InModuleScope 'OmadaWeb.PS' {
+                # Built and invoked inside the module's session state, so it inherits whatever
+                # StrictMode the module set on itself - which is the thing under test. A read of an
+                # unset variable is an error only when StrictMode is on.
+                { & { if ($NeverAssignedAnywhereInThisModule) { "reached" } } } | Should -Throw
+            }
+        }
+
+        It 'Should leave module code unstrict when OMADAWEBPS_STRICTMODE is not set' {
+            $Env:OMADAWEBPS_STRICTMODE = $null
+            Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+            Import-Module $ModulePath -Force -ErrorAction Stop
+
+            InModuleScope 'OmadaWeb.PS' {
+                { & { if ($NeverAssignedAnywhereInThisModule) { "reached" } } } | Should -Not -Throw
+            }
+        }
+    }
+
+    Context 'No unassigned variable reads in the login flows' {
+        BeforeDiscovery {
+            # The browser login flows cannot be executed by a unit test - they drive a real Edge or
+            # WebView2 window - so running the suite under StrictMode does not cover them the way it
+            # covers everything else. This walks their syntax tree instead, which is what caught the
+            # reads that made this file necessary.
+            $Script:LoginFlowFiles = @(
+                @{ File = 'Get-DataFromWebDriver.ps1'; Skip = $false; Because = '' }
+                # Invoke-WebView2MicrosoftLogin.ps1 still reads an unassigned $MfaElementIds on line
+                # 789. The fix is already on the branch of PR #67, which rewrites this file, so it is
+                # not duplicated here - two edits to the same 800-line rewrite would only collide.
+                # Flip Skip to $false once #67 has merged; the check itself is ready for it.
+                @{ File = 'Invoke-WebView2MicrosoftLogin.ps1'; Skip = $true; Because = 'fixed by PR #67, which rewrites this file' }
+            )
+        }
+
+        It 'Should not read an unassigned variable in <File>' -ForEach $Script:LoginFlowFiles {
+            if ($Skip) {
+                Set-ItResult -Skipped -Because $Because
+            }
+
+            $SourcePath = Join-Path (Split-Path (Split-Path $PSScriptRoot)) -ChildPath ('OmadaWeb.PS\Private\{0}' -f $File)
+            Test-Path $SourcePath -PathType Leaf | Should -BeTrue -Because "$SourcePath should exist"
+
+            $Tokens = $null
+            $ParseErrors = $null
+            $Ast = [System.Management.Automation.Language.Parser]::ParseFile($SourcePath, [ref]$Tokens, [ref]$ParseErrors)
+            $ParseErrors | Should -BeNullOrEmpty
+
+            # Anything the file assigns, binds as a parameter, or walks with foreach counts as defined.
+            $Assigned = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+            $Ast.FindAll({ $args[0] -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true) |
+                ForEach-Object {
+                    $Target = $_.Left
+                    if ($Target -is [System.Management.Automation.Language.ConvertExpressionAst]) {
+                        $Target = $Target.Child
+                    }
+
+                    if ($Target -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                        $null = $Assigned.Add($Target.VariablePath.UserPath)
+                    }
+                }
+
+            $Ast.FindAll({ $args[0] -is [System.Management.Automation.Language.ParameterAst] }, $true) |
+                ForEach-Object { $null = $Assigned.Add($_.Name.VariablePath.UserPath) }
+
+            # An unqualified read also finds module scope, so every $Script:-scoped name the module
+            # assigns anywhere counts as defined here - $WebView2 in one file is the $Script:WebView2
+            # another file assigns. Without this the check would flag ordinary module state.
+            Get-ChildItem -Path (Join-Path (Split-Path (Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS') -Recurse -Include '*.ps1', '*.psm1' |
+                ForEach-Object {
+                    $ModuleFileAst = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$null)
+                    $ModuleFileAst.FindAll({ $args[0] -is [System.Management.Automation.Language.VariableExpressionAst] }, $true) |
+                        Where-Object { $_.VariablePath.IsScript -or $_.VariablePath.IsGlobal } |
+                        ForEach-Object { $null = $Assigned.Add(($_.VariablePath.UserPath -split ':', 2)[-1]) }
+                }
+
+            $Ast.FindAll({ $args[0] -is [System.Management.Automation.Language.ForEachStatementAst] }, $true) |
+                ForEach-Object { $null = $Assigned.Add($_.Variable.VariablePath.UserPath) }
+
+            # Bound by the runtime rather than by this file.
+            $Automatic = @(
+                '_', 'PSItem', 'true', 'false', 'null', 'args', 'input', 'this', '$', '^', '?',
+                'MyInvocation', 'PSCmdlet', 'PSBoundParameters', 'PSScriptRoot', 'PSCommandPath',
+                'PSVersionTable', 'ErrorActionPreference', 'VerbosePreference', 'WarningPreference',
+                'InformationPreference', 'DebugPreference', 'ProgressPreference', 'Error', 'Host',
+                'PWD', 'Env', 'IsWindows', 'StackTrace', 'LASTEXITCODE', 'PID'
+            )
+            $Automatic | ForEach-Object { $null = $Assigned.Add($_) }
+
+            $Unassigned = $Ast.FindAll({ $args[0] -is [System.Management.Automation.Language.VariableExpressionAst] }, $true) |
+                Where-Object {
+                    # Only unqualified names are this file's own business: a $Script:- or $Global:-
+                    # scoped name is module state assigned elsewhere, and $Env:/$Using: are not
+                    # variables this file could assign at all.
+                    $_.VariablePath.IsUnqualified -and
+                    -not $Assigned.Contains($_.VariablePath.UserPath)
+                } |
+                ForEach-Object { '${0} (line {1})' -f $_.VariablePath.UserPath, $_.Extent.StartLineNumber } |
+                Select-Object -Unique
+
+            $Unassigned | Should -BeNullOrEmpty -Because ("{0} reads these without ever assigning them" -f $File)
+        }
+    }
+}

--- a/Tests/Unit/Test-EnvironmentSuspended.Tests.ps1
+++ b/Tests/Unit/Test-EnvironmentSuspended.Tests.ps1
@@ -66,7 +66,10 @@ Describe 'Test-EnvironmentSuspended' -Tag 'Unit' {
     Context 'Function Definition' {
         It 'Should have Url as a mandatory parameter' {
             InModuleScope 'OmadaWeb.PS' {
-                (Get-Command Test-EnvironmentSuspended).Parameters['Url'].Attributes.Mandatory | Should -Contain $true
+                # Filtered to the ParameterAttribute first: the collection also holds attributes that
+                # carry no Mandatory member, and enumerating the member across all of them is an error
+                # under StrictMode. Same idiom as the other parameter-metadata assertions.
+                (Get-Command Test-EnvironmentSuspended).Parameters['Url'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Contain $true
             }
         }
 


### PR DESCRIPTION
Closes #22

Fixes the unassigned-variable reads in the Selenium login flow and makes the test suite run the module under `Set-StrictMode -Version Latest`, which is what turns that whole bug class into a build failure instead of a silent `$null`.

## The thing that made this bigger than it looks

The `Set-StrictMode -Version Latest` in the `ImportModule` task (`Build/psakeBuild.ps1:334` on `main`) validated nothing. StrictMode is scoped to the session state it is set in, and a module runs in its own — so it reached neither the module's load-time code nor any of its functions. Verified directly:

```
caller-strict -> module function: no-throw
caller scope itself THREW: The variable '$AlsoUndefined' cannot be retrieved because it has not been set.
```

The module has always been imported unstrict no matter what the build did. That is how a read of a variable nobody assigns survived in the login flow. StrictMode now lives in the module, gated on `OMADAWEBPS_STRICTMODE`, which the `ImportModule` and `Test` tasks set.

## What was broken

| Where | Read | Effect |
|---|---|---|
| `Get-DataFromWebDriver.ps1:105,115` | `$SelectUserElementId` | never assigned — the "Select logged-in account" block could not run |
| `Get-DataFromWebDriver.ps1:108,109` | `$AccountElement` | never assigned — would have dereferenced `$null` had it been reached |
| `Get-DataFromWebDriver.ps1:144` | `$MfaRetryId` | leftover from the split into `$MfaRetryId1`/`$MfaRetryId2`; the conjunct was always true |
| `Set-DynamicParameter.ps1:42` | `.Name` on the empty `$ParameterObjects` | the entire dynamic-parameter surface failed before one parameter was built |
| `Set-DynamicParameter.ps1:45` | `$Parameter.ValidateSet` | `CommandParameterInfo` has no such member — always `$null`, so no inherited parameter has ever carried a validate set |
| `OmadaWeb.PS.psm1:431` | `$InstalledModule.RepositorySource` | `$null` on every build and test run; the empty `catch {}` swallowed it, leaving `$Script:UserAgent` as the unformatted `OmadaWeb.PS/{0}` template that every later request rejected as a malformed header |
| `Invoke-OmadaRequest.ps1:280` | `'@odata.nextLink'` on the next page | the last page is exactly the one without it — faulted on the final iteration of every paged request |
| `New-OmadaWebCacheItem.ps1:58` | `.Sum` over an empty collection | `Measure-Object` emits nothing there, so the empty-cache case faulted |
| `Invoke-OAuthAuthentication.ps1:71` | `.access_token` | the token call runs `-ErrorAction SilentlyContinue`, so a failure arrives as `$null` |
| `Invoke-BrowserAuthentication.ps1:27,32` | `.IsPresent` on absent switches | `$null` when the switch was not supplied |

## Decisions worth reviewing

**StrictMode is opt-in, not always on.** The issue said "in dev/test builds" and I kept it that way. The browser login flows are the module's largest code paths and CI cannot exercise them — they need a real interactive WebView2/Edge window, which is why the WebView2 integration tests fail locally. Shipping StrictMode would turn an unset-variable read on a path CI has never run into a broken sign-in in front of a user, trading a silent `$null` for an outage. Every test run is strict, so the bug class is still caught before it ships. Say the word if you would rather ship it on.

**Optional bound parameters are now read by index, not by dot.** `$BoundParams['Credential']` rather than `$BoundParams.Credential`, ~90 sites. Identical lookup on a hashtable, but a missing key is `$null` by index and a `PropertyNotFoundException` by dot — and `$BoundParams` is a bag of optional parameters by construction. Without this, every optional read is a landmine that only detonates when a test omits that parameter. Mechanical and behaviour-preserving; the bulk of the diff.

**The dead "Select logged-in account" block is deleted, not repaired.** The "Select logged-in user " block a few lines below already does that job correctly, matching `data-test-id` against the supplied user name. Repairing the broken one would have produced a second implementation of the same step.

**`$MfaRetryId` is fixed rather than dropped.** Replaced by a test against both `$MfaRetryId1` and `$MfaRetryId2`, which the file already declares and which is what the equivalent WebView2 flow does. This is the one behaviour change in the Selenium path: the "waiting for approval" message is now suppressed while a resend link is shown, which is what the condition was plainly meant to do.

**The InPrivate arms keep an odd asymmetry on purpose.** The second arm fires only on an explicit `-InPrivate:$false`, never on the switch being omitted, because `$null -eq $false` was already `False`. It looked like a bug; changing it would change authentication behaviour, so it is preserved and commented instead.

**The empty bearer value is preserved.** `Invoke-OAuth2Authentication` still sends `Bearer ` when the token endpoint returns nothing, because the integration tests point `-OAuthUri` at the plain test server and assert the request succeeds. Made explicit rather than turned into a terminating error. Worth a follow-up, along with the `catch {}` at `OmadaWeb.PS.psm1:455` that hid the user-agent bug — that is item D4.

**`ValidateSet` is dropped rather than derived.** It could be pulled out of `$Parameter.Attributes`, but the value is splatted on to the real `Invoke-RestMethod`/`Invoke-WebRequest`, which enforces its own validation. Deriving it would only move the same rejection earlier and could reject values the module accepts today.

## Acceptance criteria

- [x] `Get-NuGetPackage` either works and is used, or is deleted; the chosen strategy is stated in a comment or the README — done previously in #53
- [x] No undefined variable references remain in `Get-DataFromWebDriver.ps1`
- [x] No undefined variable references remain in `Invoke-WebView2MicrosoftLogin.ps1` — removed by #67; this PR adds the check that proves it
- [x] Test runs execute under `Set-StrictMode -Version Latest`
- [x] Analyzer/test run is green with StrictMode enabled

## Overlap with #67

#67 merged while this PR was open, so this branch is rebased on it. That resolved the last criterion: #67's rewrite removed the unassigned `$MfaElementIds` read, and the static check added here now covers `Invoke-WebView2MicrosoftLogin.ps1` and the four Entra helpers #67 added — all pass. The skip is gone.

One conflict, in `Invoke-OmadaRequest.ps1`: #67's new `-PreferredMfaMethod` guard landed on the lines this PR was changing. #67's logic is kept as written, with its `$BoundParams` reads moved to the index form for the same reason as the rest.

## Verification

`.\Build\build.ps1 -Task TestBuildOnly` (Analyze → Build → ImportModule → TestHelp → Test), PowerShell 7, both runs after #67 merged:

| | Passed | Failed |
|---|---|---|
| `main` (8ab62d3, baseline) | 652 | 26 |
| this branch | 660 | 26 |

The 26 failures are identical to the baseline — `diff` of the failing test names between the two runs is empty. All are `IOException: The handle is invalid.` from `Start-WebView2Login`: WebView2 needs a real interactive window and cannot run on this machine. They are pre-existing and environmental, not caused by this change. The analyzer produced no findings.

The 8 added passes are the new `Tests/Unit/StrictMode.Tests.ps1`.
