### PR TITLE
Watch the Entra sign-in page daily instead of waiting for a bug report (roadmap E5)

### DIFF
--- a/.github/workflows/entra-canary.yml
+++ b/.github/workflows/entra-canary.yml
@@ -1,0 +1,326 @@
+name: Entra Sign-in Canary
+
+# The scheduled pipeline the E2E tag was always excluded for (roadmap E5, issue #33).
+#
+# Signs in to Microsoft Entra ID once a day, in a real browser, with a real account in a tenant we
+# control, and fails when credential autofill stops recognizing Microsoft's sign-in screens. That is
+# the module's only dependency on Microsoft's DOM, and Microsoft changes it on its own schedule - so
+# without this the detection mechanism is a user bug report.
+#
+# A red canary means "autofill needs a selector update" - $Script:EntraSignInElementId in
+# OmadaWeb.PS/OmadaWeb.PS.psm1, see issue #32 - and not "login is broken". Since #52 a selector break
+# degrades autofill and hands the window to the user; this run is how that gets noticed first.
+#
+# The tenant setup, the secrets and the response to a red run are in docs/entra-canary.md.
+
+on:
+  schedule:
+    # Well clear of the nightly build at 01:17, so a runner queue shared between them never makes one
+    # look like the other's failure.
+    - cron: '43 5 * * *'
+  workflow_dispatch:
+    inputs:
+      browser_host_check_only:
+        description: 'Only check that the runner can host a WebView2 window, and skip the sign-in. Use to validate a new runner image without involving the tenant.'
+        required: false
+        default: false
+        type: boolean
+
+# Only 'issues: write' is elevated, and only so a failure can file the alert. Nothing here needs to
+# write to the repository.
+permissions:
+  contents: read
+  issues: write
+
+# Never cancel a run in progress: this drives a real sign-in against a real account, and killing it
+# half way leaves a browser profile and a listener behind on the runner for no benefit. A queued
+# duplicate simply waits.
+concurrency:
+  group: entra-signin-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Entra ID sign-in
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    # Holds the four canary secrets. An environment rather than repository secrets, so that no
+    # pull-request workflow can reach them.
+    environment: entra-canary
+
+    outputs:
+      outcome: ${{ steps.canary.outputs.outcome }}
+      report: ${{ steps.canary.outputs.report }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install modules
+        shell: pwsh
+        run: ./Build/InstallModules.ps1
+
+      # Built rather than run from source, so the canary exercises the same single .psm1 that ships
+      # to the Gallery. A sign-in that only works before the module is assembled is not a sign-in
+      # that works for a user.
+      - name: Build the module
+        shell: pwsh
+        run: ./Build/build.ps1 -Task Build -BuildVersion '0.0.0'
+
+      # Runs before the sign-in, and fails the job on its own. Without it, a runner that cannot open a
+      # browser window fails every canary assertion at once and the diagnostic reads "the sign-in page
+      # was not recognized" - true, and pointing at exactly the wrong thing. A maintainer would go
+      # looking at Microsoft's markup while the real answer was that no browser ever opened.
+      #
+      # Deliberately does not file an issue when it fails: nothing about the sign-in page has changed,
+      # so an alert saying otherwise would be a lie. The failed run is the signal.
+      - name: Check the runner can host a browser
+        shell: pwsh
+        run: ./Tests/E2E/Test-CanaryBrowserHost.ps1
+
+      - name: Run the canary
+        id: canary
+        if: inputs.browser_host_check_only != true
+        shell: pwsh
+        env:
+          OMADAWEBPS_CANARY_TENANT_ID: ${{ secrets.CANARY_TENANT_ID }}
+          OMADAWEBPS_CANARY_CLIENT_ID: ${{ secrets.CANARY_CLIENT_ID }}
+          OMADAWEBPS_CANARY_USERNAME: ${{ secrets.CANARY_USERNAME }}
+          OMADAWEBPS_CANARY_PASSWORD: ${{ secrets.CANARY_PASSWORD }}
+          OMADAWEBPS_CANARY_PORT: '8400'
+          OMADAWEBPS_STRICTMODE: '1'
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Masked before anything else runs. GitHub masks a secret it injected, but the tenant id
+          # and the account name arrive as ordinary strings in places it does not track - a Pester
+          # failure message, an exception - and this run files a public issue.
+          foreach ($name in 'OMADAWEBPS_CANARY_TENANT_ID','OMADAWEBPS_CANARY_CLIENT_ID','OMADAWEBPS_CANARY_USERNAME','OMADAWEBPS_CANARY_PASSWORD') {
+            $value = [Environment]::GetEnvironmentVariable($name)
+            if (-not [string]::IsNullOrWhiteSpace($value)) {
+              Write-Host "::add-mask::$value"
+            }
+          }
+
+          if ([string]::IsNullOrWhiteSpace($env:OMADAWEBPS_CANARY_TENANT_ID) -or
+              [string]::IsNullOrWhiteSpace($env:OMADAWEBPS_CANARY_CLIENT_ID) -or
+              [string]::IsNullOrWhiteSpace($env:OMADAWEBPS_CANARY_USERNAME) -or
+              [string]::IsNullOrWhiteSpace($env:OMADAWEBPS_CANARY_PASSWORD)) {
+            Write-Host "::notice title=Canary not configured::The 'entra-canary' environment has no canary secrets, so nothing was signed in. See docs/entra-canary.md."
+            "outcome=skipped" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "report=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            exit 0
+          }
+
+          $modulePath = Join-Path $env:GITHUB_WORKSPACE 'buildoutput/OmadaWeb.PS/OmadaWeb.PS.psm1'
+          if (-not (Test-Path $modulePath)) {
+            throw "The built module was not found at '$modulePath'."
+          }
+
+          function Invoke-CanaryAttempt {
+            param([int]$Attempt)
+
+            $diagnosticPath = Join-Path $env:RUNNER_TEMP ("canary-diagnostic-{0}.txt" -f $Attempt)
+            Remove-Item -LiteralPath $diagnosticPath -Force -ErrorAction SilentlyContinue
+            $env:OMADAWEBPS_CANARY_DIAGNOSTIC_PATH = $diagnosticPath
+
+            $container = New-PesterContainer -Path './Tests/E2E' -Data @{ ModulePath = $modulePath }
+            $configuration = New-PesterConfiguration
+            $configuration.Run.Container = $container
+            $configuration.Run.PassThru = $true
+            $configuration.Filter.Tag = 'E2E'
+            $configuration.Output.Verbosity = 'Detailed'
+            $configuration.TestResult.Enabled = $true
+            $configuration.TestResult.OutputFormat = 'JUnitXml'
+            $configuration.TestResult.OutputPath = (Join-Path $env:GITHUB_WORKSPACE ("buildoutput/CanaryResults-{0}.xml" -f $Attempt))
+
+            $result = Invoke-Pester -Configuration $configuration
+
+            $diagnostic = ''
+            if (Test-Path -LiteralPath $diagnosticPath) {
+              $diagnostic = Get-Content -LiteralPath $diagnosticPath -Raw
+            }
+
+            $failure = @($result.Failed | ForEach-Object {
+              $name = if ([string]::IsNullOrWhiteSpace($_.ExpandedPath)) { $_.Name } else { $_.ExpandedPath }
+              "- {0}: {1}" -f $name, $_.ErrorRecord.Exception.Message
+            })
+
+            return [pscustomobject]@{
+              Failed     = [int]$result.FailedCount
+              Passed     = [int]$result.PassedCount
+              Skipped    = [int]$result.SkippedCount
+              Diagnostic = $diagnostic
+              Failure    = $failure
+            }
+          }
+
+          $first = Invoke-CanaryAttempt -Attempt 1
+          $final = $first
+
+          # The tests decided for themselves that they are not configured. Reported rather than
+          # passed off as a success, so a canary that has silently stopped running is visible.
+          if ($first.Skipped -gt 0 -and $first.Passed -eq 0 -and $first.Failed -eq 0) {
+            Write-Host "::notice title=Canary skipped::The canary tests reported themselves as not configured."
+            "outcome=skipped" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "report=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            exit 0
+          }
+
+          if ($first.Failed -gt 0) {
+            # The flake policy. Microsoft's sign-in service has transient bad minutes, and a canary
+            # that alerts on one of them gets muted by its audience, which is the only failure mode
+            # worse than not having a canary. One automatic retry, and a warning either way so a run
+            # that needed the retry is still visible.
+            Write-Host "::warning title=Canary retry::The first attempt failed. Retrying once in 120 seconds before alerting."
+            Start-Sleep -Seconds 120
+            $final = Invoke-CanaryAttempt -Attempt 2
+          }
+
+          $lines = [System.Collections.Generic.List[string]]::new()
+          $lines.Add(("Attempt 1: {0} passed, {1} failed." -f $first.Passed, $first.Failed))
+          if ($first.Failed -gt 0) {
+            $lines.Add(("Attempt 2 (after the flake retry): {0} passed, {1} failed." -f $final.Passed, $final.Failed))
+          }
+
+          if ($final.Failure.Count -gt 0) {
+            $lines.Add("")
+            $lines.Add("Failed assertions:")
+            $final.Failure | ForEach-Object { $lines.Add($_) }
+          }
+
+          if (-not [string]::IsNullOrWhiteSpace($final.Diagnostic)) {
+            $lines.Add("")
+            $lines.Add("Diagnostic reported by Switch-ToManualLogin:")
+            $lines.Add("")
+            $lines.Add('```')
+            $lines.Add($final.Diagnostic.Trim())
+            $lines.Add('```')
+          }
+
+          $report = $lines -join "`n"
+
+          # Belt and braces over ::add-mask::. This text is about to become a public issue, and a
+          # value that reached it through a channel GitHub does not track would be published before
+          # anyone could react.
+          foreach ($name in 'OMADAWEBPS_CANARY_TENANT_ID','OMADAWEBPS_CANARY_CLIENT_ID','OMADAWEBPS_CANARY_USERNAME','OMADAWEBPS_CANARY_PASSWORD') {
+            $value = [Environment]::GetEnvironmentVariable($name)
+            if (-not [string]::IsNullOrWhiteSpace($value)) {
+              $report = $report.Replace($value, '***')
+            }
+          }
+
+          $outcome = if ($final.Failed -gt 0) { 'failure' } else { 'success' }
+          "outcome=$outcome" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+          $delimiter = "REPORT-" + [guid]::NewGuid().ToString('N')
+          "report<<$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $report | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $delimiter | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+          $report | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+          if ($final.Failed -gt 0) {
+            throw "The Entra sign-in canary failed twice. See the report above."
+          }
+
+      - name: Upload the canary test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: CanaryResults
+          path: buildoutput/CanaryResults-*.xml
+          if-no-files-found: ignore
+
+      # Scheduled-workflow failure mail goes to whoever last touched the file and is easy to miss, so
+      # the alert is an issue: it is durable, it carries the diagnostic, and it closes itself when
+      # the canary recovers.
+      # Gated on the canary having actually reached a verdict, not merely on the job having failed.
+      # A checkout or build failure leaves this output empty, and alerting on that would file an
+      # issue saying Microsoft changed its sign-in page when nothing had even tried to sign in.
+      - name: Open or close the canary alert
+        if: always() && (steps.canary.outputs.outcome == 'success' || steps.canary.outputs.outcome == 'failure')
+        uses: actions/github-script@v9
+        env:
+          CANARY_OUTCOME: ${{ steps.canary.outputs.outcome }}
+          CANARY_REPORT: ${{ steps.canary.outputs.report }}
+        with:
+          script: |
+            const title = 'Entra sign-in canary is failing';
+            const outcome = process.env.CANARY_OUTCOME;
+            const report = process.env.CANARY_REPORT || '(no report captured)';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'canary',
+              per_page: 100,
+            });
+            const alert = existing.data.find(issue => issue.title === title);
+
+            if (outcome === 'success') {
+              if (alert) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: alert.number,
+                  body: `The canary passed again in [run ${context.runId}](${runUrl}). Closing.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: alert.number,
+                  state: 'closed',
+                });
+              }
+              return;
+            }
+
+            const body = [
+              `The scheduled Entra ID sign-in canary failed twice in a row, so this is not a transient Microsoft hiccup.`,
+              ``,
+              `**What this means.** Credential autofill no longer recognizes a Microsoft sign-in screen. Signing in still works — a selector break degrades autofill, not login — but every user supplying \`-Credential\` now has to type it themselves.`,
+              ``,
+              `**What to do.** Update \`$Script:EntraSignInElementId\` in \`OmadaWeb.PS/OmadaWeb.PS.psm1\` from the diagnostic below, then re-run this workflow. See \`docs/entra-canary.md\` and issue #32.`,
+              ``,
+              `[Run ${context.runId}](${runUrl})`,
+              ``,
+              report,
+            ].join('\n');
+
+            if (alert) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: alert.number,
+                body,
+              });
+              return;
+            }
+
+            // The label is created on demand: a fresh clone of this repository has no 'canary'
+            // label, and a missing one would fail the create call rather than the canary.
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'canary',
+                color: 'fbca04',
+                description: 'Raised automatically by the scheduled Entra sign-in canary',
+              });
+            } catch (error) {
+              if (error.status !== 422) {
+                throw error;
+              }
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['canary'],
+            });

--- a/Build/New-EntraCanaryConfiguration.ps1
+++ b/Build/New-EntraCanaryConfiguration.ps1
@@ -179,6 +179,28 @@ function Assert-GraphSession {
     return $Context
 }
 
+function ConvertTo-ODataLiteral {
+    <#
+    .SYNOPSIS
+        Escapes a value for use inside a single-quoted OData string literal.
+    .DESCRIPTION
+        OData escapes an apostrophe by doubling it. Without this, a display name or a user principal
+        name containing one produces a filter Graph cannot parse, the lookup fails, and this script -
+        whose whole contract is to be idempotent - concludes the object does not exist and creates a
+        second one. A near-duplicate app registration in a tenant is a nuisance to unpick, and the
+        run that produced it reported success.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    return $Value.Replace("'", "''")
+}
+
 function New-CanaryPassword {
     <#
     .SYNOPSIS
@@ -247,7 +269,7 @@ function Set-CanaryUser {
         ForceChangePasswordNextSignIn = $false
     }
 
-    $Existing = @(Get-MgUser -Filter ("userPrincipalName eq '{0}'" -f $UserPrincipalName) -ErrorAction SilentlyContinue)
+    $Existing = @(Get-MgUser -Filter ("userPrincipalName eq '{0}'" -f (ConvertTo-ODataLiteral -Value $UserPrincipalName)) -ErrorAction SilentlyContinue)
     if ($Existing.Count -gt 0) {
         if ($PSCmdlet.ShouldProcess($UserPrincipalName, "Reset the canary account password")) {
             Update-MgUser -UserId $Existing[0].Id -PasswordProfile $PasswordProfile -PasswordPolicies "DisablePasswordExpiration" -AccountEnabled:$true
@@ -292,7 +314,7 @@ function Set-CanaryApplication {
         [hashtable]$RequiredResourceAccess
     )
 
-    $Existing = @(Get-MgApplication -Filter ("displayName eq '{0}'" -f $DisplayName) -ErrorAction SilentlyContinue)
+    $Existing = @(Get-MgApplication -Filter ("displayName eq '{0}'" -f (ConvertTo-ODataLiteral -Value $DisplayName)) -ErrorAction SilentlyContinue)
     if ($Existing.Count -gt 0) {
         $Application = $Existing[0]
         $RegisteredUri = @($Application.PublicClient.RedirectUris)
@@ -550,10 +572,25 @@ function Set-CanaryNamedLocation {
         "A named location can hold at most 2000 IP ranges; {0} were supplied. GitHub-hosted runners publish far more than that, which is why -AllowedIpRange is only practical with a self-hosted or fixed-egress runner." -f $IpRange.Count | Write-Error -ErrorAction "Stop"
     }
 
+    # The OData type has to match the address family. Sending an IPv6 range as an iPv4CidrRange is
+    # rejected by Graph with an error that names neither the range nor the reason, so the family is
+    # read from the address itself and a malformed entry is refused here, where it can be named.
     $IpRangeBody = @($IpRange | ForEach-Object {
+            $Cidr = $_
+            $Parts = $Cidr.Split("/")
+            $Address = $null
+            if ($Parts.Count -ne 2 -or -not [System.Net.IPAddress]::TryParse($Parts[0], [ref]$Address)) {
+                "'{0}' is not a CIDR range. Supply ranges such as '203.0.113.0/24' or '2001:db8::/32'." -f $Cidr | Write-Error -ErrorAction "Stop"
+            }
+
+            $ODataType = "#microsoft.graph.iPv4CidrRange"
+            if ($Address.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetworkV6) {
+                $ODataType = "#microsoft.graph.iPv6CidrRange"
+            }
+
             @{
-                "@odata.type" = "#microsoft.graph.iPv4CidrRange"
-                cidrAddress   = $_
+                "@odata.type" = $ODataType
+                cidrAddress   = $Cidr
             }
         })
 

--- a/Build/New-EntraCanaryConfiguration.ps1
+++ b/Build/New-EntraCanaryConfiguration.ps1
@@ -1,0 +1,771 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Provisions the Entra ID objects the scheduled sign-in canary needs, in a tenant you control.
+.DESCRIPTION
+    The canary (roadmap E5, issue #33) signs in to Microsoft Entra ID once a day with a real account
+    in a real browser, so that a change to Microsoft's sign-in page is reported by CI instead of by
+    the first user who hits it. That needs three things in a tenant: an account that can sign in with
+    a password and nothing else, an application to sign in to, and a documented reason why the
+    account is not challenged for multi-factor authentication.
+
+    This script creates all three, and is safe to run again: every object is looked up before it is
+    created, and an existing one is updated in place rather than duplicated.
+
+    WHAT IT CREATES
+
+      1. A canary user in the tenant's initial domain, with a freshly generated password, no licence,
+         no directory role and no group membership. Signing in is the only thing it can do.
+      2. A public-client application registration whose only redirect URI is the loopback address the
+         canary listens on, requesting the delegated permissions openid, profile and User.Read - and
+         with admin consent granted for them. The consent matters: an unconsented application shows a
+         consent screen, the sign-in automation does not recognize that screen, and the canary would
+         go red for a reason that has nothing to do with Microsoft changing anything.
+      3. A Conditional Access policy that blocks the canary account from every application except the
+         canary one. This is the containment: the account is powerless elsewhere by policy, not
+         merely by holding no permissions.
+
+    WHAT IT DOES ABOUT MFA
+
+      An interactive approval cannot be automated, so the canary account has to be exempt. The
+      exemption is made explicit rather than left implicit:
+
+        - Security defaults are reported, and disabled only if you pass -DisableSecurityDefaults.
+        - Every existing Conditional Access policy that requires multi-factor authentication gets the
+          canary account added to its excluded users, so the exemption is a reviewable entry on each
+          policy rather than an absence somebody has to infer.
+
+      Both are reported in the summary, so a tenant where MFA is still enforced on this account is
+      visible before the canary is ever scheduled.
+
+    WHAT IT DOES NOT DO
+
+      It does not write your tenant's identifiers anywhere. The values the workflow needs are
+      returned to you as an object, or pushed straight into GitHub with -GitHubRepository so they
+      never appear on screen at all. Nothing in this repository records them.
+
+    LICENSING
+
+      Conditional Access needs Microsoft Entra ID P1 (a P2 trial includes it). Without it, pass
+      -SkipConditionalAccess: the account is then contained only by holding no permissions, which is
+      weaker, and the summary says so. See docs/entra-canary.md.
+.PARAMETER UserPrincipalNamePrefix
+    Mailbox part of the canary account's user principal name. The tenant's initial
+    <tenant>.onmicrosoft.com domain is appended.
+.PARAMETER ApplicationDisplayName
+    Display name of the app registration the canary signs in to.
+.PARAMETER Port
+    Loopback port the canary listens on, which determines the registered redirect URI. Entra ignores
+    the port when matching a localhost redirect URI on a public client, so this mainly has to agree
+    with OMADAWEBPS_CANARY_PORT in the workflow.
+.PARAMETER AllowedIpRange
+    CIDR ranges the canary account is allowed to sign in from. When supplied, a named location is
+    created and a second Conditional Access policy blocks the account from anywhere else.
+
+    Deliberately a list you supply rather than a switch that fetches GitHub's ranges: GitHub-hosted
+    runners publish thousands of CIDRs, which exceeds the 2000 ranges Entra allows in one named
+    location, and they change without notice. IP restriction is therefore worth having on a
+    self-hosted or fixed-egress runner and is impractical on a GitHub-hosted one. Left empty, the
+    containment policy alone is relied on.
+.PARAMETER DisableSecurityDefaults
+    Turns security defaults off if they are on. Without this the script only reports them, because
+    turning them off changes the security posture of the whole tenant and that is not a side effect
+    a provisioning script should have on its own.
+.PARAMETER SkipConditionalAccess
+    Skips every Conditional Access change, for a tenant without Entra ID P1. The account is then
+    contained only by holding no permissions.
+.PARAMETER GitHubRepository
+    An owner/repo to push the four canary secrets into, using the GitHub CLI, so the values are never
+    displayed. Requires 'gh' on PATH and an authenticated session. Without it the values are returned
+    to you and nothing is sent anywhere.
+.PARAMETER EnvironmentName
+    GitHub environment the secrets are written to when -GitHubRepository is used.
+.EXAMPLE
+    Connect-MgGraph -Scopes 'User.ReadWrite.All','Application.ReadWrite.All','DelegatedPermissionGrant.ReadWrite.All','Directory.Read.All','Policy.Read.All','Policy.ReadWrite.ConditionalAccess'
+    ./Build/New-EntraCanaryConfiguration.ps1 -WhatIf
+
+    Shows every object that would be created or changed, without touching the tenant. The script
+    names any scope that is missing rather than failing part-way through.
+.EXAMPLE
+    ./Build/New-EntraCanaryConfiguration.ps1 -GitHubRepository 'Fortigi/OmadaWeb.PS'
+
+    Provisions the tenant and writes the four secrets straight into the 'entra-canary' environment,
+    so no credential is ever rendered to the console.
+.EXAMPLE
+    ./Build/New-EntraCanaryConfiguration.ps1 -SkipConditionalAccess
+
+    Provisions a tenant without Entra ID P1. The summary will state that the account is not contained
+    by policy.
+.NOTES
+    Requires the Microsoft.Graph.Authentication, Microsoft.Graph.Users, Microsoft.Graph.Applications
+    and Microsoft.Graph.Identity.SignIns modules, and an existing Connect-MgGraph session holding the
+    scopes listed in the first example.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [ValidateNotNullOrEmpty()]
+    [ValidatePattern('^[a-z0-9][a-z0-9._-]*$')]
+    [string]$UserPrincipalNamePrefix = "omadaweb-canary",
+
+    [ValidateNotNullOrEmpty()]
+    [string]$ApplicationDisplayName = "OmadaWeb.PS Sign-in Canary",
+
+    [ValidateRange(1024, 65535)]
+    [int]$Port = 8400,
+
+    [string[]]$AllowedIpRange = @(),
+
+    [switch]$DisableSecurityDefaults,
+
+    [switch]$SkipConditionalAccess,
+
+    [string]$GitHubRepository,
+
+    [ValidateNotNullOrEmpty()]
+    [string]$EnvironmentName = "entra-canary"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Microsoft Graph's well-known application ID, and the ids of the three delegated permissions the
+# canary application asks for. Written out rather than looked up by name: these are stable, and
+# resolving them by display name would make provisioning depend on the language of the tenant.
+$GraphApplicationId = "00000003-0000-0000-c000-000000000000"
+$GraphDelegatedPermission = [ordered]@{
+    "openid"    = "37f7f235-527c-4136-accd-4a02d197296e"
+    "profile"   = "14dad69e-099b-42c9-810b-d002981feec1"
+    "User.Read" = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+}
+
+$ContainmentPolicyName = "OmadaWeb.PS canary - block every application except the canary"
+$LocationPolicyName = "OmadaWeb.PS canary - block sign-in from outside the allowed ranges"
+$NamedLocationName = "OmadaWeb.PS canary runner egress"
+
+function Assert-GraphSession {
+    <#
+    .SYNOPSIS
+        Fails early and legibly when the Graph session cannot do what follows.
+    .DESCRIPTION
+        Half-provisioning a tenant and stopping on a missing scope leaves objects behind that the
+        operator then has to reason about. Checking the scopes up front costs one call and turns that
+        into a message naming exactly what to reconnect with.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$RequiredScope
+    )
+
+    foreach ($ModuleName in @("Microsoft.Graph.Authentication", "Microsoft.Graph.Users", "Microsoft.Graph.Applications", "Microsoft.Graph.Identity.SignIns")) {
+        if (-not (Get-Module -Name $ModuleName -ListAvailable)) {
+            "The module '{0}' is not installed. Install it with: Install-Module {0} -Scope CurrentUser" -f $ModuleName | Write-Error -ErrorAction "Stop"
+        }
+
+        Import-Module -Name $ModuleName -ErrorAction Stop
+    }
+
+    $Context = Get-MgContext
+    if ($null -eq $Context) {
+        "Not connected to Microsoft Graph. Run: Connect-MgGraph -Scopes '{0}'" -f ($RequiredScope -join "','") | Write-Error -ErrorAction "Stop"
+    }
+
+    $MissingScope = @($RequiredScope | Where-Object { $_ -notin $Context.Scopes })
+    if ($MissingScope.Count -gt 0) {
+        "The current Microsoft Graph session is missing the scope(s) {0}. Reconnect with: Connect-MgGraph -Scopes '{1}'" -f ($MissingScope -join ", "), ($RequiredScope -join "','") | Write-Error -ErrorAction "Stop"
+    }
+
+    return $Context
+}
+
+function New-CanaryPassword {
+    <#
+    .SYNOPSIS
+        Generates the canary account's password.
+    .DESCRIPTION
+        Drawn from a cryptographic RNG with rejection sampling rather than from Get-Random: the
+        modulo bias of the obvious approach is small, but this value is the only thing standing in
+        front of a real directory account and there is no reason to accept any bias at all.
+
+        The alphabet excludes characters that are easy to lose in transit through a shell or a YAML
+        file, because the same string has to survive being pasted into a GitHub secret.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [ValidateRange(16, 256)]
+        [int]$Length = 48
+    )
+
+    $Alphabet = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789-_.~".ToCharArray()
+    $Password = [System.Text.StringBuilder]::new()
+    $RandomNumberGenerator = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        # The largest multiple of the alphabet size that fits in a byte. Anything above it is drawn
+        # again, which is what keeps every character equally likely.
+        $Limit = [byte](256 - (256 % $Alphabet.Length))
+        $Buffer = [byte[]]::new(1)
+        while ($Password.Length -lt $Length) {
+            $RandomNumberGenerator.GetBytes($Buffer)
+            if ($Buffer[0] -ge $Limit) {
+                continue
+            }
+
+            $null = $Password.Append($Alphabet[$Buffer[0] % $Alphabet.Length])
+        }
+    }
+    finally {
+        $RandomNumberGenerator.Dispose()
+    }
+
+    return $Password.ToString()
+}
+
+function Set-CanaryUser {
+    <#
+    .SYNOPSIS
+        Creates the canary account, or resets the password of the one already there.
+    .DESCRIPTION
+        The password is reset on every run rather than reused. The script cannot read an existing
+        password back out of the directory, so the alternative would be returning secrets it does not
+        actually know - and a canary configured from those would fail on its first run.
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'Password', Justification = 'Microsoft Graph takes the new password as a plain string inside passwordProfile, and the same value has to be handed to "gh secret set". A SecureString here would be converted straight back on both sides, so it would add ceremony without shortening the plaintext lifetime. The value is generated in this process, never written to disk, and never rendered unless the operator asks for it.')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUsernameAndPasswordParams', '', Justification = 'A PSCredential would be the wrong shape: this function is creating the account whose password it is setting, not authenticating with it. There is no credential to pass, only a user principal name and the password being assigned to it.')]
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$UserPrincipalName,
+
+        [Parameter(Mandatory)]
+        [string]$Password
+    )
+
+    $PasswordProfile = @{
+        Password                      = $Password
+        ForceChangePasswordNextSignIn = $false
+    }
+
+    $Existing = @(Get-MgUser -Filter ("userPrincipalName eq '{0}'" -f $UserPrincipalName) -ErrorAction SilentlyContinue)
+    if ($Existing.Count -gt 0) {
+        if ($PSCmdlet.ShouldProcess($UserPrincipalName, "Reset the canary account password")) {
+            Update-MgUser -UserId $Existing[0].Id -PasswordProfile $PasswordProfile -PasswordPolicies "DisablePasswordExpiration" -AccountEnabled:$true
+            "Reset the password of the existing canary account." | Write-Host -ForegroundColor Green
+        }
+
+        return $Existing[0]
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($UserPrincipalName, "Create the canary account")) {
+        return $null
+    }
+
+    $User = New-MgUser -UserPrincipalName $UserPrincipalName `
+        -DisplayName "OmadaWeb.PS Sign-in Canary" `
+        -MailNickname $UserPrincipalName.Split("@")[0] `
+        -AccountEnabled `
+        -PasswordProfile $PasswordProfile `
+        -PasswordPolicies "DisablePasswordExpiration"
+
+    "Created the canary account." | Write-Host -ForegroundColor Green
+    return $User
+}
+
+function Set-CanaryApplication {
+    <#
+    .SYNOPSIS
+        Creates or updates the app registration and its service principal.
+    .DESCRIPTION
+        Registered as a public client with a single loopback redirect URI. It is a sign-in target and
+        nothing else: it holds no credentials, exposes no API and is restricted to this tenant.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DisplayName,
+
+        [Parameter(Mandatory)]
+        [string]$RedirectUri,
+
+        [Parameter(Mandatory)]
+        [hashtable]$RequiredResourceAccess
+    )
+
+    $Existing = @(Get-MgApplication -Filter ("displayName eq '{0}'" -f $DisplayName) -ErrorAction SilentlyContinue)
+    if ($Existing.Count -gt 0) {
+        $Application = $Existing[0]
+        $RegisteredUri = @($Application.PublicClient.RedirectUris)
+        if ($RedirectUri -notin $RegisteredUri) {
+            if ($PSCmdlet.ShouldProcess($DisplayName, ("Add the redirect URI {0}" -f $RedirectUri))) {
+                Update-MgApplication -ApplicationId $Application.Id -PublicClient @{ RedirectUris = @($RegisteredUri + $RedirectUri) }
+                "Added the redirect URI to the existing application." | Write-Host -ForegroundColor Green
+            }
+        }
+        else {
+            "Application already registered with this redirect URI." | Write-Host
+        }
+    }
+    else {
+        if (-not $PSCmdlet.ShouldProcess($DisplayName, "Create the canary application registration")) {
+            return $null
+        }
+
+        $Application = New-MgApplication -DisplayName $DisplayName `
+            -SignInAudience "AzureADMyOrg" `
+            -IsFallbackPublicClient `
+            -PublicClient @{ RedirectUris = @($RedirectUri) } `
+            -RequiredResourceAccess @($RequiredResourceAccess)
+
+        "Created the canary application registration." | Write-Host -ForegroundColor Green
+    }
+
+    if ($null -eq $Application) {
+        return $null
+    }
+
+    $ServicePrincipal = @(Get-MgServicePrincipal -Filter ("appId eq '{0}'" -f $Application.AppId) -ErrorAction SilentlyContinue)
+    if ($ServicePrincipal.Count -eq 0) {
+        if ($PSCmdlet.ShouldProcess($DisplayName, "Create the service principal")) {
+            $null = New-MgServicePrincipal -AppId $Application.AppId
+            "Created the service principal." | Write-Host -ForegroundColor Green
+        }
+    }
+
+    return $Application
+}
+
+function Grant-CanaryAdminConsent {
+    <#
+    .SYNOPSIS
+        Pre-consents the canary application's delegated permissions for the whole tenant.
+    .DESCRIPTION
+        Without this the first sign-in renders a consent screen. Resolve-EntraSignInScreen does not
+        recognize it, the automation would stall on it, Switch-ToManualLogin would report a page it
+        has never seen - and the canary would go red saying Microsoft changed something when in fact
+        the tenant was simply not finished being set up.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ApplicationId,
+
+        [Parameter(Mandatory)]
+        [string]$GraphApplicationId,
+
+        [Parameter(Mandatory)]
+        [string]$Scope
+    )
+
+    $ClientServicePrincipal = @(Get-MgServicePrincipal -Filter ("appId eq '{0}'" -f $ApplicationId) -ErrorAction SilentlyContinue)
+    $GraphServicePrincipal = @(Get-MgServicePrincipal -Filter ("appId eq '{0}'" -f $GraphApplicationId) -ErrorAction SilentlyContinue)
+
+    if ($ClientServicePrincipal.Count -eq 0 -or $GraphServicePrincipal.Count -eq 0) {
+        "Skipping admin consent: the service principals do not exist yet (expected with -WhatIf)." | Write-Warning
+        return
+    }
+
+    $Existing = @(Get-MgOauth2PermissionGrant -Filter ("clientId eq '{0}' and consentType eq 'AllPrincipals'" -f $ClientServicePrincipal[0].Id) -ErrorAction SilentlyContinue |
+            Where-Object { $_.ResourceId -eq $GraphServicePrincipal[0].Id })
+
+    if ($Existing.Count -gt 0) {
+        if ($Existing[0].Scope -eq $Scope) {
+            "Admin consent already granted." | Write-Host
+            return
+        }
+
+        if ($PSCmdlet.ShouldProcess($Scope, "Update the tenant-wide delegated permission grant")) {
+            Update-MgOauth2PermissionGrant -OAuth2PermissionGrantId $Existing[0].Id -Scope $Scope
+            "Updated the tenant-wide delegated permission grant." | Write-Host -ForegroundColor Green
+        }
+
+        return
+    }
+
+    if ($PSCmdlet.ShouldProcess($Scope, "Grant tenant-wide admin consent")) {
+        $null = New-MgOauth2PermissionGrant -ClientId $ClientServicePrincipal[0].Id `
+            -ConsentType "AllPrincipals" `
+            -ResourceId $GraphServicePrincipal[0].Id `
+            -Scope $Scope
+
+        "Granted tenant-wide admin consent, so no consent screen is ever shown." | Write-Host -ForegroundColor Green
+    }
+}
+
+function Get-CanarySecurityDefaultsState {
+    <#
+    .SYNOPSIS
+        Reports whether security defaults are on, and turns them off only when asked to.
+    .DESCRIPTION
+        Security defaults enforce MFA registration on every account, which the canary cannot satisfy.
+        Turning them off changes the posture of the entire tenant, so it is never a side effect: the
+        state is reported, and only -DisableSecurityDefaults acts on it.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [switch]$Disable
+    )
+
+    $Policy = Get-MgPolicyIdentitySecurityDefaultEnforcementPolicy -ErrorAction Stop
+    if (-not $Policy.IsEnabled) {
+        return "Disabled"
+    }
+
+    if (-not $Disable) {
+        "Security defaults are ENABLED in this tenant. They enforce MFA registration on every account, which the canary cannot complete. Re-run with -DisableSecurityDefaults, or exempt the account another way, before scheduling the canary." | Write-Warning
+        return "Enabled"
+    }
+
+    if ($PSCmdlet.ShouldProcess("Tenant security defaults", "Disable")) {
+        Update-MgPolicyIdentitySecurityDefaultEnforcementPolicy -IsEnabled:$false
+        "Disabled security defaults." | Write-Host -ForegroundColor Green
+        return "Disabled"
+    }
+
+    return "Enabled"
+}
+
+function Add-CanaryMfaExemption {
+    <#
+    .SYNOPSIS
+        Excludes the canary account from every Conditional Access policy that requires MFA.
+    .DESCRIPTION
+        This is the "documented conditional-access exemption" the issue asks for. Expressed as an
+        exclusion on each MFA policy rather than as a permissive policy of its own, because a grant
+        control is a requirement and never a waiver - a policy saying "this account may sign in
+        without MFA" would not override one saying "everyone must use MFA".
+
+        An empty tenant has no such policies, and the summary then says so rather than implying an
+        exemption was applied.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$UserId
+    )
+
+    $Exempted = [System.Collections.Generic.List[string]]::new()
+    foreach ($Policy in Get-MgIdentityConditionalAccessPolicy -All) {
+        if ($Policy.State -eq "disabled") {
+            continue
+        }
+
+        $BuiltInControl = @()
+        if ($null -ne $Policy.GrantControls -and $null -ne $Policy.GrantControls.BuiltInControls) {
+            $BuiltInControl = @($Policy.GrantControls.BuiltInControls)
+        }
+
+        if ("mfa" -notin $BuiltInControl) {
+            continue
+        }
+
+        $ExcludedUser = @($Policy.Conditions.Users.ExcludeUsers | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($UserId -in $ExcludedUser) {
+            $Exempted.Add($Policy.DisplayName)
+            continue
+        }
+
+        if ($PSCmdlet.ShouldProcess($Policy.DisplayName, "Exclude the canary account from this MFA policy")) {
+            # The whole users condition is sent back, not just excludeUsers. A PATCH against a
+            # Conditional Access policy replaces each condition object wholesale rather than merging
+            # into it, so sending only the exclusion would silently empty includeUsers, includeGroups
+            # and the rest - turning somebody's tenant-wide MFA requirement into a policy that
+            # applies to nobody. That failure reports success and is invisible until an audit.
+            $Users = @{
+                IncludeUsers                 = @($Policy.Conditions.Users.IncludeUsers | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                ExcludeUsers                 = @($ExcludedUser + $UserId)
+                IncludeGroups                = @($Policy.Conditions.Users.IncludeGroups | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                ExcludeGroups                = @($Policy.Conditions.Users.ExcludeGroups | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                IncludeRoles                 = @($Policy.Conditions.Users.IncludeRoles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                ExcludeRoles                 = @($Policy.Conditions.Users.ExcludeRoles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                IncludeGuestsOrExternalUsers = $Policy.Conditions.Users.IncludeGuestsOrExternalUsers
+                ExcludeGuestsOrExternalUsers = $Policy.Conditions.Users.ExcludeGuestsOrExternalUsers
+            }
+
+            Update-MgIdentityConditionalAccessPolicy -ConditionalAccessPolicyId $Policy.Id -Conditions @{ Users = $Users }
+            $Exempted.Add($Policy.DisplayName)
+        }
+    }
+
+    return $Exempted.ToArray()
+}
+
+function Set-CanaryConditionalAccessPolicy {
+    <#
+    .SYNOPSIS
+        Creates or updates one Conditional Access policy by display name.
+    .DESCRIPTION
+        Idempotent by display name, which is what lets this script be re-run: a second call updates
+        the policy it created the first time instead of adding a near-duplicate that an operator then
+        has to tell apart from the original.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DisplayName,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Conditions,
+
+        [Parameter(Mandatory)]
+        [hashtable]$GrantControls
+    )
+
+    $Existing = @(Get-MgIdentityConditionalAccessPolicy -All | Where-Object { $_.DisplayName -eq $DisplayName })
+    if ($Existing.Count -gt 0) {
+        if ($PSCmdlet.ShouldProcess($DisplayName, "Update the Conditional Access policy")) {
+            Update-MgIdentityConditionalAccessPolicy -ConditionalAccessPolicyId $Existing[0].Id -Conditions $Conditions -GrantControls $GrantControls -State "enabled"
+            "Updated Conditional Access policy '{0}'." -f $DisplayName | Write-Host -ForegroundColor Green
+        }
+
+        return $Existing[0].Id
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($DisplayName, "Create the Conditional Access policy")) {
+        return $null
+    }
+
+    $Policy = New-MgIdentityConditionalAccessPolicy -DisplayName $DisplayName -State "enabled" -Conditions $Conditions -GrantControls $GrantControls
+    "Created Conditional Access policy '{0}'." -f $DisplayName | Write-Host -ForegroundColor Green
+    return $Policy.Id
+}
+
+function Set-CanaryNamedLocation {
+    <#
+    .SYNOPSIS
+        Creates or updates the named location holding the allowed runner egress ranges.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DisplayName,
+
+        [Parameter(Mandatory)]
+        [string[]]$IpRange
+    )
+
+    # Entra allows 2000 ranges in one named location. Failing here beats letting Graph reject the
+    # whole request with a message that does not name the cause.
+    if ($IpRange.Count -gt 2000) {
+        "A named location can hold at most 2000 IP ranges; {0} were supplied. GitHub-hosted runners publish far more than that, which is why -AllowedIpRange is only practical with a self-hosted or fixed-egress runner." -f $IpRange.Count | Write-Error -ErrorAction "Stop"
+    }
+
+    $IpRangeBody = @($IpRange | ForEach-Object {
+            @{
+                "@odata.type" = "#microsoft.graph.iPv4CidrRange"
+                cidrAddress   = $_
+            }
+        })
+
+    $Body = @{
+        "@odata.type" = "#microsoft.graph.ipNamedLocation"
+        displayName   = $DisplayName
+        isTrusted     = $false
+        ipRanges      = $IpRangeBody
+    }
+
+    $Existing = @(Get-MgIdentityConditionalAccessNamedLocation -All | Where-Object { $_.DisplayName -eq $DisplayName })
+    if ($Existing.Count -gt 0) {
+        if ($PSCmdlet.ShouldProcess($DisplayName, "Update the named location")) {
+            Update-MgIdentityConditionalAccessNamedLocation -NamedLocationId $Existing[0].Id -BodyParameter $Body
+            "Updated named location '{0}'." -f $DisplayName | Write-Host -ForegroundColor Green
+        }
+
+        return $Existing[0].Id
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($DisplayName, "Create the named location")) {
+        return $null
+    }
+
+    $Location = New-MgIdentityConditionalAccessNamedLocation -BodyParameter $Body
+    "Created named location '{0}'." -f $DisplayName | Write-Host -ForegroundColor Green
+    return $Location.Id
+}
+
+function Publish-CanarySecret {
+    <#
+    .SYNOPSIS
+        Writes the canary secrets into a GitHub environment without displaying them.
+    .DESCRIPTION
+        Each value is piped to 'gh secret set' on standard input rather than passed as an argument,
+        so it never reaches a command line that a process listing or a shell history would record.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Repository,
+
+        [Parameter(Mandatory)]
+        [string]$EnvironmentName,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Secret
+    )
+
+    if ($null -eq (Get-Command -Name "gh" -ErrorAction SilentlyContinue)) {
+        "The GitHub CLI ('gh') is not on PATH, so the secrets were not published. Set them by hand from the returned object." | Write-Error -ErrorAction "Stop"
+    }
+
+    foreach ($Name in ($Secret.Keys | Sort-Object)) {
+        if (-not $PSCmdlet.ShouldProcess(("{0} ({1}/{2})" -f $Name, $Repository, $EnvironmentName), "Set the GitHub secret")) {
+            continue
+        }
+
+        # gh reads the value from standard input when --body is omitted, which keeps it off a command
+        # line that a process listing or a shell history would record.
+        $Secret[$Name] | & gh secret set $Name --repo $Repository --env $EnvironmentName
+        if ($LASTEXITCODE -ne 0) {
+            "Failed to set the GitHub secret '{0}' (gh exited with {1})." -f $Name, $LASTEXITCODE | Write-Error -ErrorAction "Stop"
+        }
+
+        "Set secret {0}." -f $Name | Write-Host -ForegroundColor Green
+    }
+}
+
+try {
+    $RequiredScope = @(
+        "User.ReadWrite.All",
+        "Application.ReadWrite.All",
+        "DelegatedPermissionGrant.ReadWrite.All",
+        # Get-MgOrganization is how the tenant's initial onmicrosoft.com domain is found, and it is
+        # not covered by any of the scopes above.
+        "Directory.Read.All"
+    )
+    if (-not $SkipConditionalAccess) {
+        $RequiredScope += "Policy.Read.All"
+        $RequiredScope += "Policy.ReadWrite.ConditionalAccess"
+    }
+
+    # Reading the security-defaults policy is covered by Policy.Read.All; turning it off is a
+    # separate scope, and it is only asked for when the script is actually going to do that.
+    if ($DisableSecurityDefaults) {
+        $RequiredScope += "Policy.ReadWrite.SecurityDefaults"
+    }
+
+    $Context = Assert-GraphSession -RequiredScope $RequiredScope
+
+    $Organization = Get-MgOrganization -ErrorAction Stop | Select-Object -First 1
+    $InitialDomain = @($Organization.VerifiedDomains | Where-Object { $_.IsInitial })
+    if ($InitialDomain.Count -eq 0) {
+        "Could not determine the tenant's initial onmicrosoft.com domain." | Write-Error -ErrorAction "Stop"
+    }
+
+    $UserPrincipalName = "{0}@{1}" -f $UserPrincipalNamePrefix, $InitialDomain[0].Name
+    $RedirectUri = "http://localhost:{0}/canary" -f $Port
+
+    # Reported so an operator running this against the wrong directory notices before anything is
+    # created. The tenant id is theirs and is deliberately not recorded anywhere by this repository.
+    "Tenant : {0}" -f $Context.TenantId | Write-Host
+    "Account: {0}" -f $UserPrincipalName | Write-Host
+    "Redirect URI: {0}" -f $RedirectUri | Write-Host
+    "" | Write-Host
+
+    $Password = New-CanaryPassword
+    $User = Set-CanaryUser -UserPrincipalName $UserPrincipalName -Password $Password
+
+    $RequiredResourceAccess = @{
+        ResourceAppId  = $GraphApplicationId
+        ResourceAccess = @($GraphDelegatedPermission.Values | ForEach-Object {
+                @{
+                    Id   = $_
+                    Type = "Scope"
+                }
+            })
+    }
+
+    $Application = Set-CanaryApplication -DisplayName $ApplicationDisplayName -RedirectUri $RedirectUri -RequiredResourceAccess $RequiredResourceAccess
+
+    if ($null -ne $Application) {
+        Grant-CanaryAdminConsent -ApplicationId $Application.AppId -GraphApplicationId $GraphApplicationId -Scope ($GraphDelegatedPermission.Keys -join " ")
+    }
+
+    $SecurityDefaults = "Not checked"
+    $MfaExemption = @()
+    $Contained = $false
+    $LocationRestricted = $false
+
+    if ($SkipConditionalAccess) {
+        "Skipping every Conditional Access change (-SkipConditionalAccess)." | Write-Host -ForegroundColor Yellow
+    }
+    else {
+        $SecurityDefaults = Get-CanarySecurityDefaultsState -Disable:$DisableSecurityDefaults
+        if ($null -ne $User) {
+            $MfaExemption = @(Add-CanaryMfaExemption -UserId $User.Id)
+
+            if ($null -ne $Application) {
+                $ContainmentId = Set-CanaryConditionalAccessPolicy -DisplayName $ContainmentPolicyName -Conditions @{
+                    Users        = @{ IncludeUsers = @($User.Id) }
+                    Applications = @{
+                        IncludeApplications = @("All")
+                        ExcludeApplications = @($Application.AppId)
+                    }
+                    ClientAppTypes = @("all")
+                } -GrantControls @{
+                    Operator        = "OR"
+                    BuiltInControls = @("block")
+                }
+                $Contained = $null -ne $ContainmentId
+            }
+
+            if ($AllowedIpRange.Count -gt 0) {
+                $LocationId = Set-CanaryNamedLocation -DisplayName $NamedLocationName -IpRange $AllowedIpRange
+                if ($null -ne $LocationId) {
+                    $null = Set-CanaryConditionalAccessPolicy -DisplayName $LocationPolicyName -Conditions @{
+                        Users          = @{ IncludeUsers = @($User.Id) }
+                        Applications   = @{ IncludeApplications = @("All") }
+                        ClientAppTypes = @("all")
+                        Locations      = @{
+                            IncludeLocations = @("All")
+                            ExcludeLocations = @($LocationId)
+                        }
+                    } -GrantControls @{
+                        Operator        = "OR"
+                        BuiltInControls = @("block")
+                    }
+                    $LocationRestricted = $true
+                }
+            }
+        }
+    }
+
+    $Secret = @{
+        CANARY_TENANT_ID = $Context.TenantId
+        CANARY_CLIENT_ID = if ($null -eq $Application) { "" } else { $Application.AppId }
+        CANARY_USERNAME  = $UserPrincipalName
+        CANARY_PASSWORD  = $Password
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($GitHubRepository)) {
+        Publish-CanarySecret -Repository $GitHubRepository -EnvironmentName $EnvironmentName -Secret $Secret
+    }
+
+    "" | Write-Host
+    "Summary" | Write-Host -ForegroundColor Cyan
+    "  Canary account          : {0}" -f $UserPrincipalName | Write-Host
+    "  Application             : {0}" -f $ApplicationDisplayName | Write-Host
+    "  Security defaults       : {0}" -f $SecurityDefaults | Write-Host
+    "  MFA exemption applied to: {0}" -f $(if ($MfaExemption.Count -eq 0) { "no policy required MFA" } else { $MfaExemption -join ", " }) | Write-Host
+    "  Contained by policy     : {0}" -f $Contained | Write-Host
+    "  Restricted by IP        : {0}" -f $LocationRestricted | Write-Host
+    "" | Write-Host
+
+    if ([string]::IsNullOrWhiteSpace($GitHubRepository)) {
+        "The four values below belong in the '{0}' GitHub environment and nowhere else. They are returned rather than printed - assign the result and read what you need, or re-run with -GitHubRepository to have them set for you without ever being displayed:" -f $EnvironmentName | Write-Host -ForegroundColor Yellow
+        $Secret.Keys | Sort-Object | ForEach-Object { "  {0}" -f $_ | Write-Host }
+        "" | Write-Host
+    }
+
+    if ($SecurityDefaults -eq "Enabled") {
+        "The canary will fail while security defaults are enabled: every sign-in is challenged for MFA registration, which cannot be automated." | Write-Warning
+    }
+
+    if (-not $Contained -and -not $SkipConditionalAccess) {
+        "The canary account is NOT contained by a Conditional Access policy. It holds no permissions, but nothing stops it signing in to other applications. See docs/entra-canary.md." | Write-Warning
+    }
+
+    return [pscustomobject]$Secret
+}
+catch {
+    $PSCmdlet.ThrowTerminatingError($PSItem)
+}

--- a/Build/psakeBuild.ps1
+++ b/Build/psakeBuild.ps1
@@ -390,7 +390,9 @@ Task Test -depends ImportModule {
     $PesterConfiguration.TestResult.Enabled = $true
     $PesterConfiguration.TestResult.OutputFormat = 'JUnitXml'
     $PesterConfiguration.TestResult.OutputPath = (Join-Path -Path $ParentPath -ChildPath 'buildoutput\TestResults.xml')
-    # E2E tests need a real Edge/WebView2 install and are slow; they are opt-in and run on a separate scheduled pipeline instead of every build.
+    # E2E tests need a real Edge/WebView2 install, a browser window and a tenant to sign in to, so
+    # they are excluded here and run daily on .github/workflows/entra-canary.yml instead - the
+    # scheduled pipeline this comment used to promise. See docs/entra-canary.md.
     $PesterConfiguration.Filter.ExcludeTag = 'E2E'
 
     # Every test run exercises the module under Set-StrictMode -Version Latest. The module picks this

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ The warning names the state, the elements that were expected but absent, and the
 
 The module waits 60 seconds without progress before it gives up on autofill, so a slow round trip to Microsoft is not mistaken for a changed page. Waiting for you to approve a sign-in request in your authenticator app does not count against that.
 
+You should not normally be the one to find out. A scheduled job signs in to Entra ID once a day in a real browser and opens an issue when autofill stops recognising a screen, so a change on Microsoft's side is usually already known - and often already fixed - by the time you meet it. See [the Entra sign-in canary](docs/entra-canary.md).
+
 ### When Omada refuses the sign-in
 
 A sign-in can also fail on the other side of the redirect. Your identity provider authenticates you, hands the browser back to Omada, and Omada decides it cannot let you in - because the account is not a member of the tenant the Omada application is registered in, because the application registration is not accepted, or for any other reason it reports. That failure is not an HTTP error and not a redirect: it is a message rendered on Omada's own logon page, which then simply sits there.

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -65,37 +65,50 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
         $SecurePassword = ConvertTo-SecureString -String $Env:OMADAWEBPS_CANARY_PASSWORD -AsPlainText -Force
         $Credential = [System.Management.Automation.PSCredential]::new($Env:OMADAWEBPS_CANARY_USERNAME, $SecurePassword)
 
-        # -ForceAuthentication and -SkipCookieCache together are what make a scheduled run mean
-        # something. A cached cookie would satisfy the request without a sign-in page ever being
-        # drawn, so the canary would go green on the strength of yesterday's success.
         $Script:CanaryWarning = @()
         $Script:CanaryError = $null
         $Script:CanaryResponse = $null
 
-        # Declared before the call rather than left to -WarningVariable to create: the tests run
-        # under Set-StrictMode -Version Latest, where reading it in the catch block after a failure
-        # that produced no warning would be an unset-variable error masking the real one.
-        $CanaryWarningOutput = @()
-
+        # Warnings are captured by merging the warning stream into the success stream and sorting the
+        # records back out, rather than with -WarningVariable. Switch-ToManualLogin emits its
+        # diagnostic from a WinForms timer handler running inside the blocking ShowDialog call, not
+        # from Invoke-OmadaWebRequest's own pipeline, and -WarningVariable collects only the latter.
+        # A capture that quietly missed it would leave the canary reporting a failure with no reason
+        # attached, which is the failure this whole exercise is meant to prevent.
+        #
+        # -ForceAuthentication and -SkipCookieCache are what make a scheduled run mean anything: a
+        # cached cookie would satisfy the request without a sign-in page ever being drawn, so the
+        # canary would go green on the strength of yesterday's success.
         try {
-            $Script:CanaryResponse = Invoke-OmadaWebRequest -Uri $Script:RelyingParty.ResourceUrl `
+            $Output = Invoke-OmadaWebRequest -Uri $Script:RelyingParty.ResourceUrl `
                 -AuthenticationType WebView2 `
                 -Credential $Credential `
                 -ForceAuthentication `
                 -SkipCookieCache `
-                -ErrorAction Stop `
-                -WarningVariable CanaryWarningOutput
+                -ErrorAction Stop 3>&1
 
-            $Script:CanaryWarning = @($CanaryWarningOutput)
+            foreach ($Record in @($Output)) {
+                if ($Record -is [System.Management.Automation.WarningRecord]) {
+                    $Script:CanaryWarning += $Record.Message
+                }
+                else {
+                    $Script:CanaryResponse = $Record
+                }
+            }
         }
         catch {
             $Script:CanaryError = $_
-            $Script:CanaryWarning = @($CanaryWarningOutput)
         }
 
-        # The one diagnostic that names a broken selector. Switch-ToManualLogin writes it to the
-        # warning stream with the state, the selectors expected but absent, the ones present, and the
-        # page path - so it is reported verbatim rather than summarized.
+        # Third route to the same fact, and the one that cannot be lost in stream plumbing: the flag
+        # Switch-ToManualLogin sets in the module's own scope. Read after the fact it is only
+        # suggestive - a retry window calls Reset-LoginAutomationState and clears it again - so it is
+        # reported rather than asserted on, and the assertions below rest on whether the sign-in
+        # actually completed.
+        $Script:ManualFallbackFlag = InModuleScope 'OmadaWeb.PS' { $Script:ManualLoginFallbackActive }
+
+        # The diagnostic that names a broken selector: the state, the selectors expected but absent,
+        # the ones present, and the page path. Reported verbatim rather than summarized.
         $Script:FallbackWarning = @($Script:CanaryWarning | Where-Object { $_ -match 'Automated Microsoft sign-in could not continue' })
 
         if ($Script:FallbackWarning.Count -gt 0) {
@@ -116,13 +129,29 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
         Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
     }
 
-    It 'Still recognizes every Microsoft sign-in screen it was shown' {
-        # This is the assertion the whole canary exists for. Its message is what a maintainer reads
-        # first in a failed run, so it carries the diagnostic rather than pointing at a log.
-        $Script:FallbackWarning -join [System.Environment]::NewLine | Should -BeNullOrEmpty -Because (
-            "credential autofill fell back to manual sign-in, which means Microsoft changed a page this module recognizes by element id. " +
-            "The diagnostic above names the state and the missing selector; update `$Script:EntraSignInElementId in OmadaWeb.PS/OmadaWeb.PS.psm1 (issue #32)"
+    It 'Signed in with the credential, without falling back to manual entry' {
+        # The assertion the whole canary exists for, and the one that does not depend on catching a
+        # warning: nobody is at this browser, so if autofill stops filling fields the sign-in simply
+        # never completes. That makes "did the request succeed" the reliable signal, and the captured
+        # diagnostic an enrichment of it rather than the thing being tested.
+        $Message = if ($null -eq $Script:CanaryError) { "" } else { $Script:CanaryError.Exception.Message }
+        $Diagnostic = $Script:FallbackWarning -join [System.Environment]::NewLine
+        if ([string]::IsNullOrWhiteSpace($Diagnostic) -and $Script:ManualFallbackFlag) {
+            $Diagnostic = "The module reported that it had handed the sign-in back to the user, but the diagnostic naming the selector was not captured."
+        }
+
+        $Report = (@($Message, $Diagnostic) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join [System.Environment]::NewLine
+
+        $Report | Should -BeNullOrEmpty -Because (
+            "credential autofill did not carry the sign-in through, which usually means Microsoft changed a page this module recognizes by element id. " +
+            "Update `$Script:EntraSignInElementId in OmadaWeb.PS/OmadaWeb.PS.psm1 from the diagnostic above (issue #32)"
         )
+    }
+
+    It 'Did not report a selector it no longer recognizes' {
+        # Separate from the assertion above so that a run which somehow completed the sign-in while
+        # still reporting an unrecognized page is not quietly passed over.
+        $Script:FallbackWarning -join [System.Environment]::NewLine | Should -BeNullOrEmpty
     }
 
     It 'Was not refused by Entra ID' {
@@ -130,13 +159,6 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
         # password or a Conditional Access block all land here instead, and all are tenant
         # configuration rather than a Microsoft DOM change.
         $Script:RelyingParty.CallbackError | Should -BeNullOrEmpty -Because "Entra returned this OAuth error code instead of an authorization code; see docs/entra-canary.md"
-    }
-
-    It 'Completed the sign-in without erroring' {
-        $Message = if ($null -eq $Script:CanaryError) { "" } else { $Script:CanaryError.Exception.Message }
-
-        $Message | Should -BeNullOrEmpty
-        $Script:CanaryError | Should -BeNullOrEmpty
     }
 
     It 'Actually travelled through Entra and back' {

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -174,6 +174,9 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
     }
 
     It 'Kept the loopback stand-in healthy throughout' {
-        $Script:RelyingParty.ListenerError | Should -BeNullOrEmpty
+        # Reads the runspace's error stream as well as the loop's own record, so a listener that died
+        # before it ever served a request cannot be reported as healthy while the sign-in failure is
+        # blamed on Microsoft.
+        (Get-CanaryRelyingPartyError -RelyingParty $Script:RelyingParty) -join [System.Environment]::NewLine | Should -BeNullOrEmpty
     }
 }

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -1,0 +1,157 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ModulePath', Justification = 'Used by Import-Module inside the Describe BeforeAll, which the analyzer does not follow into.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'The canary password arrives from a GitHub environment secret as an environment variable, which is a plain string by the time this process can see it. Building the PSCredential the module takes is the only thing done with it.')]
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+# The scheduled login-flow canary (roadmap E5, issue #33).
+#
+# WHAT THIS WATCHES
+#
+# One tier, and deliberately only one: Entra ID credential autofill. That is the module's only
+# dependency on Microsoft's sign-in DOM, and Microsoft changes it on its own schedule. Interactive
+# sign-in is IdP-agnostic and is not covered here - a tenant on Ping, Okta or ADFS reaches none of
+# this code.
+#
+# So a red canary means "autofill needs a selector update" - a routine change to
+# $Script:EntraSignInElementId in OmadaWeb.PS.psm1 - and not "login is broken". Since #52 a selector
+# break degrades autofill rather than sign-in: Switch-ToManualLogin turns autofill off and hands the
+# window to the user. This test exists to see that happen on a schedule instead of in front of one.
+#
+# WHAT IT DELIBERATELY DOES NOT WATCH
+#
+# MFA. An interactive approval cannot be automated, so the canary account is exempted from MFA by an
+# explicit Conditional Access policy (see Build/New-EntraCanaryConfiguration.ps1). The MFA screens in
+# Resolve-EntraSignInScreen are covered by unit tests against recorded page snapshots, not here.
+#
+# HOW IT AVOIDS TESTING A COPY OF ITSELF
+#
+# It drives Invoke-OmadaWebRequest, so the sign-in is worked by the shipping code path -
+# Invoke-WebView2MicrosoftLogin over what Get-EntraSignInProbeScript reads and
+# Resolve-EntraSignInScreen judges. Tests/E2E/Start-CanaryRelyingParty.ps1 stands in for the Omada
+# host on the loopback interface, which is what removes the need for an Omada environment; see the
+# header of that file for how the redirect makes the real driver engage.
+#
+# See docs/entra-canary.md for the tenant setup, the secrets, and what to do when this goes red.
+
+BeforeDiscovery {
+    # Read at discovery so the whole file can be skipped as configuration rather than reported as a
+    # failure. A developer running the suite locally, and PR Validation, both land here.
+    $Script:CanaryTenantId = $Env:OMADAWEBPS_CANARY_TENANT_ID
+    $Script:CanaryClientId = $Env:OMADAWEBPS_CANARY_CLIENT_ID
+    $Script:CanaryUserName = $Env:OMADAWEBPS_CANARY_USERNAME
+    $Script:CanaryPassword = $Env:OMADAWEBPS_CANARY_PASSWORD
+
+    $Script:CanaryConfigured = -not (
+        [string]::IsNullOrWhiteSpace($Script:CanaryTenantId) -or
+        [string]::IsNullOrWhiteSpace($Script:CanaryClientId) -or
+        [string]::IsNullOrWhiteSpace($Script:CanaryUserName) -or
+        [string]::IsNullOrWhiteSpace($Script:CanaryPassword)
+    )
+}
+
+Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigured) {
+
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'Start-CanaryRelyingParty.ps1')
+
+        Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+        Import-Module $ModulePath -Force -ErrorAction Stop
+
+        $Port = if ([string]::IsNullOrWhiteSpace($Env:OMADAWEBPS_CANARY_PORT)) { 8400 } else { [int]$Env:OMADAWEBPS_CANARY_PORT }
+
+        $Script:RelyingParty = Start-CanaryRelyingParty -TenantId $Env:OMADAWEBPS_CANARY_TENANT_ID -ClientId $Env:OMADAWEBPS_CANARY_CLIENT_ID -LoginHint $Env:OMADAWEBPS_CANARY_USERNAME -Port $Port
+
+        $SecurePassword = ConvertTo-SecureString -String $Env:OMADAWEBPS_CANARY_PASSWORD -AsPlainText -Force
+        $Credential = [System.Management.Automation.PSCredential]::new($Env:OMADAWEBPS_CANARY_USERNAME, $SecurePassword)
+
+        # -ForceAuthentication and -SkipCookieCache together are what make a scheduled run mean
+        # something. A cached cookie would satisfy the request without a sign-in page ever being
+        # drawn, so the canary would go green on the strength of yesterday's success.
+        $Script:CanaryWarning = @()
+        $Script:CanaryError = $null
+        $Script:CanaryResponse = $null
+
+        # Declared before the call rather than left to -WarningVariable to create: the tests run
+        # under Set-StrictMode -Version Latest, where reading it in the catch block after a failure
+        # that produced no warning would be an unset-variable error masking the real one.
+        $CanaryWarningOutput = @()
+
+        try {
+            $Script:CanaryResponse = Invoke-OmadaWebRequest -Uri $Script:RelyingParty.ResourceUrl `
+                -AuthenticationType WebView2 `
+                -Credential $Credential `
+                -ForceAuthentication `
+                -SkipCookieCache `
+                -ErrorAction Stop `
+                -WarningVariable CanaryWarningOutput
+
+            $Script:CanaryWarning = @($CanaryWarningOutput)
+        }
+        catch {
+            $Script:CanaryError = $_
+            $Script:CanaryWarning = @($CanaryWarningOutput)
+        }
+
+        # The one diagnostic that names a broken selector. Switch-ToManualLogin writes it to the
+        # warning stream with the state, the selectors expected but absent, the ones present, and the
+        # page path - so it is reported verbatim rather than summarized.
+        $Script:FallbackWarning = @($Script:CanaryWarning | Where-Object { $_ -match 'Automated Microsoft sign-in could not continue' })
+
+        if ($Script:FallbackWarning.Count -gt 0) {
+            "::group::Entra sign-in canary diagnostic" | Write-Host
+            $Script:FallbackWarning | ForEach-Object { $_ | Write-Host }
+            "::endgroup::" | Write-Host
+
+            # Written to a file as well as to the log so the workflow can put it in the issue it
+            # files, rather than scraping it back out of its own console output.
+            if (-not [string]::IsNullOrWhiteSpace($Env:OMADAWEBPS_CANARY_DIAGNOSTIC_PATH)) {
+                $Script:FallbackWarning -join [System.Environment]::NewLine | Set-Content -LiteralPath $Env:OMADAWEBPS_CANARY_DIAGNOSTIC_PATH -Encoding UTF8
+            }
+        }
+    }
+
+    AfterAll {
+        Stop-CanaryRelyingParty -RelyingParty $Script:RelyingParty
+        Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'Still recognizes every Microsoft sign-in screen it was shown' {
+        # This is the assertion the whole canary exists for. Its message is what a maintainer reads
+        # first in a failed run, so it carries the diagnostic rather than pointing at a log.
+        $Script:FallbackWarning -join [System.Environment]::NewLine | Should -BeNullOrEmpty -Because (
+            "credential autofill fell back to manual sign-in, which means Microsoft changed a page this module recognizes by element id. " +
+            "The diagnostic above names the state and the missing selector; update `$Script:EntraSignInElementId in OmadaWeb.PS/OmadaWeb.PS.psm1 (issue #32)"
+        )
+    }
+
+    It 'Was not refused by Entra ID' {
+        # Distinguishes a broken selector from a broken account: a disabled canary user, an expired
+        # password or a Conditional Access block all land here instead, and all are tenant
+        # configuration rather than a Microsoft DOM change.
+        $Script:RelyingParty.CallbackError | Should -BeNullOrEmpty -Because "Entra returned this OAuth error code instead of an authorization code; see docs/entra-canary.md"
+    }
+
+    It 'Completed the sign-in without erroring' {
+        $Message = if ($null -eq $Script:CanaryError) { "" } else { $Script:CanaryError.Exception.Message }
+
+        $Message | Should -BeNullOrEmpty
+        $Script:CanaryError | Should -BeNullOrEmpty
+    }
+
+    It 'Actually travelled through Entra and back' {
+        # Guards against the canary passing for the wrong reason. Without this, a stand-in that
+        # somehow answered the first request with a cookie would look exactly like a successful
+        # sign-in, and the tier under test would never have run at all.
+        $Script:RelyingParty.RedirectHitCount | Should -BeGreaterThan 0 -Because "the browser never came back from login.microsoftonline.com, so the autofill tier was not exercised"
+    }
+
+    It 'Returned the protected resource' {
+        $Script:CanaryResponse | Should -Not -BeNullOrEmpty
+        ($Script:CanaryResponse.Content | ConvertFrom-Json).canary | Should -Be "ok"
+    }
+
+    It 'Kept the loopback stand-in healthy throughout' {
+        $Script:RelyingParty.ListenerError | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/E2E/Start-CanaryRelyingParty.ps1
+++ b/Tests/E2E/Start-CanaryRelyingParty.ps1
@@ -411,6 +411,59 @@ function Start-CanaryRelyingParty {
     return $RelyingParty
 }
 
+function Get-CanaryRelyingPartyError {
+    <#
+    .SYNOPSIS
+        Everything that has gone wrong in the listener so far, readable while it is still running.
+
+    .DESCRIPTION
+        Two sources, because neither is complete on its own. The loop records what its own catch
+        block saw into ListenerError; anything that killed the loop before or outside that catch
+        lands in the runspace's error stream instead, and is only re-raised by EndInvoke - which
+        cannot be called until the listener is being torn down, and therefore not before the
+        assertions run.
+
+        Reading the error stream directly is what closes that gap. Without it a listener that died on
+        its first statement would serve nothing at all while the canary reported it as healthy, and
+        the sign-in failure would be blamed on Microsoft.
+
+    .PARAMETER RelyingParty
+        The object returned by Start-CanaryRelyingParty.
+
+    .OUTPUTS
+        System.String[]. Empty when nothing has gone wrong.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String[]])]
+    param(
+        [AllowNull()]
+        $RelyingParty
+    )
+
+    if ($null -eq $RelyingParty) {
+        return @()
+    }
+
+    $Reported = [System.Collections.Generic.List[string]]::new()
+
+    if (-not [string]::IsNullOrWhiteSpace($RelyingParty.ListenerError)) {
+        $Reported.Add([string]$RelyingParty.ListenerError)
+    }
+
+    # Indexed, never enumerated. Streams.Error is a PSDataCollection, and its enumerator is a
+    # blocking one: while the invocation is still open it waits for the next item rather than ending,
+    # so "@($collection)" on a running listener never returns. Reading Count and indexing is the
+    # non-blocking form, and unlike ReadAll it leaves the records in place for EndInvoke to re-raise.
+    if ($null -ne $RelyingParty.PowerShellInstance) {
+        $ErrorStream = $RelyingParty.PowerShellInstance.Streams.Error
+        for ($Index = 0; $Index -lt $ErrorStream.Count; $Index++) {
+            $Reported.Add([string]$ErrorStream[$Index])
+        }
+    }
+
+    return $Reported.ToArray()
+}
+
 function Stop-CanaryRelyingParty {
     <#
     .SYNOPSIS
@@ -450,6 +503,28 @@ function Stop-CanaryRelyingParty {
     }
     catch {
         "Stop-CanaryRelyingParty - could not close the listener: {0}" -f $_.Exception.Message | Write-Verbose
+    }
+
+    # EndInvoke before Dispose. Disposing a PowerShell instance without ending its invocation leaves
+    # the async operation unobserved and can strand the thread, and EndInvoke is what re-raises a
+    # terminating error from the listener thread - one the loop's own catch never saw because it
+    # never got as far as the loop.
+    #
+    # Note that this runs from an AfterAll, which is after the assertions. Anything recorded here is
+    # for the log, not for a test; Get-CanaryRelyingPartyError is what the assertions read.
+    try {
+        if ($null -ne $RelyingParty.PowerShellInstance -and $null -ne $RelyingParty.AsyncResult) {
+            if ($RelyingParty.AsyncResult.AsyncWaitHandle.WaitOne([System.TimeSpan]::FromSeconds(10))) {
+                $null = $RelyingParty.PowerShellInstance.EndInvoke($RelyingParty.AsyncResult)
+            }
+            else {
+                $RelyingParty.ListenerError = "The listener thread did not finish within 10 seconds of the listener being closed."
+            }
+        }
+    }
+    catch {
+        $RelyingParty.ListenerError = $_.Exception.Message
+        "Stop-CanaryRelyingParty - the listener thread ended with an error: {0}" -f $_.Exception.Message | Write-Verbose
     }
 
     try {

--- a/Tests/E2E/Start-CanaryRelyingParty.ps1
+++ b/Tests/E2E/Start-CanaryRelyingParty.ps1
@@ -1,0 +1,472 @@
+# Start-CanaryRelyingParty.ps1
+#
+# The loopback stand-in for an Omada environment used by the scheduled Entra sign-in canary
+# (see .github/workflows/entra-canary.yml and docs/entra-canary.md).
+#
+# WHY THIS EXISTS
+#
+# The canary watches one thing: whether the Entra ID credential autofill tier still recognizes
+# Microsoft's sign-in screens. That tier is Invoke-WebView2MicrosoftLogin driving what
+# Get-EntraSignInProbeScript reads and Resolve-EntraSignInScreen judges, and the only way to know it
+# still works is to point it at a live login.microsoftonline.com page.
+#
+# It must be the real driver, not a copy of it. A canary built on its own harness would happily go
+# green while the shipping code path was broken, which is the one failure this whole exercise is
+# meant to make impossible.
+#
+# Initialize-WebView2 navigates to the session's BaseUrl and then, on every timer tick, switches on
+# the host the browser is currently on: the BaseUrl host means "look for the oisauthtoken cookie",
+# and login.microsoftonline.com means "drive the sign-in". So a local listener standing in for the
+# Omada host gives the entire real code path with no Omada environment involved:
+#
+#   1. The module navigates to http://localhost:<port>/
+#   2. This listener answers 302 to the tenant's authorize endpoint for the canary app registration
+#   3. The browser lands on Entra, the host no longer matches, and the real autofill driver takes over
+#   4. Entra redirects back to http://localhost:<port>/canary, which sets oisauthtoken and returns 200
+#   5. Get-WebView2Cookie finds the cookie, closes the window, and the request completes
+#
+# The authorization code is never redeemed. The canary asserts that the sign-in screens were driven,
+# not that a token was issued - redeeming one would test Entra's token endpoint, which is not what
+# breaks.
+#
+# TWO THINGS THE ROUTING HAS TO GET RIGHT
+#
+#   - The redirect path must not contain "logon", "login", "signin", "sign-in" or "error".
+#     Get-OmadaLogonErrorScript treats a path matching those as an Omada logon page and then sweeps
+#     the whole body for anything carrying an error severity, so a path like /signin-callback would
+#     have the module scraping this page for a failure banner. "/canary" is deliberately none of them.
+#   - The served page must carry no element whose class names an error severity, for the same reason.
+#
+# The listener runs in its own runspace because the WebView2 sign-in blocks the calling thread on a
+# WinForms dialog: a listener on that thread would never answer the request that opens the window.
+
+#Requires -Version 5.1
+
+function New-CanaryPkcePair {
+    <#
+    .SYNOPSIS
+        Returns a PKCE code verifier and its S256 challenge.
+
+    .DESCRIPTION
+        The canary never redeems the authorization code, so PKCE protects nothing here. It is sent
+        anyway because a public-client registration is entitled to require it, and a canary that
+        breaks the day someone ticks that box in the tenant would be reporting on the tenant's
+        configuration rather than on Microsoft's sign-in page.
+
+        Base64url per RFC 7636: standard base64 with '+' and '/' swapped for '-' and '_', and the
+        padding removed.
+
+    .OUTPUTS
+        PSCustomObject with the members Verifier and Challenge.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    param()
+
+    $RandomBytes = [byte[]]::new(32)
+    $RandomNumberGenerator = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $RandomNumberGenerator.GetBytes($RandomBytes)
+    }
+    finally {
+        $RandomNumberGenerator.Dispose()
+    }
+
+    $Verifier = [Convert]::ToBase64String($RandomBytes).Replace("+", "-").Replace("/", "_").TrimEnd("=")
+
+    $Sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $ChallengeBytes = $Sha256.ComputeHash([System.Text.Encoding]::ASCII.GetBytes($Verifier))
+    }
+    finally {
+        $Sha256.Dispose()
+    }
+
+    $Challenge = [Convert]::ToBase64String($ChallengeBytes).Replace("+", "-").Replace("/", "_").TrimEnd("=")
+
+    return [pscustomobject]@{
+        Verifier  = $Verifier
+        Challenge = $Challenge
+    }
+}
+
+function New-CanaryAuthorizeUri {
+    <#
+    .SYNOPSIS
+        Builds the Entra ID authorization request the stand-in redirects the browser to.
+
+    .DESCRIPTION
+        Every value is escaped with [System.Uri]::EscapeDataString rather than assembled by string
+        concatenation, because the login hint is an account name and the redirect URI carries a
+        port and a path.
+
+        'prompt=login' is what makes the canary deterministic. Without it, a WebView2 profile that
+        still holds a session cookie would be waved straight through and the sign-in screens - the
+        only thing under test - would never be rendered. The canary would then pass by not testing
+        anything, which is worse than failing.
+
+        The login hint is sent so that Entra can serve the account's own sign-in experience. It does
+        not skip the username screen: the automation still fills it in, which is what the canary is
+        there to watch.
+
+    .PARAMETER TenantId
+        The directory (tenant) ID hosting the canary account and app registration.
+
+    .PARAMETER ClientId
+        The application (client) ID of the canary app registration.
+
+    .PARAMETER RedirectUri
+        The loopback URI Entra hands the browser back to. Must be registered on the application.
+
+    .PARAMETER CodeChallenge
+        The S256 PKCE challenge from New-CanaryPkcePair.
+
+    .PARAMETER State
+        The opaque state value echoed back on the redirect, which the listener checks.
+
+    .PARAMETER LoginHint
+        The canary account's user principal name.
+
+    .OUTPUTS
+        System.String. The absolute authorization request URI.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TenantId,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ClientId,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$RedirectUri,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$CodeChallenge,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$State,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$LoginHint
+    )
+
+    $QueryParameter = [ordered]@{
+        client_id             = $ClientId
+        response_type         = "code"
+        redirect_uri          = $RedirectUri
+        response_mode         = "query"
+        scope                 = "openid profile User.Read"
+        state                 = $State
+        code_challenge        = $CodeChallenge
+        code_challenge_method = "S256"
+        prompt                = "login"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($LoginHint)) {
+        $QueryParameter["login_hint"] = $LoginHint
+    }
+
+    $QueryString = ($QueryParameter.GetEnumerator() | ForEach-Object {
+            "{0}={1}" -f [System.Uri]::EscapeDataString($_.Key), [System.Uri]::EscapeDataString($_.Value)
+        }) -join "&"
+
+    return "https://login.microsoftonline.com/{0}/oauth2/v2.0/authorize?{1}" -f [System.Uri]::EscapeDataString($TenantId), $QueryString
+}
+
+function New-CanarySetCookieHeader {
+    <#
+    .SYNOPSIS
+        Builds the Set-Cookie header that stands in for Omada's session cookie.
+
+    .DESCRIPTION
+        Get-WebView2Cookie looks for a cookie named 'oisauthtoken' whose domain ends with the host of
+        the session's BaseUrl, and closes the sign-in window once it finds one. The cookie is written
+        host-only - no Domain attribute - because a Domain of 'localhost' is rejected by parts of the
+        cookie stack, and host-only still satisfies that suffix match.
+
+        Not marked Secure: the stand-in serves plain HTTP on the loopback interface, and a Secure
+        cookie would be dropped, leaving the sign-in window waiting forever for a cookie the browser
+        had thrown away.
+
+    .PARAMETER Name
+        The cookie name.
+
+    .PARAMETER Value
+        The cookie value.
+
+    .PARAMETER Path
+        The cookie path.
+
+    .OUTPUTS
+        System.String. The Set-Cookie header value.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Value,
+
+        [string]$Path = "/"
+    )
+
+    return "{0}={1}; Path={2}; HttpOnly; SameSite=Lax" -f $Name, $Value, $Path
+}
+
+function Start-CanaryRelyingParty {
+    <#
+    .SYNOPSIS
+        Starts the loopback stand-in and returns the state the canary asserts against.
+
+    .DESCRIPTION
+        Serves three routes:
+
+          /canary   - the registered redirect URI. Records the hit, sets oisauthtoken, returns 200.
+          /api/*    - the resource the module requests once it holds the cookie. Returns JSON.
+          anything  - 302 to the authorization request.
+
+        The catch-all redirect is deliberate. Test-EnvironmentSuspended probes the BaseUrl with its
+        own HttpClient before the browser ever opens, and that client follows redirects, so it will
+        fetch the Entra sign-in page and find no suspension notice. That is harmless, and it is why
+        the redirect has to be stateless: a listener that redirected only once would already have
+        spent its redirect by the time the browser asked.
+
+        The returned object is a synchronized hashtable so the listener thread and the test thread
+        can both touch it. The test reads RedirectHitCount and CallbackError after the sign-in;
+        ListenerError carries anything the loop itself threw.
+
+    .PARAMETER TenantId
+        The directory (tenant) ID hosting the canary account and app registration.
+
+    .PARAMETER ClientId
+        The application (client) ID of the canary app registration.
+
+    .PARAMETER LoginHint
+        The canary account's user principal name.
+
+    .PARAMETER Port
+        The loopback port to listen on. Must be covered by a registered redirect URI; Entra ignores
+        the port when matching a localhost redirect URI on a public client, so any port that a
+        registration already covers with the same path will do.
+
+    .OUTPUTS
+        System.Collections.Hashtable, synchronized.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TenantId,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ClientId,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$LoginHint,
+
+        [ValidateRange(1024, 65535)]
+        [int]$Port = 8400
+    )
+
+    $Prefix = "http://localhost:{0}/" -f $Port
+    $RedirectUri = "http://localhost:{0}/canary" -f $Port
+    $Pkce = New-CanaryPkcePair
+    $StateValue = [guid]::NewGuid().ToString("N")
+
+    $AuthorizeUri = New-CanaryAuthorizeUri -TenantId $TenantId -ClientId $ClientId -RedirectUri $RedirectUri -CodeChallenge $Pkce.Challenge -State $StateValue -LoginHint $LoginHint
+
+    $CookieName = "oisauthtoken"
+    $CookieValue = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("canary-cookie-value"))
+
+    $Listener = [System.Net.HttpListener]::new()
+    $Listener.Prefixes.Add($Prefix)
+    $Listener.Start()
+
+    # The authorization URI and the Set-Cookie header are built here rather than inside the loop
+    # because a runspace does not inherit this session's functions: anything the loop needs from the
+    # helpers above has to be computed on this side and carried across in the state.
+    $RelyingParty = [hashtable]::Synchronized(@{
+            Listener         = $Listener
+            BaseUrl          = "http://localhost:{0}" -f $Port
+            ResourceUrl      = "http://localhost:{0}/api/ping" -f $Port
+            RedirectUri      = $RedirectUri
+            RedirectPath     = "/canary"
+            AuthorizeUri     = $AuthorizeUri
+            ExpectedState    = $StateValue
+            CookieName       = $CookieName
+            CookieValue      = $CookieValue
+            SetCookieHeader  = (New-CanarySetCookieHeader -Name $CookieName -Value $CookieValue)
+            RedirectHitCount = 0
+            CallbackError    = $null
+            ListenerError    = $null
+        })
+
+    # Only .NET types and the state hashtable cross into the runspace - the helper functions above
+    # stay on this side, because a runspace created here does not inherit this session's functions.
+    $ListenerLoop = {
+        param($RelyingParty)
+
+        $Listener = $RelyingParty.Listener
+        while ($Listener.IsListening) {
+            $Context = $null
+            try {
+                $Context = $Listener.GetContext()
+            }
+            catch {
+                # Stop-CanaryRelyingParty closes the listener, which is what unblocks GetContext.
+                # Only an exception while still listening is worth recording.
+                if ($Listener.IsListening) {
+                    $RelyingParty.ListenerError = $_.Exception.Message
+                }
+
+                break
+            }
+
+            try {
+                $Path = $Context.Request.Url.AbsolutePath
+                $Body = ""
+                $ContentType = "text/html; charset=utf-8"
+
+                if ($Path -eq $RelyingParty.RedirectPath) {
+                    $RelyingParty.RedirectHitCount = $RelyingParty.RedirectHitCount + 1
+
+                    $ReturnedError = $Context.Request.QueryString["error"]
+                    $ReturnedState = $Context.Request.QueryString["state"]
+                    if (-not [string]::IsNullOrWhiteSpace($ReturnedError)) {
+                        # The description can name the account and the tenant, so only the code is
+                        # kept: this value is reported by a failing canary into a public issue.
+                        $RelyingParty.CallbackError = $ReturnedError
+                    }
+                    elseif ($ReturnedState -ne $RelyingParty.ExpectedState) {
+                        $RelyingParty.CallbackError = "state_mismatch"
+                    }
+
+                    $Context.Response.Headers.Add("Set-Cookie", $RelyingParty.SetCookieHeader)
+                    $Context.Response.StatusCode = 200
+                    # No element here may carry a class naming an error severity - see the header of
+                    # this file for why.
+                    $Body = "<html><head><title>OmadaWeb.PS canary</title></head><body><p>Canary sign-in complete.</p></body></html>"
+                }
+                elseif ($Path -like "/api/*") {
+                    $Context.Response.StatusCode = 200
+                    $ContentType = "application/json; charset=utf-8"
+                    $Body = '{"canary":"ok"}'
+                }
+                else {
+                    $Context.Response.StatusCode = 302
+                    $Context.Response.Headers.Add("Location", $RelyingParty.AuthorizeUri)
+                    $Body = "<html><head><title>OmadaWeb.PS canary</title></head><body><p>Redirecting.</p></body></html>"
+                }
+
+                $Bytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
+                $Context.Response.ContentType = $ContentType
+                $Context.Response.ContentLength64 = $Bytes.Length
+                $Context.Response.OutputStream.Write($Bytes, 0, $Bytes.Length)
+                $Context.Response.Close()
+            }
+            catch {
+                # One aborted or timed-out client must never take the listener down: the browser
+                # abandons requests routinely while it navigates.
+                try {
+                    if ($null -ne $Context) {
+                        $Context.Response.Abort()
+                    }
+                }
+                catch {
+                    # Nothing left to do for a response that cannot even be aborted.
+                    $null = $_
+                }
+            }
+        }
+    }
+
+    $Runspace = [runspacefactory]::CreateRunspace()
+    $Runspace.ApartmentState = "MTA"
+    $Runspace.ThreadOptions = "ReuseThread"
+    $Runspace.Open()
+
+    $PowerShellInstance = [powershell]::Create()
+    $PowerShellInstance.Runspace = $Runspace
+    $null = $PowerShellInstance.AddScript($ListenerLoop).AddArgument($RelyingParty)
+
+    $RelyingParty["Runspace"] = $Runspace
+    $RelyingParty["PowerShellInstance"] = $PowerShellInstance
+    $RelyingParty["AsyncResult"] = $PowerShellInstance.BeginInvoke()
+
+    return $RelyingParty
+}
+
+function Stop-CanaryRelyingParty {
+    <#
+    .SYNOPSIS
+        Stops the loopback stand-in and disposes its runspace.
+
+    .DESCRIPTION
+        Closing the listener is what unblocks the GetContext call the loop is parked on, so it has to
+        happen before the runspace is torn down. Every step is best-effort: this runs from a Pester
+        AfterAll, where throwing would replace a real test failure with a cleanup failure.
+
+    .PARAMETER RelyingParty
+        The object returned by Start-CanaryRelyingParty.
+    #>
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $RelyingParty
+    )
+
+    if ($null -eq $RelyingParty) {
+        return
+    }
+
+    try {
+        if ($null -ne $RelyingParty.Listener -and $RelyingParty.Listener.IsListening) {
+            $RelyingParty.Listener.Stop()
+        }
+    }
+    catch {
+        "Stop-CanaryRelyingParty - could not stop the listener: {0}" -f $_.Exception.Message | Write-Verbose
+    }
+
+    try {
+        if ($null -ne $RelyingParty.Listener) {
+            $RelyingParty.Listener.Close()
+        }
+    }
+    catch {
+        "Stop-CanaryRelyingParty - could not close the listener: {0}" -f $_.Exception.Message | Write-Verbose
+    }
+
+    try {
+        if ($null -ne $RelyingParty.PowerShellInstance) {
+            $RelyingParty.PowerShellInstance.Dispose()
+        }
+    }
+    catch {
+        "Stop-CanaryRelyingParty - could not dispose the PowerShell instance: {0}" -f $_.Exception.Message | Write-Verbose
+    }
+
+    try {
+        if ($null -ne $RelyingParty.Runspace) {
+            $RelyingParty.Runspace.Dispose()
+        }
+    }
+    catch {
+        "Stop-CanaryRelyingParty - could not dispose the runspace: {0}" -f $_.Exception.Message | Write-Verbose
+    }
+}

--- a/Tests/E2E/Test-CanaryBrowserHost.ps1
+++ b/Tests/E2E/Test-CanaryBrowserHost.ps1
@@ -1,0 +1,155 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Answers one question about a machine: can it host the WebView2 window the sign-in needs?
+.DESCRIPTION
+    The canary rests on an assumption that is invisible until it fails: that the runner can create a
+    WinForms window and initialize a CoreWebView2 inside it. If it cannot, every canary assertion
+    fails at once and the diagnostic says the sign-in page was not recognized - which is true, and
+    which points at exactly the wrong thing. A maintainer would go looking at Microsoft's markup while
+    the real answer was that no browser ever opened.
+
+    So this is kept separate and deliberately knows nothing about Entra ID, credentials or the module's
+    sign-in flow. It opens a window, navigates to about:blank, waits for the runtime to report itself
+    initialized, and closes. Green means the host is capable and any canary failure is about the
+    sign-in page; red means the canary cannot run here at all.
+
+    Run it on a new runner image before trusting a red canary, and after any change to how the
+    WebView2 assemblies are bundled.
+.PARAMETER ModulePath
+    The built module to take the WebView2 assemblies and their resolved paths from. Defaults to the
+    build output, because that is what the canary itself loads.
+
+    Must be the .psm1 and not the .psd1: importing the manifest returns a module of type Manifest,
+    whose session state holds only the three exported commands, so the private functions this needs
+    are invisible from it. The PR Validation workflow imports the .psm1 for the same reason.
+.PARAMETER TimeoutSeconds
+    How long to wait for CoreWebView2 to report initialization before giving up.
+.EXAMPLE
+    ./Tests/E2E/Test-CanaryBrowserHost.ps1
+
+    Exits 0 when the machine can host a WebView2 window, and 1 with a reason when it cannot.
+#>
+[CmdletBinding()]
+param(
+    [string]$ModulePath = (Join-Path (Split-Path (Split-Path $PSScriptRoot)) -ChildPath "buildoutput/OmadaWeb.PS/OmadaWeb.PS.psm1"),
+
+    [ValidateRange(10, 600)]
+    [int]$TimeoutSeconds = 90
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+try {
+    "Apartment state : {0}" -f [System.Threading.Thread]::CurrentThread.GetApartmentState() | Write-Host
+    "Session name    : {0}" -f [System.Environment]::GetEnvironmentVariable("SESSIONNAME") | Write-Host
+    "Module          : {0}" -f $ModulePath | Write-Host
+
+    if ([System.Threading.Thread]::CurrentThread.GetApartmentState() -ne "STA") {
+        # PowerShell 7 is STA by default on Windows, so this only fires when something has gone out of
+        # its way to change it - and a WinForms dialog on an MTA thread fails in ways that look like a
+        # hung sign-in rather than like a configuration mistake.
+        "This process is not running in a single-threaded apartment. WinForms needs STA; start PowerShell without -MTA." | Write-Error -ErrorAction "Stop"
+    }
+
+    if (-not (Test-Path $ModulePath)) {
+        "The module was not found at '{0}'. Build it first with ./Build/build.ps1 -Task Build." -f $ModulePath | Write-Error -ErrorAction "Stop"
+    }
+
+    $Module = Import-Module $ModulePath -Force -PassThru -ErrorAction Stop
+
+    # Run inside the module's own session state, which is the only place the bundled assembly paths
+    # ($Script:WebView2CorePath and friends) are resolved. Reproducing that resolution here would be a
+    # second implementation of it, and a smoke test that passes against a copy of the real paths is
+    # not a smoke test.
+    $Result = & $Module {
+        param($TimeoutSeconds)
+
+        if (-not (Install-WebView2)) {
+            return [pscustomobject]@{
+                Success = $false
+                Reason  = "The WebView2 runtime is not available and could not be installed."
+            }
+        }
+
+        Add-ReflectionAssembly -Object $Script:WebView2CorePath
+        Add-ReflectionAssembly -Object $Script:WebView2WinFormsPath
+        Add-ReflectionAssembly -Object "System.Drawing" -Type LoadWithPartialName
+        Add-ReflectionAssembly -Object "System.Windows.Forms" -Type LoadWithPartialName
+
+        $Outcome = [hashtable]::Synchronized(@{
+                Initialized = $false
+                Reason      = "The initialization event never fired."
+            })
+
+        $Form = New-Object System.Windows.Forms.Form
+        try {
+            $Form.Text = "OmadaWeb.PS canary browser host check"
+            $Form.Width = 800
+            $Form.Height = 600
+            # Off-screen and unlisted: nothing here is for a human to look at, and a window that steals
+            # focus on a shared machine is a nuisance.
+            $Form.ShowInTaskbar = $false
+            $Form.StartPosition = "Manual"
+            $Form.Location = New-Object System.Drawing.Point(-4000, -4000)
+
+            $WebView2 = New-Object Microsoft.Web.WebView2.WinForms.WebView2
+            $WebView2.CreationProperties = New-Object Microsoft.Web.WebView2.WinForms.CoreWebView2CreationProperties
+            $WebView2.CreationProperties.UserDataFolder = (New-Item -ItemType Directory -Force -Path (Join-Path ([System.IO.Path]::GetTempPath()) ("OmadaWebCanaryHostCheck_{0}" -f [guid]::NewGuid().ToString("N")))).FullName
+            $WebView2.Dock = "Fill"
+            $WebView2.Source = [System.Uri]::new("about:blank")
+
+            $WebView2.add_CoreWebView2InitializationCompleted({
+                    param($EventSender, $EventArgs)
+
+                    if ($EventArgs.IsSuccess) {
+                        $Outcome.Initialized = $true
+                        $Outcome.Reason = ""
+                    }
+                    else {
+                        $Outcome.Reason = "CoreWebView2 initialization failed: {0}" -f $EventArgs.InitializationException.Message
+                    }
+
+                    $EventSender.FindForm().Close()
+                })
+
+            $Form.Controls.Add($WebView2)
+
+            # A hard stop, so a runner that can create the window but never finishes initializing the
+            # runtime fails with this message instead of holding the job until the job timeout.
+            $Timer = New-Object System.Windows.Forms.Timer
+            $Timer.Interval = $TimeoutSeconds * 1000
+            $Timer.Add_Tick({
+                    $Timer.Stop()
+                    $Form.Close()
+                })
+            $Timer.Start()
+
+            $null = $Form.ShowDialog()
+            $Timer.Stop()
+            $Timer.Dispose()
+        }
+        finally {
+            $Form.Dispose()
+        }
+
+        return [pscustomobject]@{
+            Success = $Outcome.Initialized
+            Reason  = $Outcome.Reason
+        }
+    } $TimeoutSeconds
+
+    if ($Result.Success) {
+        "This machine can host a WebView2 window. A canary failure here is about the sign-in page, not the runner." | Write-Host -ForegroundColor Green
+        exit 0
+    }
+
+    "This machine cannot host a WebView2 window, so the canary cannot run on it. {0}" -f $Result.Reason | Write-Error -ErrorAction "Continue"
+    exit 1
+}
+catch {
+    "The browser host check failed: {0}" -f $_.Exception.Message | Write-Error -ErrorAction "Continue"
+    exit 1
+}

--- a/Tests/E2E/Test-CanaryBrowserHost.ps1
+++ b/Tests/E2E/Test-CanaryBrowserHost.ps1
@@ -84,6 +84,13 @@ try {
                 Reason      = "The initialization event never fired."
             })
 
+        # A profile per run, because a shared one would let a previous run's state decide this one's
+        # answer. Held in a variable so the finally below can delete it: on a GitHub-hosted runner the
+        # VM is discarded anyway, but this is also run on self-hosted runners - which is exactly where
+        # the docs recommend it, for a fixed egress address - and by developers on their own machines.
+        # A daily job leaving a browser profile behind each time is a slow disk leak on both.
+        $UserDataFolder = (New-Item -ItemType Directory -Force -Path (Join-Path ([System.IO.Path]::GetTempPath()) ("OmadaWebCanaryHostCheck_{0}" -f [guid]::NewGuid().ToString("N")))).FullName
+
         $Form = New-Object System.Windows.Forms.Form
         try {
             $Form.Text = "OmadaWeb.PS canary browser host check"
@@ -97,7 +104,7 @@ try {
 
             $WebView2 = New-Object Microsoft.Web.WebView2.WinForms.WebView2
             $WebView2.CreationProperties = New-Object Microsoft.Web.WebView2.WinForms.CoreWebView2CreationProperties
-            $WebView2.CreationProperties.UserDataFolder = (New-Item -ItemType Directory -Force -Path (Join-Path ([System.IO.Path]::GetTempPath()) ("OmadaWebCanaryHostCheck_{0}" -f [guid]::NewGuid().ToString("N")))).FullName
+            $WebView2.CreationProperties.UserDataFolder = $UserDataFolder
             $WebView2.Dock = "Fill"
             $WebView2.Source = [System.Uri]::new("about:blank")
 
@@ -132,7 +139,34 @@ try {
             $Timer.Dispose()
         }
         finally {
+            # The control is disposed before the form, and before the delete below, because that is
+            # what tears down the CoreWebView2 and lets its browser process exit. Deleting first
+            # simply loses to the lock the process still holds on EBWebView\lockfile.
+            if ($null -ne $WebView2) {
+                $WebView2.Dispose()
+            }
+
             $Form.Dispose()
+
+            # Even after disposing, the browser process takes a moment to go away, so the delete is
+            # retried rather than attempted once. Best-effort throughout and deliberately not fatal:
+            # a profile left behind must not turn a machine that can host a browser into a reported
+            # failure, which is the one question this script exists to answer.
+            $Removed = $false
+            foreach ($Attempt in 1..10) {
+                try {
+                    Remove-Item -LiteralPath $UserDataFolder -Recurse -Force -ErrorAction Stop
+                    $Removed = $true
+                    break
+                }
+                catch {
+                    Start-Sleep -Milliseconds 500
+                }
+            }
+
+            if (-not $Removed) {
+                "Could not remove the temporary browser profile '{0}'. It is safe to delete by hand." -f $UserDataFolder | Write-Warning
+            }
         }
 
         return [pscustomobject]@{

--- a/Tests/Unit/CanaryRelyingParty.Tests.ps1
+++ b/Tests/Unit/CanaryRelyingParty.Tests.ps1
@@ -303,6 +303,24 @@ Describe 'Start-CanaryRelyingParty' -Tag 'Unit' {
         ($Response.Content | ConvertFrom-Json).canary | Should -Be "ok"
     }
 
+    It 'Reports the listener health without blocking on the still-open error stream' {
+        # Regression guard. Streams.Error is a PSDataCollection whose enumerator blocks while the
+        # invocation is open, waiting for the next record instead of ending - so reading it with
+        # "@($collection)" hangs for as long as the listener runs. In the canary that is a job that
+        # never finishes rather than a test that fails, which is far harder to diagnose.
+        $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $Reported = Get-CanaryRelyingPartyError -RelyingParty $Script:RelyingParty
+        $Stopwatch.Stop()
+
+        $Stopwatch.Elapsed.TotalSeconds | Should -BeLessThan 5
+        $Reported | Should -BeNullOrEmpty
+    }
+
+    It 'Returns nothing for a null relying party rather than throwing' {
+        # Called from an AfterAll that may run after Start-CanaryRelyingParty itself failed.
+        Get-CanaryRelyingPartyError -RelyingParty $null | Should -BeNullOrEmpty
+    }
+
     It 'Survives a client that abandons its request' {
         # The browser abandons requests routinely while it navigates; one of those must not take the
         # listener down and strand the sign-in window.

--- a/Tests/Unit/CanaryRelyingParty.Tests.ps1
+++ b/Tests/Unit/CanaryRelyingParty.Tests.ps1
@@ -1,0 +1,329 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ModulePath', Justification = 'Declared so the container -Data the build passes to every test file binds. Genuinely unused: these tests cover the canary scaffolding, which is not part of the module.')]
+param(
+    # Accepted and unused. The build hands every container the same -Data, and a test file whose
+    # param block rejects it fails to discover at all. Nothing here needs the module: the relying
+    # party is scaffolding for the canary, not part of OmadaWeb.PS.
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    . (Join-Path (Split-Path $PSScriptRoot) -ChildPath 'E2E\Start-CanaryRelyingParty.ps1')
+
+    # Every request below goes through HttpClient rather than Invoke-WebRequest. The two things
+    # these tests need most - reading a 302 without following it, and reading a Set-Cookie header -
+    # are spelled differently on Windows PowerShell 5.1 and PowerShell 7 (-MaximumRedirection 0
+    # throws on 5.1, and -SkipHttpErrorCheck needs 7.4+), and PR Validation runs both editions.
+    if ($PSVersionTable.PSEdition -eq "Desktop") {
+        Add-Type -AssemblyName System.Net.Http
+    }
+
+    function Invoke-CanaryRequest {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Uri,
+
+            [switch]$FollowRedirect
+        )
+
+        $Handler = [System.Net.Http.HttpClientHandler]::new()
+        $Handler.AllowAutoRedirect = [bool]$FollowRedirect
+        $Handler.UseCookies = $false
+        $Client = [System.Net.Http.HttpClient]::new($Handler)
+        try {
+            $Client.Timeout = [System.TimeSpan]::FromSeconds(15)
+            $Response = $Client.GetAsync($Uri).GetAwaiter().GetResult()
+            try {
+                $Location = $null
+                if ($null -ne $Response.Headers.Location) {
+                    $Location = $Response.Headers.Location.OriginalString
+                }
+
+                $SetCookie = @()
+                $CookieValues = $null
+                if ($Response.Headers.TryGetValues("Set-Cookie", [ref]$CookieValues)) {
+                    $SetCookie = @($CookieValues)
+                }
+
+                return [pscustomobject]@{
+                    StatusCode = [int]$Response.StatusCode
+                    Location   = $Location
+                    SetCookie  = $SetCookie
+                    Content    = $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+                }
+            }
+            finally {
+                $Response.Dispose()
+            }
+        }
+        finally {
+            $Client.Dispose()
+        }
+    }
+
+    function Get-CanaryQueryParameter {
+        # [System.Web.HttpUtility] lives in a different assembly on each edition, and asking for the
+        # wrong one is a load failure rather than a test failure. Splitting the query is cheaper than
+        # being right about that on both.
+        param(
+            [Parameter(Mandatory)]
+            [string]$Uri
+        )
+
+        $Query = ([System.Uri]::new($Uri)).Query.TrimStart("?")
+        $Parameter = @{}
+        foreach ($Pair in $Query.Split("&")) {
+            if ([string]::IsNullOrWhiteSpace($Pair)) {
+                continue
+            }
+
+            $Separator = $Pair.IndexOf("=")
+            if ($Separator -lt 0) {
+                $Parameter[[System.Uri]::UnescapeDataString($Pair)] = ""
+                continue
+            }
+
+            $Name = [System.Uri]::UnescapeDataString($Pair.Substring(0, $Separator))
+            $Parameter[$Name] = [System.Uri]::UnescapeDataString($Pair.Substring($Separator + 1))
+        }
+
+        return $Parameter
+    }
+}
+
+Describe 'New-CanaryPkcePair' -Tag 'Unit' {
+
+    It 'Returns a verifier and a challenge that are base64url, not base64' {
+        $Pair = New-CanaryPkcePair
+
+        $Pair.Verifier | Should -Not -Match '[+/=]'
+        $Pair.Challenge | Should -Not -Match '[+/=]'
+    }
+
+    It 'Returns a verifier inside the length RFC 7636 allows' {
+        $Pair = New-CanaryPkcePair
+
+        $Pair.Verifier.Length | Should -BeGreaterOrEqual 43
+        $Pair.Verifier.Length | Should -BeLessOrEqual 128
+    }
+
+    It 'Derives the challenge as base64url of SHA-256 over the ASCII verifier' {
+        $Pair = New-CanaryPkcePair
+
+        $Sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $Expected = [Convert]::ToBase64String($Sha256.ComputeHash([System.Text.Encoding]::ASCII.GetBytes($Pair.Verifier)))
+        }
+        finally {
+            $Sha256.Dispose()
+        }
+
+        $Pair.Challenge | Should -Be $Expected.Replace("+", "-").Replace("/", "_").TrimEnd("=")
+    }
+
+    It 'Returns a different verifier on every call' {
+        $First = New-CanaryPkcePair
+        $Second = New-CanaryPkcePair
+
+        $First.Verifier | Should -Not -Be $Second.Verifier
+    }
+}
+
+Describe 'New-CanaryAuthorizeUri' -Tag 'Unit' {
+
+    BeforeAll {
+        $Script:AuthorizeParameter = @{
+            TenantId      = "11111111-1111-1111-1111-111111111111"
+            ClientId      = "22222222-2222-2222-2222-222222222222"
+            RedirectUri   = "http://localhost:8400/canary"
+            CodeChallenge = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG"
+            State         = "0123456789abcdef"
+            LoginHint     = "canary@example.onmicrosoft.com"
+        }
+    }
+
+    It 'Targets the tenant-specific v2.0 authorize endpoint' {
+        $Uri = New-CanaryAuthorizeUri @Script:AuthorizeParameter
+
+        $Uri | Should -BeLike "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/oauth2/v2.0/authorize?*"
+    }
+
+    It 'Produces a URI the framework can parse' {
+        $Uri = New-CanaryAuthorizeUri @Script:AuthorizeParameter
+
+        { [System.Uri]::new($Uri) } | Should -Not -Throw
+    }
+
+    It 'Requests an authorization code delivered to the loopback redirect URI' {
+        $Query = Get-CanaryQueryParameter -Uri (New-CanaryAuthorizeUri @Script:AuthorizeParameter)
+
+        $Query["response_type"] | Should -Be "code"
+        $Query["response_mode"] | Should -Be "query"
+        $Query["redirect_uri"] | Should -Be "http://localhost:8400/canary"
+    }
+
+    It 'Forces the sign-in screens to be rendered' {
+        # Without prompt=login a warm profile is waved straight through, the screens under test are
+        # never drawn, and the canary passes by testing nothing.
+        $Query = Get-CanaryQueryParameter -Uri (New-CanaryAuthorizeUri @Script:AuthorizeParameter)
+
+        $Query["prompt"] | Should -Be "login"
+    }
+
+    It 'Sends the PKCE challenge with its method' {
+        $Query = Get-CanaryQueryParameter -Uri (New-CanaryAuthorizeUri @Script:AuthorizeParameter)
+
+        $Query["code_challenge"] | Should -Be $Script:AuthorizeParameter.CodeChallenge
+        $Query["code_challenge_method"] | Should -Be "S256"
+    }
+
+    It 'Escapes a login hint that contains characters with a meaning in a query string' {
+        $Parameter = $Script:AuthorizeParameter.Clone()
+        $Parameter.LoginHint = "canary+test@example.onmicrosoft.com"
+
+        $Uri = New-CanaryAuthorizeUri @Parameter
+
+        # A raw '+' in a query string decodes to a space, which would send Entra a different account.
+        $Uri | Should -Not -Match 'login_hint=canary\+test'
+        (Get-CanaryQueryParameter -Uri $Uri)["login_hint"] | Should -Be "canary+test@example.onmicrosoft.com"
+    }
+
+    It 'Omits the login hint when none was supplied' {
+        $Parameter = $Script:AuthorizeParameter.Clone()
+        $Parameter.LoginHint = ""
+
+        New-CanaryAuthorizeUri @Parameter | Should -Not -Match 'login_hint'
+    }
+
+    It 'Does not carry the code verifier' {
+        # Only the challenge may travel in the front channel; the verifier is the secret half.
+        $Pair = New-CanaryPkcePair
+        $Parameter = $Script:AuthorizeParameter.Clone()
+        $Parameter.CodeChallenge = $Pair.Challenge
+
+        New-CanaryAuthorizeUri @Parameter | Should -Not -Match ([regex]::Escape($Pair.Verifier))
+    }
+}
+
+Describe 'New-CanarySetCookieHeader' -Tag 'Unit' {
+
+    It 'Names the cookie Get-WebView2Cookie waits for' {
+        New-CanarySetCookieHeader -Name "oisauthtoken" -Value "abc" | Should -BeLike "oisauthtoken=abc;*"
+    }
+
+    It 'Omits Domain so the cookie is host-only' {
+        # A Domain of 'localhost' is rejected by parts of the cookie stack. Host-only still satisfies
+        # the suffix match Get-WebView2Cookie applies against the BaseUrl host.
+        New-CanarySetCookieHeader -Name "oisauthtoken" -Value "abc" | Should -Not -Match 'Domain='
+    }
+
+    It 'Omits Secure so a plain-HTTP loopback response is not dropped' {
+        New-CanarySetCookieHeader -Name "oisauthtoken" -Value "abc" | Should -Not -Match '(^|;\s*)Secure(\s*;|$)'
+    }
+
+    It 'Applies to the whole site' {
+        New-CanarySetCookieHeader -Name "oisauthtoken" -Value "abc" | Should -Match 'Path=/'
+    }
+}
+
+Describe 'Start-CanaryRelyingParty' -Tag 'Unit' {
+
+    BeforeAll {
+        $Script:Port = Get-Random -Minimum 21000 -Maximum 23000
+        $Script:RelyingParty = Start-CanaryRelyingParty -TenantId "11111111-1111-1111-1111-111111111111" -ClientId "22222222-2222-2222-2222-222222222222" -LoginHint "canary@example.onmicrosoft.com" -Port $Script:Port
+    }
+
+    AfterAll {
+        Stop-CanaryRelyingParty -RelyingParty $Script:RelyingParty
+    }
+
+    It 'Redirects an unauthenticated request to the Entra authorization endpoint' {
+        $Response = Invoke-CanaryRequest -Uri $Script:RelyingParty.BaseUrl
+
+        $Response.StatusCode | Should -Be 302
+        $Response.Location | Should -BeLike "https://login.microsoftonline.com/*"
+    }
+
+    It 'Keeps redirecting, because the environment probe spends the first one' {
+        # Test-EnvironmentSuspended fetches the BaseUrl with its own redirect-following client before
+        # the browser ever opens. A listener that redirected only once would have nothing left to
+        # send the browser.
+        foreach ($Attempt in 1..3) {
+            (Invoke-CanaryRequest -Uri $Script:RelyingParty.BaseUrl).StatusCode | Should -Be 302
+        }
+    }
+
+    It 'Sets the session cookie when Entra hands the browser back' {
+        $Uri = "{0}?code=fake-code&state={1}" -f $Script:RelyingParty.RedirectUri, $Script:RelyingParty.ExpectedState
+        $Response = Invoke-CanaryRequest -Uri $Uri
+
+        $Response.StatusCode | Should -Be 200
+        ($Response.SetCookie -join ";") | Should -Match 'oisauthtoken='
+        $Script:RelyingParty.CallbackError | Should -BeNullOrEmpty
+    }
+
+    It 'Counts the redirect so a canary cannot pass without a real round trip through Entra' {
+        $Script:RelyingParty.RedirectHitCount | Should -BeGreaterThan 0
+    }
+
+    It 'Serves a callback page that the Omada logon-error scraper reads as clean' {
+        # Get-OmadaLogonErrorScript sweeps the body for anything carrying an error severity whenever
+        # the path looks like a logon page, and reports a match as a refused sign-in.
+        $Uri = "{0}?code=fake-code&state={1}" -f $Script:RelyingParty.RedirectUri, $Script:RelyingParty.ExpectedState
+        $Response = Invoke-CanaryRequest -Uri $Uri
+
+        $Script:RelyingParty.RedirectPath | Should -Not -Match 'logon|login|signin|sign-in|error'
+        $Response.Content | Should -Not -Match 'class\s*=\s*"[^"]*error'
+        $Response.Content | Should -Not -Match 'role\s*=\s*"alert"'
+    }
+
+    It 'Reports a state mismatch rather than treating the callback as a success' {
+        $Uri = "{0}?code=fake-code&state=not-the-state-we-sent" -f $Script:RelyingParty.RedirectUri
+        $null = Invoke-CanaryRequest -Uri $Uri
+
+        $Script:RelyingParty.CallbackError | Should -Be "state_mismatch"
+        $Script:RelyingParty.CallbackError = $null
+    }
+
+    It 'Records the error code when Entra refuses the sign-in' {
+        $Uri = "{0}?error=access_denied&error_description=names-the-account&state={1}" -f $Script:RelyingParty.RedirectUri, $Script:RelyingParty.ExpectedState
+        $null = Invoke-CanaryRequest -Uri $Uri
+
+        $Script:RelyingParty.CallbackError | Should -Be "access_denied"
+    }
+
+    It 'Does not keep the error description, which can name the account and the tenant' {
+        # A failing canary reports this value into a public issue.
+        $Script:RelyingParty.CallbackError | Should -Not -Match 'names-the-account'
+    }
+
+    It 'Serves the resource the module requests once it holds the cookie' {
+        $Response = Invoke-CanaryRequest -Uri $Script:RelyingParty.ResourceUrl
+
+        $Response.StatusCode | Should -Be 200
+        ($Response.Content | ConvertFrom-Json).canary | Should -Be "ok"
+    }
+
+    It 'Survives a client that abandons its request' {
+        # The browser abandons requests routinely while it navigates; one of those must not take the
+        # listener down and strand the sign-in window.
+        $Client = [System.Net.Http.HttpClient]::new()
+        try {
+            $CancellationSource = [System.Threading.CancellationTokenSource]::new([System.TimeSpan]::FromMilliseconds(1))
+            try {
+                $null = $Client.GetAsync($Script:RelyingParty.ResourceUrl, $CancellationSource.Token).GetAwaiter().GetResult()
+            }
+            catch {
+                $null = $_
+            }
+            finally {
+                $CancellationSource.Dispose()
+            }
+        }
+        finally {
+            $Client.Dispose()
+        }
+
+        (Invoke-CanaryRequest -Uri $Script:RelyingParty.ResourceUrl).StatusCode | Should -Be 200
+        $Script:RelyingParty.ListenerError | Should -BeNullOrEmpty
+    }
+}

--- a/docs/entra-canary.md
+++ b/docs/entra-canary.md
@@ -1,0 +1,237 @@
+# The Entra sign-in canary
+
+A scheduled GitHub Actions run that signs in to Microsoft Entra ID once a day, in a real browser,
+with a real account, and fails when credential autofill stops recognizing Microsoft's sign-in
+screens.
+
+Delivers roadmap item E5 ([#33](https://github.com/Fortigi/OmadaWeb.PS/issues/33)).
+
+> **No tenant identifier, domain, account name or password appears anywhere in this repository.**
+> Every value the canary needs is a GitHub environment secret you set yourself. Everything below
+> uses placeholders.
+
+## Why it exists
+
+Credential autofill is one optional tier of sign-in: it engages only when `-Credential` is supplied,
+and it is the module's only dependency on Microsoft's sign-in DOM. Microsoft changes that DOM on its
+own schedule, and until now the detection mechanism was a user bug report.
+
+`Build/psakeBuild.ps1` has excluded the `E2E` tag from every build since long before this workflow
+existed, with a comment promising a separate scheduled pipeline. This is that pipeline.
+
+## What it covers, and what it deliberately does not
+
+| | |
+|---|---|
+| **Covers** | The username screen, the password screen and "Stay signed in?" — the screens a password sign-in actually renders — driven by the shipping code path: `Invoke-WebView2MicrosoftLogin` over what `Get-EntraSignInProbeScript` reads and `Resolve-EntraSignInScreen` judges. |
+| **Does not cover** | Multi-factor authentication. An interactive approval cannot be automated, so the canary account is exempt by policy. The MFA screens in `Resolve-EntraSignInScreen` are covered by unit tests against recorded page snapshots instead. |
+| **Does not cover** | Interactive sign-in in general. That is IdP-agnostic — a tenant on Ping, Okta or ADFS reaches none of this code — so there is nothing here for the canary to watch. |
+| **Does not cover** | Omada itself. The canary needs no Omada environment; see below. |
+
+**A red canary means "autofill needs a selector update", not "login is broken".** Since
+[#52](https://github.com/Fortigi/OmadaWeb.PS/pull/52) a selector break turns autofill off and hands
+the window to the user, so the blast radius is already capped. The canary is what makes that visible
+before a user hits it.
+
+## How it works without an Omada environment
+
+`Initialize-WebView2` navigates to the session's `BaseUrl` and then, on each timer tick, switches on
+the host the browser is currently on: the `BaseUrl` host means "look for the session cookie", and
+`login.microsoftonline.com` means "drive the sign-in". A local listener standing in for the Omada
+host is therefore enough to get the entire real code path:
+
+```
+Invoke-OmadaWebRequest -Uri http://localhost:8400/api/ping -AuthenticationType WebView2 -Credential <canary>
+        │
+        ▼
+  http://localhost:8400/            302  ──▶  login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize
+        │                                              │
+        │                                              │  ◀── the tier under test drives these screens
+        │                                              ▼
+  http://localhost:8400/canary  ◀── 302 ── Entra redirects back with a code
+        │
+        └─ sets oisauthtoken, returns 200 → Get-WebView2Cookie closes the window → request completes
+```
+
+The listener is `Tests/E2E/Start-CanaryRelyingParty.ps1`. The authorization code is never redeemed:
+the canary asserts that the sign-in screens were driven, not that a token was issued.
+
+Two details in that listener are load-bearing and should not be "tidied up":
+
+- **The redirect path is `/canary`.** `Get-OmadaLogonErrorScript` treats a path matching
+  `logon|login|signin|sign-in|error` as an Omada logon page and then sweeps the body for anything
+  carrying an error severity. A path like `/signin-callback` would have the module scraping this page
+  for a failure banner.
+- **The redirect is stateless.** `Test-EnvironmentSuspended` fetches the `BaseUrl` with its own
+  redirect-following client before the browser ever opens, so a listener that redirected only once
+  would have nothing left to send the browser.
+
+## Setting up the tenant
+
+Use a dedicated tenant you are willing to have a password-only account in. A free trial tenant with
+nothing else in it is the right shape.
+
+```powershell
+Install-Module Microsoft.Graph -Scope CurrentUser
+
+Connect-MgGraph -Scopes 'User.ReadWrite.All','Application.ReadWrite.All',
+                        'DelegatedPermissionGrant.ReadWrite.All','Directory.Read.All',
+                        'Policy.Read.All','Policy.ReadWrite.ConditionalAccess'
+
+# Review everything it would do first.
+./Build/New-EntraCanaryConfiguration.ps1 -WhatIf
+
+# Then provision, and push the secrets straight into GitHub so they are never displayed.
+./Build/New-EntraCanaryConfiguration.ps1 -GitHubRepository 'Fortigi/OmadaWeb.PS'
+```
+
+The script is idempotent — every object is looked up before it is created — so re-running it is how
+you rotate the password.
+
+### What it creates
+
+1. **A canary user** in the tenant's initial `onmicrosoft.com` domain, with a generated password, no
+   licence, no directory role and no group membership. Signing in is the only thing it can do. Its
+   password is set not to expire and not to require a change at first sign-in; both prompts are
+   screens the automation would not recognise.
+2. **A public-client app registration** whose only redirect URI is `http://localhost:8400/canary`,
+   requesting `openid`, `profile` and `User.Read` — **with tenant-wide admin consent granted**. The
+   consent is not optional: an unconsented application shows a consent screen, the automation does
+   not recognise it, and the canary would go red claiming Microsoft had changed something when in
+   fact the tenant was simply not finished being set up.
+3. **A Conditional Access policy** blocking the canary account from every application except the
+   canary one. This is the containment — the account is powerless elsewhere by policy, not merely by
+   holding no permissions.
+
+### The MFA exemption
+
+The canary cannot answer an MFA prompt, so the account has to be exempt, and the exemption is made
+explicit rather than left as an absence:
+
+- **Security defaults** are reported, and disabled only if you pass `-DisableSecurityDefaults`.
+  Turning them off changes the posture of the whole tenant, which is not something a provisioning
+  script should do as a side effect. While they are on, every sign-in is challenged for MFA
+  registration and the canary will fail.
+- **Every enabled Conditional Access policy that requires MFA** gets the canary account added to its
+  excluded users. Expressed as an exclusion on each policy rather than as a permissive policy of its
+  own, because a grant control is a requirement and never a waiver: a policy saying "this account may
+  sign in without MFA" would not override one saying "everyone must use MFA".
+
+In an empty tenant there are no such policies, and the script's summary says so rather than implying
+an exemption was applied.
+
+### Licensing
+
+Conditional Access needs Microsoft Entra ID P1; a P2 trial includes it. Without P1, pass
+`-SkipConditionalAccess`. The account is then contained only by holding no permissions, which is
+weaker — nothing stops it signing in to other applications — and the script says so in its summary.
+
+### IP restriction
+
+`-AllowedIpRange` takes a list of CIDR ranges, creates a named location from them, and adds a second
+policy blocking the account from anywhere else.
+
+It is a list you supply rather than a switch that fetches GitHub's ranges, because that would not
+work: GitHub-hosted runners publish several thousand CIDRs, which exceeds the 2000 ranges Entra
+allows in a single named location, and they change without notice. **IP restriction is therefore
+worth having on a self-hosted or fixed-egress runner and is impractical on a GitHub-hosted one.** On
+GitHub-hosted runners the containment policy is what limits the account instead.
+
+## The GitHub side
+
+The workflow reads its secrets from an **environment** named `entra-canary`, not from repository
+secrets, so no pull-request workflow can reach them.
+
+| Secret | Contains |
+|---|---|
+| `CANARY_TENANT_ID` | Directory (tenant) ID |
+| `CANARY_CLIENT_ID` | Application (client) ID of the canary app registration |
+| `CANARY_USERNAME` | The canary account's user principal name |
+| `CANARY_PASSWORD` | The canary account's password |
+
+`New-EntraCanaryConfiguration.ps1 -GitHubRepository <owner/repo>` writes all four through
+`gh secret set` on standard input, so they never appear on a command line or on screen.
+
+If the environment is empty the workflow **skips** with a notice rather than passing quietly, so a
+canary that has silently stopped running is visible.
+
+### The browser host check
+
+Before the sign-in, the job runs `Tests/E2E/Test-CanaryBrowserHost.ps1`, which opens a WebView2
+window on `about:blank` and closes it. It knows nothing about Entra ID or credentials, and that is
+the point: without it, a runner that cannot open a browser fails every canary assertion at once and
+the diagnostic reads "the sign-in page was not recognised" — true, and pointing at exactly the wrong
+thing.
+
+It fails the job on its own and deliberately **does not** file an issue, because nothing about the
+sign-in page has changed and an alert saying otherwise would be a lie.
+
+Run it on its own against a new runner image with the **Run workflow** button and the
+`browser_host_check_only` input, which skips the sign-in entirely and so needs no tenant at all. It
+also runs standalone:
+
+```powershell
+./Build/build.ps1 -Task Build -BuildVersion '0.0.0'
+./Tests/E2E/Test-CanaryBrowserHost.ps1
+```
+
+### Flake policy
+
+Microsoft's sign-in service has transient bad minutes, and a canary that alerts on one of them gets
+muted by its audience — the only failure mode worse than having no canary. So the job runs the test,
+and on failure waits 120 seconds and runs it **once** more. The job fails only if both attempts fail.
+A first attempt that the retry cleared is still reported as a warning annotation, so flakes stay
+visible.
+
+### Notification
+
+Scheduled-workflow failure mail goes to whoever last touched the file and is easy to miss. Instead, a
+double failure opens an issue titled **"Entra sign-in canary is failing"**, labelled `canary`,
+carrying the diagnostic and a link to the run; a later green run comments on it and closes it. It
+uses the built-in `GITHUB_TOKEN`, so there is no extra secret.
+
+The alert step is gated on the canary having reached a verdict, not merely on the job having failed —
+a checkout or build failure must not file an issue claiming Microsoft changed its sign-in page.
+
+Secret values are masked with `::add-mask::` before anything else runs, and the issue body is passed
+through a second literal replacement of all four values, because that text is about to become public.
+
+## When the canary goes red
+
+1. **Read the diagnostic in the issue.** It is what `Switch-ToManualLogin` emitted, and it names the
+   state, the elements that were expected but absent, the ones that were present, and the page path.
+2. **Decide which failure it is.** The canary asserts several things separately, on purpose:
+   - *"Still recognizes every Microsoft sign-in screen it was shown"* failed → a selector broke. This
+     is the one the canary exists for.
+   - *"Was not refused by Entra ID"* failed → tenant configuration, not Microsoft. An OAuth error code
+     is reported: a disabled account, an expired password, a Conditional Access block, or consent
+     that was revoked.
+   - *"Actually travelled through Entra and back"* failed → the browser never reached Entra. Look at
+     the runner and the listener, not at the selector table.
+   - The **browser host check** failed instead, and no issue was filed → the runner could not open a
+     window at all. Nothing about the sign-in page is implicated.
+3. **Fix a selector break** by updating `$Script:EntraSignInElementId` in
+   `OmadaWeb.PS/OmadaWeb.PS.psm1`. That table is read both by the script that reads the page and by
+   the rules that judge it, so it is a one-line change — see
+   [#32](https://github.com/Fortigi/OmadaWeb.PS/issues/32) and
+   [#30](https://github.com/Fortigi/OmadaWeb.PS/issues/30).
+4. **Re-run the workflow** from the Actions tab. A green run closes the issue by itself.
+
+## Running it locally
+
+```powershell
+$env:OMADAWEBPS_CANARY_TENANT_ID = '<tenant id>'
+$env:OMADAWEBPS_CANARY_CLIENT_ID = '<application id>'
+$env:OMADAWEBPS_CANARY_USERNAME  = '<canary upn>'
+$env:OMADAWEBPS_CANARY_PASSWORD  = '<password>'
+
+Invoke-Pester -Path ./Tests/E2E -TagFilter E2E -Output Detailed
+```
+
+Without those variables the tests report **skipped**, which is also what keeps them out of a normal
+build. The build additionally excludes the `E2E` tag outright, so `./Build/build.ps1` never opens a
+browser.
+
+To prove the canary can actually detect a break, change one id in `$Script:EntraSignInElementId` to
+something that does not exist and run it again: it should fail on the first assertion and name that
+id in the diagnostic.

--- a/docs/entra-canary.md
+++ b/docs/entra-canary.md
@@ -201,8 +201,14 @@ through a second literal replacement of all four values, because that text is ab
 1. **Read the diagnostic in the issue.** It is what `Switch-ToManualLogin` emitted, and it names the
    state, the elements that were expected but absent, the ones that were present, and the page path.
 2. **Decide which failure it is.** The canary asserts several things separately, on purpose:
-   - *"Still recognizes every Microsoft sign-in screen it was shown"* failed → a selector broke. This
-     is the one the canary exists for.
+   - *"Signed in with the credential, without falling back to manual entry"* failed → a selector
+     broke. This is the one the canary exists for. Note that it rests on whether the sign-in actually
+     completed rather than on catching the warning: nobody is at this browser, so if autofill stops
+     filling fields the sign-in simply never finishes. The diagnostic enriches that verdict; it does
+     not carry it.
+   - *"Did not report a selector it no longer recognizes"* failed on its own → the sign-in completed
+     but the module still reported a page it did not recognise. Worth reading: something changed that
+     the automation recovered from.
    - *"Was not refused by Entra ID"* failed → tenant configuration, not Microsoft. An OAuth error code
      is reported: a disabled account, an expired password, a Conditional Access block, or consent
      that was revoked.


### PR DESCRIPTION
Closes #33

## What was missing

`Build/psakeBuild.ps1` has excluded the `E2E` tag from every build with the comment *"run on a separate scheduled pipeline instead of every build"*. **That pipeline did not exist, and neither did a single `E2E`-tagged test** — `grep -rn "E2E"` across `main` returns only those two lines in the build script. The comment overstated the coverage.

Meanwhile credential autofill depends on Microsoft's sign-in DOM, which changes on Microsoft's schedule, and the detection mechanism was a user bug report.

## What this adds

| | |
|---|---|
| `.github/workflows/entra-canary.yml` | Daily run on `windows-latest`, retry-once flake policy, issue-based alerting |
| `Tests/E2E/EntraSignInCanary.Tests.ps1` | The `E2E`-tagged canary. Skips when unconfigured |
| `Tests/E2E/Start-CanaryRelyingParty.ps1` | Loopback stand-in for the Omada host |
| `Tests/E2E/Test-CanaryBrowserHost.ps1` | "Can this runner open a browser at all?", separate on purpose |
| `Tests/Unit/CanaryRelyingParty.Tests.ps1` | 28 unit tests over the parts that need no browser |
| `Build/New-EntraCanaryConfiguration.ps1` | Idempotent Microsoft Graph provisioning of the tenant |
| `docs/entra-canary.md` | The runbook |
| `Build/psakeBuild.ps1` | The exclusion comment now names a workflow that exists |
| `README.md` | One paragraph: you should not normally be the one to find out |

## How it reaches a real Entra sign-in with no Omada environment

`Initialize-WebView2` switches per timer tick on the host the browser is on — the `BaseUrl` host means "look for the session cookie", `login.microsoftonline.com` means "drive the sign-in". So a loopback listener standing in for the Omada host yields the entire real code path:

```
Invoke-OmadaWebRequest -Uri http://localhost:8400/api/ping -AuthenticationType WebView2 -Credential <canary>
   → http://localhost:8400/  302 →  login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize
                                       ↓  the tier under test drives username / password / KMSI
   → http://localhost:8400/canary  ← 302  sets oisauthtoken → window closes → request completes
```

It drives `Invoke-OmadaWebRequest`, not a harness of its own. A canary built on a copy of the driver would go green while the shipping path was broken.

## Decisions worth reviewing

- **Entra-only target, not a full Omada round trip.** The canary's subject is the Entra autofill tier, which is the only Microsoft-DOM dependency. Including Omada would need an always-on instance and would make a red canary mean "something, somewhere" instead of "a selector broke".
- **The authorization code is never redeemed.** What is under test is that the screens were driven, not that a token was issued. Redeeming one would test Entra's token endpoint, which is not what breaks.
- **The alert is a GitHub issue, not failure mail.** Default scheduled-failure mail goes to whoever last touched the file and is easy to miss. The issue carries the diagnostic and closes itself on the next green run.
- **The browser host check is a separate step that files nothing.** Without it, a runner that cannot open a window fails every assertion at once and the diagnostic reads "the sign-in page was not recognised" — true, and pointing at exactly the wrong thing.
- **MFA is out of scope by design.** An interactive approval cannot be automated, so the canary account is exempt by an explicit Conditional Access exclusion. The MFA screens stay covered by unit tests over recorded snapshots.
- **`-AllowedIpRange` takes a CIDR list rather than fetching GitHub's ranges.** The issue asked for IP restriction; GitHub-hosted runners publish several thousand CIDRs against Entra's 2000-per-named-location limit, and they change without notice. It is offered and documented as practical for self-hosted or fixed-egress runners, with the containment policy doing the work on GitHub-hosted ones. **This is a deliberate deviation from the issue's wording** and is the main thing worth disagreeing with.
- **The MFA exemption edits existing policies.** `Add-CanaryMfaExemption` sends the *whole* users condition back, because a Conditional Access PATCH replaces each condition object wholesale — sending only `excludeUsers` would silently empty `includeUsers` and turn a tenant-wide MFA requirement into a policy applying to nobody. Worth a second pair of eyes.

## Secrecy

No tenant identifier, domain, object id, application id, account name or password appears anywhere in this repository. The only GUIDs added are Microsoft Graph's well-known app id and its three published permission ids, plus `1111…`/`2222…` placeholders in tests. Values live in a GitHub **environment** (`entra-canary`) so no pull-request workflow can reach them, are masked with `::add-mask::` before anything else runs, and the issue body gets a second literal replacement of all four — because that text becomes public and the tenant id and account name arrive as ordinary strings in places GitHub does not track.

## Acceptance criteria

- [x] Dedicated canary account provisioned in a dev tenant, scoped to the minimum permissions, with a documented conditional-access exemption — `Build/New-EntraCanaryConfiguration.ps1`
- [x] Scheduled workflow on `windows-latest` runs the tagged login E2E tests daily — `.github/workflows/entra-canary.yml`
- [x] Credentials held as repository/environment secrets; no secret reaches logs or artefacts
- [x] Failure notifies the maintainer — issue opened, updated and closed automatically
- [x] Failure output identifies which state/selector broke — reuses the `Switch-ToManualLogin` diagnostic from #52
- [x] Flake policy defined — one automatic re-run after 120 s before alerting
- [x] The `psakeBuild.ps1` exclusion comment is updated to point at the workflow that now exists

**Not yet provable, and not ticked:** that the workflow goes green end-to-end. That needs the tenant provisioned and the four secrets set, which is the maintainer's action. See below.

## Verification

```
./Build/build.ps1 -Task TestBuildOnly -BuildVersion '0.0.0'
```

| | Total | Failed |
|---|---|---|
| `origin/main` (65c5e33), measured | 695 | 26 |
| this branch, same base | 721 | 26 |
| this branch, rebased onto `b189498` | 758 | 26 |

The failure set never moves: the same two integration files, with the same 14/12 split, which are the pre-existing WebView2-dependent failures. The baseline was measured by building `origin/main` in a throwaway worktree, not assumed. 28 new passing unit tests, no new failure.

Also confirmed locally:

- `Invoke-Pester ./Tests/E2E` with no canary variables → **6 skipped, 0 failed**.
- The build's `ExcludeTag 'E2E'` filter → **6 NotRun**, so a normal build never opens a browser.
- `Test-CanaryBrowserHost.ps1` → exit 0 on a real desktop.
- Reproduced the `PSDataCollection` hang found while fixing a review comment, then confirmed the fix: `Get-CanaryRelyingPartyError` now returns promptly against a running listener, with a unit test asserting it.`n- Temporary WebView2 profiles: 0 before, 0 after a run of `Test-CanaryBrowserHost.ps1`.`n- Fed `Resolve-EntraSignInScreen` a snapshot with every id renamed, the diagnostic the canary would publish is:

```text
Automated Microsoft sign-in could not continue - handing control back to you.
  State            : Unknown
  Missing elements : i0116, idSIButton9
  Page URL         : https://login.microsoftonline.com/common/oauth2/v2.0/authorize
  Reason           : The page carries none of the elements this module recognizes.
```

It names the broken selectors and withholds the query string, which carries `client_id`/`state`/`nonce`.

## What is needed to finish

PR Validation runs `main`'s workflows, so it will not exercise this new workflow file. To prove it end to end:

1. `./Build/New-EntraCanaryConfiguration.ps1 -WhatIf`, then without `-WhatIf`, against the dev tenant.
2. Run the workflow with **`browser_host_check_only`** ticked — validates that a GitHub-hosted runner can host a WebView2 window, without involving the tenant. This is the one assumption I could not verify from here.
3. Run it normally.

Until then the canary is wired up and inert: with no secrets it skips with a notice rather than passing quietly.
