### PR TITLE
Name the Entra codes that ask a user to pick an account, and stop blaming the sign-in page

### DIFF
--- a/OmadaWeb.PS/Private/Get-EntraErrorVerdict.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraErrorVerdict.ps1
@@ -26,15 +26,18 @@ function Get-EntraErrorVerdict {
 
         An error code this function does not recognize is answered with Manual, not with silence:
         the list below is not, and cannot be, exhaustive, so anything unknown fails safe by handing
-        the sign-in back to the user with the code named in the diagnostic.
+        the sign-in back to the user with the code named in the diagnostic. IsRecognized says which
+        of the two happened, because the two deserve different words: a code that is in the list
+        below has a meaning worth stating, while one that is not is worth a bug report. Nothing but
+        the caller's wording depends on it - the action is Manual either way.
 
     .PARAMETER ErrorCode
         The value of iErrorCode, or sErrorCode, as read from the page. Accepts a number, the same
         number as a string, or a string such as 'AADSTS50126' - only the digits are used.
 
     .OUTPUTS
-        PSCustomObject with the members IsError, Code, Numeric, Action, IsTerminal and Reason.
-        Action is one of 'None', 'Stop' or 'Manual'.
+        PSCustomObject with the members IsError, Code, Numeric, Action, IsTerminal, IsRecognized
+        and Reason. Action is one of 'None', 'Stop' or 'Manual'.
     #>
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSCustomObject])]
@@ -46,12 +49,13 @@ function Get-EntraErrorVerdict {
     )
 
     $Verdict = [pscustomobject]@{
-        IsError    = $false
-        Code       = $null
-        Numeric    = 0
-        Action     = "None"
-        IsTerminal = $false
-        Reason     = $null
+        IsError      = $false
+        Code         = $null
+        Numeric      = 0
+        Action       = "None"
+        IsTerminal   = $false
+        IsRecognized = $false
+        Reason       = $null
     }
 
     if ([string]::IsNullOrWhiteSpace($ErrorCode)) {
@@ -96,17 +100,32 @@ function Get-EntraErrorVerdict {
         # authentication is required, or has to be enrolled in, before this account can continue.
         50076 = "Entra ID requires multi-factor authentication for this sign-in."
         50079 = "This account has to enroll in multi-factor authentication before it can sign in."
+
+        # Issue #76. The 1600x family is not a failure of the credential at all: it is Entra ID
+        # saying that it cannot settle on an account by itself. Silent single sign-on hits it
+        # whenever the browser holds more than one identity, or holds one that the target tenant
+        # does not know, and the answer to every one of them is the same - the person at the
+        # keyboard picks an account in the window that is already open. They are listed here rather
+        # than left to the catch-all below because a documented condition that this module can name
+        # should never be reported as one it has never heard of.
+        16000  = "Entra ID cannot continue this sign-in without a choice being made: either more than one account is signed in and none of them can be picked automatically, or the account it picked cannot be used for this application. Please choose the account to sign in with in the browser window that is open."
+        16001  = "The account this sign-in selected is not one Entra ID accepts for it. Please choose another account in the browser window that is open."
+        16002  = "Entra ID could not match this sign-in to any of the sessions the browser already holds. Please choose the account to sign in with in the browser window that is open."
+        160021 = "Entra ID found no signed-in session for the account this sign-in asked for. Please sign in with that account in the browser window that is open."
+        16003  = "The account that is signed in is not known in the tenant this application belongs to, so single sign-on cannot be used for it. Please sign in with an account of that tenant in the browser window that is open."
     }
 
     if ($TerminalReason.ContainsKey([int]$Numeric)) {
         $Verdict.Action = "Stop"
         $Verdict.IsTerminal = $true
+        $Verdict.IsRecognized = $true
         $Verdict.Reason = $TerminalReason[[int]$Numeric]
         return $Verdict
     }
 
     if ($ManualReason.ContainsKey([int]$Numeric)) {
         $Verdict.Action = "Manual"
+        $Verdict.IsRecognized = $true
         $Verdict.Reason = $ManualReason[[int]$Numeric]
         return $Verdict
     }

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -316,14 +316,25 @@ $(Get-EntraElementVisibilityScript)
                     "Manual" {
                         # Entra ID named its own error, and it is one only the person at the keyboard
                         # can resolve - registering security information, completing an extra
-                        # verification step. Waiting out the stall timeout first would add a silent
-                        # minute to a message that is already known, so hand over now.
+                        # verification step, picking which account to use. Waiting out the stall
+                        # timeout first would add a silent minute to a message that is already known,
+                        # so hand over now.
                         $Reason = $Decision.Reason
                         if (-not [string]::IsNullOrWhiteSpace($Decision.Code)) {
                             $Reason = "{0}: {1}" -f $Decision.Code, $Reason
                         }
 
-                        Switch-ToManualLogin -State ("Deciding/{0}" -f $Decision.Screen) -FoundElementId $Present -Url $Script:WebView2.Source.AbsoluteUri -Reason $Reason | Out-Null
+                        # No selector failed here - the page was read, and it said what was wrong -
+                        # so no missing element is named. Whether the handover asks for a bug report
+                        # follows from the code, not from the screen: a code with an entry in the
+                        # verdict table has already been explained, while one without it is exactly
+                        # what the issue tracker is for (issue #76).
+                        $Cause = "UnrecognizedCode"
+                        if ($Decision.IsRecognized) {
+                            $Cause = "RecognizedCondition"
+                        }
+
+                        Switch-ToManualLogin -State ("Deciding/{0}" -f $Decision.Screen) -FoundElementId $Present -Url $Script:WebView2.Source.AbsoluteUri -Reason $Reason -Cause $Cause | Out-Null
                         return $false
                     }
 

--- a/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
+++ b/OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1
@@ -72,7 +72,9 @@ function Resolve-EntraSignInScreen {
 
     .OUTPUTS
         PSCustomObject with the members Screen, Action, ElementId, SubmitId, Index, Value,
-        ValueSource, Code, Reason and IsTerminal.
+        ValueSource, Code, Reason, IsTerminal and IsRecognized. IsRecognized is the verdict's own -
+        it says whether the code the page reported is one this module has an entry for, which is
+        what decides whether the handover asks the user for a bug report.
     #>
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSCustomObject])]
@@ -97,16 +99,17 @@ function Resolve-EntraSignInScreen {
     $Id = $Script:EntraSignInElementId
 
     $Decision = [pscustomobject]@{
-        Screen      = "Unknown"
-        Action      = "Wait"
-        ElementId   = $null
-        SubmitId    = $null
-        Index       = -1
-        Value       = $null
-        ValueSource = $null
-        Code        = $null
-        Reason      = $null
-        IsTerminal  = $false
+        Screen       = "Unknown"
+        Action       = "Wait"
+        ElementId    = $null
+        SubmitId     = $null
+        Index        = -1
+        Value        = $null
+        ValueSource  = $null
+        Code         = $null
+        Reason       = $null
+        IsTerminal   = $false
+        IsRecognized = $false
     }
 
     if ($null -eq $PageState) {
@@ -148,6 +151,7 @@ function Resolve-EntraSignInScreen {
         $Decision.Code = $ErrorVerdict.Code
         $Decision.Reason = $ErrorVerdict.Reason
         $Decision.IsTerminal = $ErrorVerdict.IsTerminal
+        $Decision.IsRecognized = $ErrorVerdict.IsRecognized
 
         # The verdict's own answer is carried through rather than flattened into "wait and see".
         # Waiting is the right response to a page this module does not recognize, because it might

--- a/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
+++ b/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
@@ -15,6 +15,21 @@ function Switch-ToManualLogin {
         diagnostic naming the state, the selectors that were expected but absent, and the page the
         browser is on - the three things needed to fix the selector table afterwards.
 
+        Not every handover is a selector break, though, and saying so when it is not is worse than
+        saying nothing. -Cause names which of three things happened, and only the wording follows
+        from it - the switch itself is made the same way in all three cases:
+
+          - UnrecognizedScreen. The page matched no known sign-in step. This is the case the
+            function was written for: the markup is the suspect, the missing selectors are the
+            evidence, and a bug report is the fix.
+          - UnrecognizedCode. Entra ID named an error this module has no entry for. The page was
+            read perfectly well, so no selector is to blame and none is reported - but the code
+            itself is worth reporting, so the request to do so stays.
+          - RecognizedCondition. Entra ID named something this module knows and cannot answer on
+            the user's behalf, such as a request to pick an account. Nothing is broken, nothing is
+            missing, and asking for a bug report would send a user to the issue tracker for a
+            normal day at work (issue #76).
+
         Only the path of the page URL is reported. Sign-in URLs carry client_id, state and nonce
         query parameters, and this text is written to a stream that users routinely capture into
         support logs.
@@ -34,7 +49,10 @@ function Switch-ToManualLogin {
         [string]$Url,
 
         [AllowNull()]
-        [string]$Reason
+        [string]$Reason,
+
+        [ValidateSet("UnrecognizedScreen", "UnrecognizedCode", "RecognizedCondition")]
+        [string]$Cause = "UnrecognizedScreen"
     )
 
     if ($Script:ManualLoginFallbackActive) {
@@ -60,17 +78,25 @@ function Switch-ToManualLogin {
     }
 
     # Not every caller knows which selector is to blame - a script exception carries a reason but no
-    # element - so the default has to say "unknown", not something the reader would act on.
-    $MissingText = "unknown"
+    # element - so a handover that blames the markup has to say "unknown", not something the reader
+    # would act on. When the page reported its own error there is no selector to name at all, and
+    # printing "unknown" there invents a failure that did not happen: the line is left out instead.
     $NamedMissingElementId = @($MissingElementId | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $MissingText = $null
     if ($NamedMissingElementId.Count -gt 0) {
         $MissingText = $NamedMissingElementId -join ", "
+    }
+    elseif ($Cause -eq "UnrecognizedScreen") {
+        $MissingText = "unknown"
     }
 
     $Lines = [System.Collections.Generic.List[string]]::new()
     $Lines.Add("Automated Microsoft sign-in could not continue - handing control back to you.")
     $Lines.Add("  State            : {0}" -f $State)
-    $Lines.Add("  Missing elements : {0}" -f $MissingText)
+    if (-not [string]::IsNullOrWhiteSpace($MissingText)) {
+        $Lines.Add("  Missing elements : {0}" -f $MissingText)
+    }
+
     $NamedFoundElementId = @($FoundElementId | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
     if ($NamedFoundElementId.Count -gt 0) {
         $Lines.Add("  Elements present : {0}" -f ($NamedFoundElementId -join ", "))
@@ -81,7 +107,15 @@ function Switch-ToManualLogin {
         $Lines.Add("  Reason           : {0}" -f (Protect-LogMessage -Message $Reason))
     }
 
-    $Lines.Add("The sign-in page no longer matches what this module knows about it, which usually means Microsoft changed it. Please sign in yourself in the browser window that is open - only filling in your credentials automatically stopped working, signing in did not. Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues.")
+    if ($Cause -eq "RecognizedCondition") {
+        # Entra ID said what it wants and this module knows what that means. Claiming the page had
+        # changed would be false, and asking for a bug report would be asking a user to report a
+        # sign-in working as designed.
+        $Lines.Add("Entra ID asked for something that only you can do. Please sign in yourself in the browser window that is open - nothing about the page is broken, and there is nothing to report.")
+    }
+    else {
+        $Lines.Add("The sign-in page no longer matches what this module knows about it, which usually means Microsoft changed it. Please sign in yourself in the browser window that is open - only filling in your credentials automatically stopped working, signing in did not. Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues.")
+    }
 
     ($Lines -join [System.Environment]::NewLine) | Write-Warning
 

--- a/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
+++ b/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
@@ -23,8 +23,9 @@ function Switch-ToManualLogin {
             function was written for: the markup is the suspect, the missing selectors are the
             evidence, and a bug report is the fix.
           - UnrecognizedCode. Entra ID named an error this module has no entry for. The page was
-            read perfectly well, so no selector is to blame and none is reported - but the code
-            itself is worth reporting, so the request to do so stays.
+            read perfectly well, so no selector is to blame, none is reported, and the markup is
+            not accused of anything - but the code itself is worth reporting, so the request to do
+            so stays. That request is the whole reason this differs from RecognizedCondition.
           - RecognizedCondition. Entra ID named something this module knows and cannot answer on
             the user's behalf, such as a request to pick an account. Nothing is broken, nothing is
             missing, and asking for a bug report would send a user to the issue tracker for a
@@ -107,14 +108,24 @@ function Switch-ToManualLogin {
         $Lines.Add("  Reason           : {0}" -f (Protect-LogMessage -Message $Reason))
     }
 
-    if ($Cause -eq "RecognizedCondition") {
-        # Entra ID said what it wants and this module knows what that means. Claiming the page had
-        # changed would be false, and asking for a bug report would be asking a user to report a
-        # sign-in working as designed.
-        $Lines.Add("Entra ID asked for something that only you can do. Please sign in yourself in the browser window that is open - nothing about the page is broken, and there is nothing to report.")
-    }
-    else {
-        $Lines.Add("The sign-in page no longer matches what this module knows about it, which usually means Microsoft changed it. Please sign in yourself in the browser window that is open - only filling in your credentials automatically stopped working, signing in did not. Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues.")
+    switch ($Cause) {
+        "RecognizedCondition" {
+            # Entra ID said what it wants and this module knows what that means. Claiming the page
+            # had changed would be false, and asking for a bug report would be asking a user to
+            # report a sign-in working as designed.
+            $Lines.Add("Entra ID asked for something that only you can do. Please sign in yourself in the browser window that is open - nothing about the page is broken, and there is nothing to report.")
+        }
+
+        "UnrecognizedCode" {
+            # The page was read and understood; it is the code that is new. Blaming the markup would
+            # send a reader to the selector table, which is the one place the answer is not - but
+            # the code itself is worth reporting, because that is how it gets an entry.
+            $Lines.Add("Entra ID reported an error code this module has no entry for. Please sign in yourself in the browser window that is open - only filling in your credentials automatically stopped working, signing in did not. Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues.")
+        }
+
+        default {
+            $Lines.Add("The sign-in page no longer matches what this module knows about it, which usually means Microsoft changed it. Please sign in yourself in the browser window that is open - only filling in your credentials automatically stopped working, signing in did not. Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues.")
+        }
     }
 
     ($Lines -join [System.Environment]::NewLine) | Write-Warning

--- a/Tests/Unit/Get-EntraErrorVerdict.Tests.ps1
+++ b/Tests/Unit/Get-EntraErrorVerdict.Tests.ps1
@@ -79,8 +79,53 @@ Describe 'Get-EntraErrorVerdict' -Tag 'Unit' {
         }
     }
 
-    Context 'Codes this module has never seen' {
-        # Microsoft adds error codes, so the list above cannot be exhaustive. An unrecognized code
+    Context 'Account selection and session conditions' {
+        # Issue #76. The whole 1600x family says one thing: Entra ID cannot settle on an account by
+        # itself. None of them is a fault in this module and none of them is worth a bug report, so
+        # the verdict has to name them rather than let them fall into the catch-all below.
+        It 'Names <ErrorCode> instead of calling it unrecognized' -TestCases @(
+            @{ ErrorCode = '16000' }
+            @{ ErrorCode = '16001' }
+            @{ ErrorCode = '16002' }
+            @{ ErrorCode = '160021' }
+            @{ ErrorCode = '16003' }
+        ) {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ ErrorCode = $ErrorCode } {
+                $Verdict = Get-EntraErrorVerdict -ErrorCode $ErrorCode
+
+                $Verdict.IsError | Should -BeTrue
+                $Verdict.Action | Should -Be 'Manual'
+                $Verdict.IsTerminal | Should -BeFalse
+                $Verdict.IsRecognized | Should -BeTrue
+                $Verdict.Reason | Should -Not -BeNullOrEmpty
+                $Verdict.Reason | Should -Not -BeLike '*does not recognize*'
+            }
+        }
+
+        It 'Sends the user to the browser window that is already open' {
+            InModuleScope 'OmadaWeb.PS' {
+                (Get-EntraErrorVerdict -ErrorCode '16000').Reason | Should -BeLike '*browser window*'
+            }
+        }
+
+        It 'Reaches the same verdict from <Description>' -TestCases @(
+            @{ Description = 'the number itself'; ErrorCode = 16000 }
+            @{ Description = 'the number as a string'; ErrorCode = '16000' }
+            @{ Description = 'the AADSTS form'; ErrorCode = 'AADSTS16000' }
+        ) {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ ErrorCode = $ErrorCode } {
+                $Verdict = Get-EntraErrorVerdict -ErrorCode $ErrorCode
+
+                $Verdict.Numeric | Should -Be 16000
+                $Verdict.Code | Should -Be 'AADSTS16000'
+                $Verdict.Action | Should -Be 'Manual'
+                $Verdict.IsRecognized | Should -BeTrue
+                $Verdict.Reason | Should -Not -BeLike '*does not recognize*'
+            }
+        }
+    }
+
+    Context 'Codes this module has never seen' {        # Microsoft adds error codes, so the list above cannot be exhaustive. An unrecognized code
         # has to fail safe and name itself, not be treated as a healthy page.
         It 'Fails safe and names the code' {
             InModuleScope 'OmadaWeb.PS' {
@@ -90,6 +135,19 @@ Describe 'Get-EntraErrorVerdict' -Tag 'Unit' {
                 $Verdict.Action | Should -Be 'Manual'
                 $Verdict.IsTerminal | Should -BeFalse
                 $Verdict.Reason | Should -BeLike '*AADSTS90210*'
+            }
+        }
+
+        It 'Marks the code as one it does not know' {
+            InModuleScope 'OmadaWeb.PS' {
+                # The fail-safe is what keeps an unknown code from being guessed at, and the flag is
+                # what lets the handover still ask for a report. Weakening either would hide the
+                # next code Microsoft adds.
+                $Verdict = Get-EntraErrorVerdict -ErrorCode 'AADSTS99999'
+
+                $Verdict.Action | Should -Be 'Manual'
+                $Verdict.IsRecognized | Should -BeFalse
+                $Verdict.Reason | Should -BeLike '*does not recognize*'
             }
         }
     }

--- a/Tests/Unit/Get-EntraErrorVerdict.Tests.ps1
+++ b/Tests/Unit/Get-EntraErrorVerdict.Tests.ps1
@@ -125,7 +125,8 @@ Describe 'Get-EntraErrorVerdict' -Tag 'Unit' {
         }
     }
 
-    Context 'Codes this module has never seen' {        # Microsoft adds error codes, so the list above cannot be exhaustive. An unrecognized code
+    Context 'Codes this module has never seen' {
+        # Microsoft adds error codes, so the list above cannot be exhaustive. An unrecognized code
         # has to fail safe and name itself, not be treated as a healthy page.
         It 'Fails safe and names the code' {
             InModuleScope 'OmadaWeb.PS' {

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -105,6 +105,56 @@ Describe 'Switch-ToManualLogin' -Tag 'Unit' {
             $Warning | Should -Not -BeLike '*abcdef1234567890*'
         }
     }
+
+    Context 'What the handover says about why it happened' {
+        # Issue #76. A screen this module cannot read is worth a bug report; a condition Entra ID
+        # named itself is not. The two cases have to say different things, and the first one must
+        # not lose a word of what it says today.
+        It 'Blames the markup and asks for a report when the screen is unrecognized' {
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'ProcessingScenarios' -MissingElementId 'i0116' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                $Warning = $Warnings -join "`n"
+
+                $Warning | Should -BeLike '*no longer matches what this module knows about it*'
+                $Warning | Should -BeLike '*usually means Microsoft changed it*'
+                $Warning | Should -BeLike '*https://github.com/Fortigi/OmadaWeb.PS/issues*'
+            }
+        }
+
+        It 'Makes no claim about the page and asks for no report when the condition is recognized' {
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'Deciding/SignInError' -Cause 'RecognizedCondition' -Reason 'AADSTS16000: Entra ID could not decide which account to use.' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                $Warning = $Warnings -join "`n"
+
+                $Warning | Should -BeLike '*sign in yourself in the browser window*'
+                $Warning | Should -Not -BeLike '*Microsoft changed it*'
+                $Warning | Should -Not -BeLike '*github.com*'
+            }
+        }
+
+        It 'Leaves the missing element line out when no selector is to blame' {
+            InModuleScope 'OmadaWeb.PS' {
+                # The page was read and understood - nothing was missing. Printing 'unknown' here
+                # would invent a selector failure that never happened.
+                Switch-ToManualLogin -State 'Deciding/SignInError' -Cause 'RecognizedCondition' -Reason 'AADSTS16000: Entra ID could not decide which account to use.' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                ($Warnings -join "`n") | Should -Not -BeLike '*Missing elements*'
+            }
+        }
+
+        It 'Still asks for a report when the code itself is unknown' {
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'Deciding/SignInError' -Cause 'UnrecognizedCode' -Reason 'AADSTS99999: unknown' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                $Warning = $Warnings -join "`n"
+
+                $Warning | Should -BeLike '*https://github.com/Fortigi/OmadaWeb.PS/issues*'
+                $Warning | Should -Not -BeLike '*Missing elements*'
+            }
+        }
+    }
 }
 
 Describe 'Reset-LoginAutomationState' -Tag 'Unit' {
@@ -532,8 +582,45 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
         }
     }
 
-    It 'Resets the fallback when the browser leaves the Microsoft sign-in page' {
+    It 'Names an interaction-required code instead of blaming the sign-in page' {
         InModuleScope 'OmadaWeb.PS' {
+            # Issue #76. AADSTS16000 is a documented condition: Entra ID wants a person to pick an
+            # account. Handing over is right, but calling the code unrecognized, blaming the markup
+            # and asking for a bug report are all wrong.
+            $Script:LoginAutomationFallbackTimeout = 60
+            $Script:NextScriptResult = Script:New-SnapshotResult @{
+                ids        = @('idSIButton9', 'i0281')
+                visibleIds = @('idSIButton9', 'i0281')
+                errorCode  = '16000'
+            }
+
+            $Warning = Script:Invoke-LoginTick -Count 3
+
+            $Script:MicrosoftOnlineLogin | Should -BeFalse
+            $Warning | Should -BeLike '*AADSTS16000*'
+            $Warning | Should -Not -BeLike '*does not recognize*'
+            $Warning | Should -Not -BeLike '*Microsoft changed it*'
+            $Warning | Should -Not -BeLike '*github.com*'
+            $Warning | Should -Not -BeLike '*Missing elements*'
+        }
+    }
+
+    It 'Keeps asking for a report when the code on the page is one it has never seen' {
+        InModuleScope 'OmadaWeb.PS' {
+            # The fail-safe that made issue #76 visible in the first place. It stays.
+            $Script:LoginAutomationFallbackTimeout = 60
+            $Script:NextScriptResult = Script:New-SnapshotResult @{ errorCode = '99999' }
+
+            $Warning = Script:Invoke-LoginTick -Count 3
+
+            $Script:MicrosoftOnlineLogin | Should -BeFalse
+            $Warning | Should -BeLike '*AADSTS99999*'
+            $Warning | Should -BeLike '*https://github.com/Fortigi/OmadaWeb.PS/issues*'
+            $Warning | Should -Not -BeLike '*Missing elements : unknown*'
+        }
+    }
+
+    It 'Resets the fallback when the browser leaves the Microsoft sign-in page' {        InModuleScope 'OmadaWeb.PS' {
             $Script:ManualLoginFallbackActive = $true
             $Script:UnmatchedPageSince = [DateTime]::Now
             $Script:WebView2.Source = [System.Uri]::New('https://omada.contoso.com/home')

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -151,6 +151,7 @@ Describe 'Switch-ToManualLogin' -Tag 'Unit' {
                 $Warning = $Warnings -join "`n"
 
                 $Warning | Should -BeLike '*https://github.com/Fortigi/OmadaWeb.PS/issues*'
+                $Warning | Should -Not -BeLike '*Microsoft changed it*'
                 $Warning | Should -Not -BeLike '*Missing elements*'
             }
         }
@@ -616,11 +617,13 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
             $Script:MicrosoftOnlineLogin | Should -BeFalse
             $Warning | Should -BeLike '*AADSTS99999*'
             $Warning | Should -BeLike '*https://github.com/Fortigi/OmadaWeb.PS/issues*'
+            $Warning | Should -Not -BeLike '*Microsoft changed it*'
             $Warning | Should -Not -BeLike '*Missing elements : unknown*'
         }
     }
 
-    It 'Resets the fallback when the browser leaves the Microsoft sign-in page' {        InModuleScope 'OmadaWeb.PS' {
+    It 'Resets the fallback when the browser leaves the Microsoft sign-in page' {
+        InModuleScope 'OmadaWeb.PS' {
             $Script:ManualLoginFallbackActive = $true
             $Script:UnmatchedPageSince = [DateTime]::Now
             $Script:WebView2.Source = [System.Uri]::New('https://omada.contoso.com/home')


### PR DESCRIPTION
Closes #76

## What was wrong

1. **AADSTS16000 had no classification.** `OmadaWeb.PS/Private/Get-EntraErrorVerdict.ps1:82-99` mapped codes in `$TerminalReason` and `$ManualReason`; 16000 was in neither, so it reached the catch-all at `Get-EntraErrorVerdict.ps1:116-117` and was reported as an error *"which this module does not recognize"*. It is a documented code - `InteractionRequired` - and so are its neighbours 16001, 16002, 160021 and 16003.

2. **The handover asserted a wrong cause.** `OmadaWeb.PS/Private/Switch-ToManualLogin.ps1:84` appended, unconditionally, *"The sign-in page no longer matches what this module knows about it, which usually means Microsoft changed it ... Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues."* For a screen that matched nothing, that text is right. For a code the module could have named, it is three false statements and a request to file a bug for a normal condition.

3. **`Missing elements : unknown`.** The `"Manual"` branch at `OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1:326` called `Switch-ToManualLogin` without `-MissingElementId`, while the stall path at line 282 passes it - so the field printed the literal `unknown`.

## What changed

- **`OmadaWeb.PS/Private/Get-EntraErrorVerdict.ps1`** - the whole 1600x family is classified as Manual and non-terminal, each with a reason that names the real meaning and says what the person has to do in the window that is already open: 16000 (`InteractionRequired`), 16001 (`UserAccountSelectionInvalid`), 16002 and 160021 (`AppSessionSelectionInvalid`), 16003 (`SsoUserAccountNotFoundInResourceTenant`). The verdict gained an `IsRecognized` member so a caller can tell a classified code from the catch-all; nothing in the verdict's own action depends on it. Comment-based help updated.
- **`OmadaWeb.PS/Private/Switch-ToManualLogin.ps1`** - new `-Cause` parameter, `UnrecognizedScreen` (the default, today's behaviour verbatim) / `UnrecognizedCode` / `RecognizedCondition`. Only the closing paragraph and the `Missing elements` line follow from it.
- **`OmadaWeb.PS/Private/Resolve-EntraSignInScreen.ps1`** - the decision carries `IsRecognized` through from the verdict. Rule 1 is untouched.
- **`OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1`** - the `"Manual"` branch passes the cause (recognized code vs. unknown code) and deliberately names no missing element.
- **`Tests/Unit/Get-EntraErrorVerdict.Tests.ps1`, `Tests/Unit/Switch-ToManualLogin.Tests.ps1`** - 16 new tests, written before the fix and confirmed failing first.

The **Edge WebDriver engine needed no change**: `Get-DataFromWebDriver.ps1` never reads the page's error code and never calls `Get-EntraErrorVerdict`, so both of its handovers (`Get-DataFromWebDriver.ps1:181` stall, `:193` script exception) are genuine unrecognized-screen cases and keep the default cause and the original wording. Verified with `Select-String -Path OmadaWeb.PS\Private\*.ps1 -Pattern 'Switch-ToManualLogin|Get-EntraErrorVerdict'`.

## The two messages, as rendered

Recognized code:

```
Automated Microsoft sign-in could not continue - handing control back to you.
  State            : Deciding/SignInError
  Elements present : idSIButton9, i0281
  Page URL         : https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize
  Reason           : AADSTS16000: Entra ID cannot continue this sign-in without a choice being made: either more than one account is signed in and none of them can be picked automatically, or the account it picked cannot be used for this application. Please choose the account to sign in with in the browser window that is open.
Entra ID asked for something that only you can do. Please sign in yourself in the browser window that is open - nothing about the page is broken, and there is nothing to report.
```

Unrecognized screen (unchanged):

```
Automated Microsoft sign-in could not continue - handing control back to you.
  State            : Deciding/NoMatchingScreen
  Missing elements : i0116
  Page URL         : https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize
The sign-in page no longer matches what this module knows about it, which usually means Microsoft changed it. Please sign in yourself in the browser window that is open - only filling in your credentials automatically stopped working, signing in did not. Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues.
```

## Acceptance criteria

- [x] AADSTS16000 is named for what it is, autofill steps aside, and the reason is accurate - `Get-EntraErrorVerdict.Account selection and session conditions.Names 16000 instead of calling it unrecognized`
- [x] No suggestion that Microsoft changed the page and no request to open an issue, for a documented code - `Invoke-WebView2MicrosoftLogin selector fallback.Names an interaction-required code instead of blaming the sign-in page`
- [x] `Missing elements` is omitted rather than printed as `unknown` on that path - `Switch-ToManualLogin.What the handover says about why it happened.Leaves the missing element line out when no selector is to blame`
- [x] 16001 / 16002 / 160021 / 16003 classified with the same answer - `Names <ErrorCode> instead of calling it unrecognized`, five cases
- [x] Numeric, bare-digit and `AADSTS...` input forms reach the same verdict - `Reaches the same verdict from <Description>`, three cases
- [x] A genuinely unknown code still produces the unrecognized reason and the "please report" wording - `Codes this module has never seen.Marks the code as one it does not know` and `Invoke-WebView2MicrosoftLogin selector fallback.Keeps asking for a report when the code on the page is one it has never seen`
- [x] Existing terminal codes still stop - `Failures that a retry cannot turn into a success.Stops the sign-in on <ErrorCode>` (50126, 50053, 50055, 53003), unchanged and still green

## Decisions worth reviewing

- **Omit the field rather than populate it.** On this path nothing was missing: the page was read, and it reported its own error. Naming "expected but absent" selectors there would invent a selector failure that did not happen and send the next reader hunting for one. The field is therefore left out entirely when the handover was caused by a reported code, and it still reads `unknown` where it always did - a handover that does blame the markup but cannot name a selector, such as the WebDriver loop's exception path (`Get-DataFromWebDriver.ps1:193`), which the existing test `Says the missing selector is unknown when the caller cannot name one` still defends.
- **Three causes, not two.** An unknown *code* is neither an unrecognized screen nor a recognized condition: no selector is to blame, so the field is dropped and the markup is not accused of anything, but the code itself is worth a bug report, so the request to file one stays. It reads: "Entra ID reported an error code this module has no entry for. Please sign in yourself in the browser window that is open - only filling in your credentials automatically stopped working, signing in did not. Please report the details above at https://github.com/Fortigi/OmadaWeb.PS/issues." Only `UnrecognizedScreen` still says the page changed. (Raised by Copilot; the first version of this branch reused the unrecognized-screen paragraph here.)
- **Rule 1 in `Resolve-EntraSignInScreen` is deliberately not changed.** The issue raises redesigning it - letting a drivable screen keep being driven when the code is non-terminal - as a design question, and it stays a design question. Automation behaviour is byte-for-byte what it was; only the classification and the wording moved. The broader hardening of the "page no longer drivable" path belongs with #32.
- **`IsRecognized` is a new public-ish member** on the verdict and on the decision object. Both are private functions, so nothing outside the module sees them, but the comment-based help of both was updated because the documented output shape changed.

## Verification

- `Invoke-Pester -Path Tests/Unit -Output None -PassThru` on `origin/main` (baseline): **Passed 639, Failed 0, Skipped 10**.
- Same command on this branch: **Passed 655, Failed 0, Skipped 10** - 16 new tests, no regressions.
- The 14 new assertions that could fail before the fix were run against the unmodified module first and did fail, each for its own reason (missing `IsRecognized`, the "does not recognize" reason, and an unbound `-Cause` parameter).
- `Invoke-ScriptAnalyzer -Severity Warning,Error` on every touched file: no new findings. The four it reports (`PSAvoidUsingWriteHost`, `PSReviewUnusedParameter`, `PSAvoidUsingConvertToSecureStringWithPlainText`) are all pre-existing and on lines this branch did not touch.