### PR TITLE
Keep the update check working when the newest gallery package is a prerelease

### DIFF
--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -485,25 +485,13 @@ try {
     }
     else {
         $Script:UserAgent = $Script:UserAgent -f $($InstalledModule['Version'])
-        $GalleryVersion = Get-GalleryModuleVersion -ModuleName $ModuleName
-
-        if (-not $GalleryVersion) {
-        }
-        else {
-            if ([System.Version]$InstalledModule['Version'] -lt [System.Version]$GalleryVersion) {
-                "The installed version {0} of '{1}' is outdated. Latest version: {2}. Execute Update-Module {1} to update to the latest version!" -f ($($InstalledModule['Version'])), $ModuleName, $GalleryVersion | Write-Warning
-            }
-            elseif ([System.Version]$InstalledModule['Version'] -eq [System.Version]$GalleryVersion) {
-                "The installed version {0} of '{1}' is up-to-date." -f ($($InstalledModule['Version'])) , $ModuleName | Write-Verbose
-            }
-            else {
-                "The installed version {0} of '{1}' is newer than the gallery version {2}." -f ($($InstalledModule['Version'])), $ModuleName, $GalleryVersion | Write-Warning
-            }
-        }
+        Write-ModuleVersionStatus -ModuleName $ModuleName -InstalledModule $InstalledModule
     }
 
 }
-catch {}
+catch {
+    "The version check for module '{0}' could not be completed: {1}" -f $ModuleName, $_.Exception.Message | Write-Verbose
+}
 
 $Script:EdgeProfiles = Get-EdgeProfile
 

--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -477,8 +477,9 @@ try {
     $InstalledModule = Get-InstalledModuleInfo -ModuleName $ModuleName
     # Get-InstalledModuleInfo returns $null whenever the module was imported from a path instead of
     # installed - every build and every test run. Reading a member off that $null is an error under
-    # StrictMode, and the empty catch below swallowed it, so $Script:UserAgent kept its unformatted
-    # "OmadaWeb.PS/{0}" template and every request built from it was rejected as a malformed header.
+    # StrictMode, and the catch below - empty at the time - swallowed it, so $Script:UserAgent kept
+    # its unformatted "OmadaWeb.PS/{0}" template and every request built from it was rejected as a
+    # malformed header.
     if ($null -eq $InstalledModule -or -not $InstalledModule['RepositorySource'] -or $InstalledModule['RepositorySource'] -notlike "*powershellgallery.com*") {
         "Module '{0}' was not sourced from the PowerShell Gallery. Skipping version check." -f $ModuleName | Write-Verbose
         $Script:UserAgent = $Script:UserAgent -f "Development"

--- a/OmadaWeb.PS/Private/Compare-ModuleVersion.ps1
+++ b/OmadaWeb.PS/Private/Compare-ModuleVersion.ps1
@@ -1,0 +1,75 @@
+function Compare-ModuleVersion {
+    [CmdletBinding()]
+    param(
+        [string]$ReferenceVersion,
+        [string]$DifferenceVersion
+    )
+
+    # Returns -1, 0 or 1 the way a comparer does, and $null when either side cannot be parsed. The
+    # $null is the point: the caller that cannot compare has to say so on the verbose stream and
+    # move on, rather than throw the way the [System.Version] cast this replaces did.
+    $Reference = ConvertTo-ModuleVersionInfo -Version $ReferenceVersion
+    $Difference = ConvertTo-ModuleVersionInfo -Version $DifferenceVersion
+
+    if ($null -eq $Reference -or $null -eq $Difference) {
+        return $null
+    }
+
+    if ($Reference.Version -lt $Difference.Version) {
+        return -1
+    }
+
+    if ($Reference.Version -gt $Difference.Version) {
+        return 1
+    }
+
+    # Same numeric version, so SemVer precedence decides: a tagged version sorts below the untagged
+    # release of the same number. 2026.9.1-nightly74 is what comes before 2026.9.1, never after it.
+    if ($Reference.PrereleaseTag -eq $Difference.PrereleaseTag) {
+        return 0
+    }
+
+    if (-not $Reference.IsPrerelease) {
+        return 1
+    }
+
+    if (-not $Difference.IsPrerelease) {
+        return -1
+    }
+
+    # Two tags on the same version. Strict SemVer would compare "nightly9" and "nightly74" as text,
+    # because neither is a purely numeric identifier, and would then declare nightly9 the newer of
+    # the two. This module's tags are a word followed by a build counter, so text order is the wrong
+    # answer for every nightly user it would reach. When both tags share a prefix and differ only in
+    # a trailing run of digits, those digits are compared as numbers; anything else falls back to
+    # the ordinal comparison SemVer prescribes.
+    $TagPattern = "^(?<Prefix>.*?)(?<Number>\d+)$"
+    $ReferenceMatch = [regex]::Match($Reference.PrereleaseTag, $TagPattern)
+    $DifferenceMatch = [regex]::Match($Difference.PrereleaseTag, $TagPattern)
+
+    if ($ReferenceMatch.Success -and $DifferenceMatch.Success -and $ReferenceMatch.Groups["Prefix"].Value -eq $DifferenceMatch.Groups["Prefix"].Value) {
+        $ReferenceNumber = [System.Numerics.BigInteger]::Parse($ReferenceMatch.Groups["Number"].Value)
+        $DifferenceNumber = [System.Numerics.BigInteger]::Parse($DifferenceMatch.Groups["Number"].Value)
+
+        if ($ReferenceNumber -lt $DifferenceNumber) {
+            return -1
+        }
+
+        if ($ReferenceNumber -gt $DifferenceNumber) {
+            return 1
+        }
+
+        return 0
+    }
+
+    $OrdinalResult = [string]::CompareOrdinal($Reference.PrereleaseTag, $Difference.PrereleaseTag)
+    if ($OrdinalResult -lt 0) {
+        return -1
+    }
+
+    if ($OrdinalResult -gt 0) {
+        return 1
+    }
+
+    return 0
+}

--- a/OmadaWeb.PS/Private/ConvertTo-ModuleVersionInfo.ps1
+++ b/OmadaWeb.PS/Private/ConvertTo-ModuleVersionInfo.ps1
@@ -1,0 +1,49 @@
+function ConvertTo-ModuleVersionInfo {
+    [CmdletBinding()]
+    param(
+        [string]$Version
+    )
+
+    # The obvious type for this job would be [System.Management.Automation.SemanticVersion], and it
+    # is the wrong one: SemVer allows at most three numeric components, while this module ships four
+    # component builds such as 2026.7.9.9. SemanticVersion::TryParse rejects exactly the versions
+    # that are already installed on people's machines, so the parse is done by hand instead: split
+    # the string where SemVer says the prerelease tag begins, and hand the numeric part to
+    # [System.Version], which takes two to four components and behaves the same on Windows
+    # PowerShell 5.1 and PowerShell 7.
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        return $null
+    }
+
+    $RemainingVersion = $Version.Trim()
+
+    # Build metadata carries no precedence at all under SemVer, so it is removed before anything
+    # else and never influences a comparison.
+    $BuildMetadataIndex = $RemainingVersion.IndexOf("+")
+    if ($BuildMetadataIndex -ge 0) {
+        $RemainingVersion = $RemainingVersion.Substring(0, $BuildMetadataIndex)
+    }
+
+    $PrereleaseIndex = $RemainingVersion.IndexOf("-")
+    if ($PrereleaseIndex -ge 0) {
+        $NumericPart = $RemainingVersion.Substring(0, $PrereleaseIndex)
+        $PrereleaseTag = $RemainingVersion.Substring($PrereleaseIndex + 1)
+    }
+    else {
+        $NumericPart = $RemainingVersion
+        $PrereleaseTag = $null
+    }
+
+    $ParsedVersion = $null
+    if (-not [System.Version]::TryParse($NumericPart, [ref]$ParsedVersion)) {
+        "{0} - '{1}' is not a version this module can compare." -f $MyInvocation.MyCommand, $Version | Write-Verbose
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        Version       = $ParsedVersion
+        PrereleaseTag = $PrereleaseTag
+        IsPrerelease  = -not [string]::IsNullOrEmpty($PrereleaseTag)
+        Original      = $Version
+    }
+}

--- a/OmadaWeb.PS/Private/Get-GalleryModuleVersion.ps1
+++ b/OmadaWeb.PS/Private/Get-GalleryModuleVersion.ps1
@@ -1,7 +1,8 @@
-﻿function Get-GalleryModuleVersion {
+function Get-GalleryModuleVersion {
     [CmdletBinding()]
     param(
-        [string]$ModuleName
+        [string]$ModuleName,
+        [switch]$IncludePrerelease
     )
 
     try {
@@ -23,17 +24,37 @@
             $Parameters.Add("TimeoutSec", $TimeoutSec)
         }
         $Response = Invoke-RestMethod @Parameters
-        $Response = $Response | Select-Object *,@{Name='Published';Expression={($_.Properties.Published.'#text') }}
 
-        if ($null -ne $Response) {
-            $LatestVersion = $Response | Sort-Object Published -Descending | Select-Object -First 1
-            return $LatestVersion.Properties.version
-        }
-        else {
+        if ($null -eq $Response) {
             return $null
         }
+
+        # FindPackagesById() returns every package ever pushed for this id, prereleases included and
+        # in no particular order. Picking the entry with the newest Published date - what this used
+        # to do - answers the wrong question twice: a republished older package would win, and a
+        # nightly published after the last stable release would be handed to a stable installation.
+        # So the feed is reduced to the highest version of the requested channel, by comparing
+        # versions rather than dates.
+        $LatestVersion = $null
+        foreach ($Package in $Response) {
+            $VersionInfo = ConvertTo-ModuleVersionInfo -Version $Package.Properties.version
+            if ($null -eq $VersionInfo) {
+                continue
+            }
+
+            if ($VersionInfo.IsPrerelease -and -not $IncludePrerelease) {
+                continue
+            }
+
+            if ($null -eq $LatestVersion -or (Compare-ModuleVersion -ReferenceVersion $LatestVersion -DifferenceVersion $VersionInfo.Original) -lt 0) {
+                $LatestVersion = $VersionInfo.Original
+            }
+        }
+
+        return $LatestVersion
     }
     catch {
+        "{0} - Could not read the version of '{1}' from the PowerShell Gallery: {2}" -f $MyInvocation.MyCommand, $ModuleName, $_.Exception.Message | Write-Verbose
         return $null
     }
 }

--- a/OmadaWeb.PS/Private/Get-InstalledModuleInfo.ps1
+++ b/OmadaWeb.PS/Private/Get-InstalledModuleInfo.ps1
@@ -10,10 +10,36 @@
 
     $Module = Get-Module -ListAvailable -Name $ModuleName | ForEach-Object {$_ | Where-Object { (Split-Path $_.Path) -eq (Split-Path $ModuleStack.ScriptName) }} | Sort-Object Version -Descending | Select-Object -First 1
     if ($Module) {
+        # A prerelease install reports its numeric version in $Module.Version and keeps the tag that
+        # makes it a prerelease - "nightly74" - in the manifest's PSData. That is the only place the
+        # channel of the installation can be read from, and on a stable install the key is simply
+        # absent: PSData then holds nothing but Tags, ProjectUri, LicenseUri and
+        # ExternalModuleDependencies. Both levels are plain hashtables, so they are probed with
+        # Contains rather than by member access, which under Set-StrictMode -Version Latest would
+        # turn a stable installation into an error.
+        $PrereleaseTag = $null
+        $PrivateData = $Module.PrivateData
+        if ($PrivateData -is [System.Collections.IDictionary] -and $PrivateData.Contains("PSData")) {
+            $PsData = $PrivateData["PSData"]
+            if ($PsData -is [System.Collections.IDictionary] -and $PsData.Contains("Prerelease")) {
+                $PrereleaseTag = $PsData["Prerelease"]
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($PrereleaseTag)) {
+            $PrereleaseTag = $null
+            $FullVersion = "{0}" -f $Module.Version
+        }
+        else {
+            $FullVersion = "{0}-{1}" -f $Module.Version, $PrereleaseTag
+        }
+
         $ModuleInfo = @{
             Name             = $Module.Name
             Version          = $Module.Version
             RepositorySource = $Module.RepositorySourceLocation
+            Prerelease       = $PrereleaseTag
+            FullVersion      = $FullVersion
         }
         return $ModuleInfo
     }

--- a/OmadaWeb.PS/Private/Write-ModuleVersionStatus.ps1
+++ b/OmadaWeb.PS/Private/Write-ModuleVersionStatus.ps1
@@ -1,0 +1,55 @@
+function Write-ModuleVersionStatus {
+    [CmdletBinding()]
+    param(
+        [string]$ModuleName,
+        [System.Collections.IDictionary]$InstalledModule
+    )
+
+    # The update check is channel aware, and the two channels ask different questions. Someone on a
+    # stable release wants to know about the next stable release and nothing else - a nightly that
+    # happens to be the most recently published package is not an update they can act on, and
+    # telling them about it is noise. Someone who deliberately installed a nightly is comparing
+    # against nightlies as well, so for them a newer nightly counts, and so does a stable release
+    # that has since overtaken the nightly they are running.
+    $InstalledVersion = $null
+    if ($InstalledModule.Contains("FullVersion")) {
+        $InstalledVersion = $InstalledModule["FullVersion"]
+    }
+
+    if ([string]::IsNullOrWhiteSpace($InstalledVersion)) {
+        $InstalledVersion = "{0}" -f $InstalledModule["Version"]
+    }
+
+    $InstalledVersionInfo = ConvertTo-ModuleVersionInfo -Version $InstalledVersion
+    if ($null -eq $InstalledVersionInfo) {
+        "The installed version '{0}' of '{1}' could not be read as a version. Skipping the update check." -f $InstalledVersion, $ModuleName | Write-Verbose
+        return
+    }
+
+    $GalleryVersion = Get-GalleryModuleVersion -ModuleName $ModuleName -IncludePrerelease:$InstalledVersionInfo.IsPrerelease
+
+    if (-not $GalleryVersion) {
+        "No version of '{0}' could be read from the PowerShell Gallery. Skipping the update check." -f $ModuleName | Write-Verbose
+        return
+    }
+
+    # A comparison that cannot be made is reported rather than discarded. The block this replaced
+    # cast both sides to [System.Version] inside a try whose catch was empty, so a gallery version
+    # carrying a prerelease tag threw, took the rest of the check down with it, and left no trace
+    # beyond a record in $Error.
+    $Comparison = Compare-ModuleVersion -ReferenceVersion $InstalledVersion -DifferenceVersion $GalleryVersion
+    if ($null -eq $Comparison) {
+        "The installed version {0} of '{1}' could not be compared with the gallery version {2}. Skipping the update check." -f $InstalledVersion, $ModuleName, $GalleryVersion | Write-Verbose
+        return
+    }
+
+    if ($Comparison -lt 0) {
+        "The installed version {0} of '{1}' is outdated. Latest version: {2}. Execute Update-Module {1} to update to the latest version!" -f $InstalledVersion, $ModuleName, $GalleryVersion | Write-Warning
+    }
+    elseif ($Comparison -eq 0) {
+        "The installed version {0} of '{1}' is up-to-date." -f $InstalledVersion, $ModuleName | Write-Verbose
+    }
+    else {
+        "The installed version {0} of '{1}' is newer than the gallery version {2}." -f $InstalledVersion, $ModuleName, $GalleryVersion | Write-Warning
+    }
+}

--- a/Tests/Unit/Compare-ModuleVersion.Tests.ps1
+++ b/Tests/Unit/Compare-ModuleVersion.Tests.ps1
@@ -1,0 +1,109 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'ConvertTo-ModuleVersionInfo' -Tag 'Unit' {
+    It 'Should split a prerelease into its numeric part and its tag' {
+        InModuleScope 'OmadaWeb.PS' {
+            $VersionInfo = ConvertTo-ModuleVersionInfo -Version '2026.9.1-nightly74'
+
+            $VersionInfo.Version | Should -Be ([System.Version]'2026.9.1')
+            $VersionInfo.PrereleaseTag | Should -Be 'nightly74'
+            $VersionInfo.IsPrerelease | Should -BeTrue
+            $VersionInfo.Original | Should -Be '2026.9.1-nightly74'
+        }
+    }
+
+    It 'Should parse a four component version, which SemanticVersion cannot' {
+        InModuleScope 'OmadaWeb.PS' {
+            $VersionInfo = ConvertTo-ModuleVersionInfo -Version '2026.7.9.9'
+
+            $VersionInfo.Version | Should -Be ([System.Version]'2026.7.9.9')
+            $VersionInfo.IsPrerelease | Should -BeFalse
+        }
+    }
+
+    It 'Should ignore build metadata, which carries no precedence' {
+        InModuleScope 'OmadaWeb.PS' {
+            $VersionInfo = ConvertTo-ModuleVersionInfo -Version '2026.9.1-nightly74+abc123'
+
+            $VersionInfo.PrereleaseTag | Should -Be 'nightly74'
+        }
+    }
+
+    It 'Should return $null for a value that is not a version' {
+        InModuleScope 'OmadaWeb.PS' {
+            ConvertTo-ModuleVersionInfo -Version 'latest' | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Should return $null for an empty value' {
+        InModuleScope 'OmadaWeb.PS' {
+            ConvertTo-ModuleVersionInfo -Version '' | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Compare-ModuleVersion' -Tag 'Unit' {
+    It 'Should report the reference as older when it is a lower stable version' {
+        InModuleScope 'OmadaWeb.PS' {
+            Compare-ModuleVersion -ReferenceVersion '1.0.0' -DifferenceVersion '2.0.0' | Should -Be -1
+        }
+    }
+
+    It 'Should report the reference as newer when it is a higher stable version' {
+        InModuleScope 'OmadaWeb.PS' {
+            Compare-ModuleVersion -ReferenceVersion '2.0.0' -DifferenceVersion '1.0.0' | Should -Be 1
+        }
+    }
+
+    It 'Should report equality for two identical stable versions' {
+        InModuleScope 'OmadaWeb.PS' {
+            Compare-ModuleVersion -ReferenceVersion '2026.9.1' -DifferenceVersion '2026.9.1' | Should -Be 0
+        }
+    }
+
+    It 'Should sort a prerelease below the stable release of the same version' {
+        InModuleScope 'OmadaWeb.PS' {
+            Compare-ModuleVersion -ReferenceVersion '2026.9.1-nightly74' -DifferenceVersion '2026.9.1' | Should -Be -1
+            Compare-ModuleVersion -ReferenceVersion '2026.9.1' -DifferenceVersion '2026.9.1-nightly74' | Should -Be 1
+        }
+    }
+
+    It 'Should report equality for two identical prereleases' {
+        InModuleScope 'OmadaWeb.PS' {
+            Compare-ModuleVersion -ReferenceVersion '2026.9.1-nightly74' -DifferenceVersion '2026.9.1-nightly74' | Should -Be 0
+        }
+    }
+
+    It 'Should order nightly tags by their build number rather than as text' {
+        InModuleScope 'OmadaWeb.PS' {
+            Compare-ModuleVersion -ReferenceVersion '2026.9.1-nightly9' -DifferenceVersion '2026.9.1-nightly74' | Should -Be -1
+            Compare-ModuleVersion -ReferenceVersion '2026.9.1-nightly74' -DifferenceVersion '2026.9.1-nightly9' | Should -Be 1
+        }
+    }
+
+    It 'Should compare a four component build against a three component release' {
+        InModuleScope 'OmadaWeb.PS' {
+            Compare-ModuleVersion -ReferenceVersion '2026.7.9.9' -DifferenceVersion '2026.9.1' | Should -Be -1
+            Compare-ModuleVersion -ReferenceVersion '2026.9.1.1' -DifferenceVersion '2026.9.1' | Should -Be 1
+        }
+    }
+
+    It 'Should return $null instead of throwing when a value cannot be parsed' {
+        InModuleScope 'OmadaWeb.PS' {
+            { Compare-ModuleVersion -ReferenceVersion 'not-a-version' -DifferenceVersion '1.0.0' } | Should -Not -Throw
+            Compare-ModuleVersion -ReferenceVersion 'not-a-version' -DifferenceVersion '1.0.0' | Should -BeNullOrEmpty
+            Compare-ModuleVersion -ReferenceVersion '1.0.0' -DifferenceVersion 'unknown' | Should -BeNullOrEmpty
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}

--- a/Tests/Unit/Get-GalleryModuleVersion.Tests.ps1
+++ b/Tests/Unit/Get-GalleryModuleVersion.Tests.ps1
@@ -8,7 +8,7 @@ BeforeAll {
 }
 
 Describe 'Get-GalleryModuleVersion' -Tag 'Unit' {
-    It 'Should return the version of the most recently updated package' {
+    It 'Should return the highest version in the feed' {
         InModuleScope 'OmadaWeb.PS' {
             Mock Invoke-RestMethod {
                 @(
@@ -28,6 +28,93 @@ Describe 'Get-GalleryModuleVersion' -Tag 'Unit' {
             }
 
             Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -Be '2.0.0'
+        }
+    }
+
+    It 'Should return the highest version rather than the most recently published one' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Invoke-RestMethod {
+                @(
+                    [PSCustomObject]@{
+                        Properties = [PSCustomObject]@{
+                            version   = '2.0.0'
+                            Published = [PSCustomObject]@{ '#text' = (Get-Date).AddDays(-5) }
+                        }
+                    }
+                    [PSCustomObject]@{
+                        Properties = [PSCustomObject]@{
+                            version   = '1.0.0'
+                            Published = [PSCustomObject]@{ '#text' = (Get-Date) }
+                        }
+                    }
+                )
+            }
+
+            Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -Be '2.0.0'
+        }
+    }
+
+    It 'Should return the highest stable version when the feed contains a newer prerelease' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Invoke-RestMethod {
+                @(
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = '2026.9.1' } }
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = '2026.9.2-nightly74' } }
+                )
+            }
+
+            Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -Be '2026.9.1'
+        }
+    }
+
+    It 'Should return the newer prerelease when prereleases are requested' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Invoke-RestMethod {
+                @(
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = '2026.9.1' } }
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = '2026.9.2-nightly74' } }
+                )
+            }
+
+            Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' -IncludePrerelease | Should -Be '2026.9.2-nightly74'
+        }
+    }
+
+    It 'Should prefer a stable release over an older prerelease when prereleases are requested' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Invoke-RestMethod {
+                @(
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = '2026.9.1-nightly74' } }
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = '2026.9.1' } }
+                )
+            }
+
+            Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' -IncludePrerelease | Should -Be '2026.9.1'
+        }
+    }
+
+    It 'Should return $null when the feed holds nothing but prereleases and stable was asked for' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Invoke-RestMethod {
+                @(
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = '2026.9.1-nightly74' } }
+                )
+            }
+
+            Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Should ignore a feed entry whose version cannot be parsed' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Invoke-RestMethod {
+                @(
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = 'unknown' } }
+                    [PSCustomObject]@{ Properties = [PSCustomObject]@{ version = '2026.9.1' } }
+                )
+            }
+
+            Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -Be '2026.9.1'
         }
     }
 

--- a/Tests/Unit/Write-ModuleVersionStatus.Tests.ps1
+++ b/Tests/Unit/Write-ModuleVersionStatus.Tests.ps1
@@ -1,0 +1,196 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Write-ModuleVersionStatus' -Tag 'Unit' {
+    It 'Should still warn that the installation is outdated when the newest gallery package is a prerelease' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-GalleryModuleVersion {
+                if ($IncludePrerelease) { '2026.9.1-nightly74' } else { '2026.9.1' }
+            }
+
+            $Warnings = @()
+            Write-ModuleVersionStatus -ModuleName 'OmadaWeb.PS' -InstalledModule @{
+                Version     = '2026.8.1'
+                FullVersion = '2026.8.1'
+                Prerelease  = $null
+            } -WarningVariable Warnings -WarningAction SilentlyContinue
+
+            $Warnings.Count | Should -Be 1
+            $Warnings[0].Message | Should -BeLike '*is outdated*2026.9.1*'
+        }
+    }
+
+    It 'Should keep a prerelease on the gallery invisible to a stable installation' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-GalleryModuleVersion {
+                if ($IncludePrerelease) { '2026.9.2-nightly74' } else { '2026.9.1' }
+            }
+
+            $Warnings = @()
+            Write-ModuleVersionStatus -ModuleName 'OmadaWeb.PS' -InstalledModule @{
+                Version     = '2026.9.1'
+                FullVersion = '2026.9.1'
+                Prerelease  = $null
+            } -WarningVariable Warnings -WarningAction SilentlyContinue
+
+            $Warnings.Count | Should -Be 0
+            Should -Invoke Get-GalleryModuleVersion -ParameterFilter { -not $IncludePrerelease }
+        }
+    }
+
+    It 'Should compare a prerelease installation against prereleases as well' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-GalleryModuleVersion {
+                if ($IncludePrerelease) { '2026.9.1-nightly74' } else { '2026.8.1' }
+            }
+
+            $Warnings = @()
+            Write-ModuleVersionStatus -ModuleName 'OmadaWeb.PS' -InstalledModule @{
+                Version     = '2026.9.1'
+                FullVersion = '2026.9.1-nightly9'
+                Prerelease  = 'nightly9'
+            } -WarningVariable Warnings -WarningAction SilentlyContinue
+
+            $Warnings.Count | Should -Be 1
+            $Warnings[0].Message | Should -BeLike '*2026.9.1-nightly9*is outdated*2026.9.1-nightly74*'
+            Should -Invoke Get-GalleryModuleVersion -ParameterFilter { $IncludePrerelease }
+        }
+    }
+
+    It 'Should warn when the installed version is newer than the gallery version' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-GalleryModuleVersion { '2026.8.1' }
+
+            $Warnings = @()
+            Write-ModuleVersionStatus -ModuleName 'OmadaWeb.PS' -InstalledModule @{
+                Version     = '2026.9.1'
+                FullVersion = '2026.9.1'
+                Prerelease  = $null
+            } -WarningVariable Warnings -WarningAction SilentlyContinue
+
+            $Warnings.Count | Should -Be 1
+            $Warnings[0].Message | Should -BeLike '*is newer than the gallery version*'
+        }
+    }
+
+    It 'Should say why it skipped when the gallery version could not be determined' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-GalleryModuleVersion { $null }
+
+            $Warnings = @()
+            $VerboseMessages = @()
+            Write-ModuleVersionStatus -ModuleName 'OmadaWeb.PS' -InstalledModule @{
+                Version     = '2026.9.1'
+                FullVersion = '2026.9.1'
+                Prerelease  = $null
+            } -WarningVariable Warnings -WarningAction SilentlyContinue -Verbose 4>&1 | ForEach-Object { $VerboseMessages += $_ }
+
+            $Warnings.Count | Should -Be 0
+            ($VerboseMessages -join "`n") | Should -BeLike '*PowerShell Gallery*'
+        }
+    }
+
+    It 'Should skip without warning when a version cannot be compared' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-GalleryModuleVersion { 'latest' }
+
+            $Warnings = @()
+            { Write-ModuleVersionStatus -ModuleName 'OmadaWeb.PS' -InstalledModule @{
+                    Version     = '2026.9.1'
+                    FullVersion = '2026.9.1'
+                    Prerelease  = $null
+                } -WarningVariable Warnings -WarningAction SilentlyContinue } | Should -Not -Throw
+
+            $Warnings.Count | Should -Be 0
+        }
+    }
+
+    It 'Should fall back to the numeric version when no full version was supplied' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-GalleryModuleVersion { '2026.9.1' }
+
+            $Warnings = @()
+            Write-ModuleVersionStatus -ModuleName 'OmadaWeb.PS' -InstalledModule @{
+                Version = '2026.8.1'
+            } -WarningVariable Warnings -WarningAction SilentlyContinue
+
+            $Warnings.Count | Should -Be 1
+            $Warnings[0].Message | Should -BeLike '*2026.8.1*is outdated*'
+        }
+    }
+}
+
+Describe 'Get-InstalledModuleInfo' -Tag 'Unit' {
+    It 'Should report the prerelease tag and the full version of a nightly installation' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Get-PSCallStack {
+                [PSCustomObject]@{
+                    Command    = 'OmadaWeb.PS.psm1'
+                    ScriptName = 'C:\Modules\OmadaWeb.PS\2026.9.1\OmadaWeb.PS.psm1'
+                }
+            }
+            Mock Get-Module {
+                [PSCustomObject]@{
+                    Name                     = 'OmadaWeb.PS'
+                    Version                  = [System.Version]'2026.9.1'
+                    Path                     = 'C:\Modules\OmadaWeb.PS\2026.9.1\OmadaWeb.PS.psd1'
+                    RepositorySourceLocation = 'https://www.powershellgallery.com/api/v2'
+                    PrivateData              = @{
+                        PSData = @{
+                            Prerelease = 'nightly74'
+                            Tags       = @('Omada')
+                        }
+                    }
+                }
+            }
+
+            $ModuleInfo = Get-InstalledModuleInfo -ModuleName 'OmadaWeb.PS'
+
+            $ModuleInfo['Version'] | Should -Be ([System.Version]'2026.9.1')
+            $ModuleInfo['Prerelease'] | Should -Be 'nightly74'
+            $ModuleInfo['FullVersion'] | Should -Be '2026.9.1-nightly74'
+            $ModuleInfo['RepositorySource'] | Should -Be 'https://www.powershellgallery.com/api/v2'
+        }
+    }
+
+    It 'Should not fail on a stable installation, whose PSData has no Prerelease key' {
+        InModuleScope 'OmadaWeb.PS' {
+            Set-StrictMode -Version Latest
+            Mock Get-PSCallStack {
+                [PSCustomObject]@{
+                    Command    = 'OmadaWeb.PS.psm1'
+                    ScriptName = 'C:\Modules\OmadaWeb.PS\2026.9.1\OmadaWeb.PS.psm1'
+                }
+            }
+            Mock Get-Module {
+                [PSCustomObject]@{
+                    Name                     = 'OmadaWeb.PS'
+                    Version                  = [System.Version]'2026.9.1'
+                    Path                     = 'C:\Modules\OmadaWeb.PS\2026.9.1\OmadaWeb.PS.psd1'
+                    RepositorySourceLocation = 'https://www.powershellgallery.com/api/v2'
+                    PrivateData              = @{
+                        PSData = @{
+                            Tags       = @('Omada')
+                            ProjectUri = 'https://github.com/Fortigi/OmadaWeb.PS'
+                        }
+                    }
+                }
+            }
+
+            $ModuleInfo = Get-InstalledModuleInfo -ModuleName 'OmadaWeb.PS'
+
+            $ModuleInfo['Prerelease'] | Should -BeNullOrEmpty
+            $ModuleInfo['FullVersion'] | Should -Be '2026.9.1'
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}


### PR DESCRIPTION
Closes #75

## What broke

At import, the version check read the newest package from the PowerShell Gallery and cast both sides to `[System.Version]`. Three defects lined up:

- `OmadaWeb.PS/Private/Get-GalleryModuleVersion.ps1:29` — `Sort-Object Published -Descending | Select-Object -First 1`. No prerelease filter, so a nightly could be returned to a stable installation, and sorting on publication date meant a republished older package won.
- `OmadaWeb.PS/OmadaWeb.PS.psm1:493` and `:496` — `[System.Version]$InstalledModule['Version'] -lt [System.Version]$GalleryVersion` throws `PSInvalidCastException` on `2026.9.1-nightly74`.
- `OmadaWeb.PS/OmadaWeb.PS.psm1:506` — `catch {}` swallowed it, taking the rest of the `else` branch with it. The consequence is not cosmetic: while a nightly happened to be the most recently published package, **the "your installation is outdated" warning was never emitted at all**, and the only trace was a record in `$Error`.
- `OmadaWeb.PS/OmadaWeb.PS.psm1:490-491` — an empty `if (-not $GalleryVersion) { }`.

## What changed

| File | Change |
| --- | --- |
| `OmadaWeb.PS/Private/ConvertTo-ModuleVersionInfo.ps1` | New. Splits a version string into its numeric part, its prerelease tag and an `IsPrerelease` flag; returns `$null` rather than throwing on anything unparsable. |
| `OmadaWeb.PS/Private/Compare-ModuleVersion.ps1` | New. Returns -1/0/1, and `$null` when either side cannot be parsed. Applies the SemVer rule that a tagged version sorts below the untagged release of the same number. |
| `OmadaWeb.PS/Private/Get-GalleryModuleVersion.ps1` | Reduces the feed by comparing versions instead of publication dates, and filters prereleases out unless `-IncludePrerelease` is given. An unparsable feed entry is skipped, not fatal. The `catch` says why it returned `$null`. |
| `OmadaWeb.PS/Private/Get-InstalledModuleInfo.ps1` | Additively returns `Prerelease` and `FullVersion`. `Name`, `Version` and `RepositorySource` are unchanged. |
| `OmadaWeb.PS/Private/Write-ModuleVersionStatus.ps1` | New. The gallery lookup, the comparison and the three messages, extracted from the psm1 so they can be tested. |
| `OmadaWeb.PS/OmadaWeb.PS.psm1` | The `else` branch calls `Write-ModuleVersionStatus`; the empty `catch {}` and the empty `if` are gone. The "not sourced from the PowerShell Gallery" skip and the `$Script:UserAgent` formatting are untouched. |
| `Tests/Unit/Compare-ModuleVersion.Tests.ps1` | New, 13 assertions. |
| `Tests/Unit/Write-ModuleVersionStatus.Tests.ps1` | New, 9 assertions. |
| `Tests/Unit/Get-GalleryModuleVersion.Tests.ps1` | Six added cases for channel filtering and version ordering. |

## Acceptance criteria

- [x] A prerelease on the gallery is never a thrown cast — `Compare-ModuleVersion` returns `$null` instead of throwing (`Compare-ModuleVersion.Tests.ps1`, "Should return $null instead of throwing when a value cannot be parsed"), and a prerelease tag now parses (`ConvertTo-ModuleVersionInfo`, "Should split a prerelease into its numeric part and its tag").
- [x] A prerelease is invisible to a stable installation — `Get-GalleryModuleVersion.Tests.ps1`, "Should return the highest stable version when the feed contains a newer prerelease"; `Write-ModuleVersionStatus.Tests.ps1`, "Should keep a prerelease on the gallery invisible to a stable installation".
- [x] The update notification keeps working regardless of what the newest published package is — `Write-ModuleVersionStatus.Tests.ps1`, "Should still warn that the installation is outdated when the newest gallery package is a prerelease".
- [x] Sorting on the parsed version rather than on `Published` — `Get-GalleryModuleVersion.Tests.ps1`, "Should return the highest version rather than the most recently published one".
- [x] A version that genuinely cannot be determined is one `Write-Verbose` line stating why, not a discarded exception — `Write-ModuleVersionStatus.ps1:32` and `:42`, `OmadaWeb.PS.psm1:493`; covered by "Should say why it skipped when the gallery version could not be determined".
- [x] Both PowerShell editions — the comparison uses only `[System.Version]::TryParse` and string work, both present on 5.1 and 7. Verified by the `Validate (powershell)` leg of PR Validation.
- [ ] Out of scope: the identical defect in OmadaSqlTroubleshooter, tracked separately in that repository. Not touched here.

## Decisions worth reviewing

**1. The update check is channel aware, which is not the issue's default.** The issue suggests filtering prereleases out full stop, with an opt-in switch. What is implemented instead: a stable installation compares only against the newest stable release, and a prerelease installation compares against prereleases as well, so a nightly user is told when a newer nightly *or* a newer stable exists. The alternative — stable-only for everyone — leaves nightly users with no update signal at all, or with a permanent "you are newer than the gallery" warning.

**2. `[System.Management.Automation.SemanticVersion]` is deliberately not used, and this diverges from the issue's suggested direction.** The issue proposes comparing with `SemanticVersion` where available and falling back to `[version]::TryParse` on 5.1. Measured on PowerShell 7 on this machine:

```
SemanticVersion::TryParse("2026.7.9.9")        -> False
SemanticVersion::TryParse("2026.9.1")          -> True
SemanticVersion::TryParse("2026.9.1-nightly74") -> True
```

SemVer permits at most three numeric components, and this module ships four component builds. A `SemanticVersion`-first comparison therefore fails on the **installed** side — the version already on people's machines — on both editions, not only on 5.1. The issue's author reasonably assumed SemVer would parse the installed version. So the parse is done by splitting at the first `-` and handing the numeric part to `[System.Version]::TryParse`, which takes two to four components and behaves identically on both editions, with the SemVer precedence rule applied on top.

**3. One deliberate departure from strict SemVer for nightly tags.** Strict SemVer compares `nightly9` and `nightly74` as text — neither is a purely numeric identifier — and concludes `nightly9` is the newer of the two. That is the wrong answer for every nightly user it would reach. When two tags on the same version share a prefix and differ only in a trailing run of digits, those digits are compared as numbers; anything else falls back to the ordinal comparison SemVer prescribes. Covered by "Should order nightly tags by their build number rather than as text".

**4. Only the body of the `else` branch was extracted.** `Write-ModuleVersionStatus` exists so the end-to-end behaviour is testable without installing the module from the gallery. Lines 482–486 and 488 of the psm1 — the "not sourced from the PowerShell Gallery" skip path and the `$Script:UserAgent` formatting — are unchanged, because an earlier bug lived exactly there and nothing in this change needs to touch it. The only edit in that region is to the comment above them, which described the catch below as empty; it no longer is.

**5. Channel detection probes with `Contains`, not member access.** `Get-Module -ListAvailable` exposes the tag at `$Module.PrivateData.PSData.Prerelease`, but `PrivateData` is a plain `Hashtable` and on a stable install the `PSData` keys are only `Tags`/`ProjectUri`/`ExternalModuleDependencies`/`LicenseUri` — there is no `Prerelease` key. Member access there would break every stable installation under `Set-StrictMode -Version Latest`, which the psm1 enables when `OMADAWEBPS_STRICTMODE=1`. Covered by "Should not fail on a stable installation, whose PSData has no Prerelease key", which sets strict mode inside the test.

**6. `*AvoidUsingEmptyCatchBlock*` is excluded from the build** (`Build/psakeBuild.ps1:34`), which is why this empty catch never tripped the analyzer. The analyzer will not catch a regression here either, so the verbose-on-failure behaviour is asserted by a test instead of relied on from the linter.

## Verification

- Baseline on `origin/main` in this worktree: **Passed=639 Failed=0 Skipped=10** (Total 649).
- After the change: **Passed=667 Failed=0 Skipped=10** (Total 677) — 28 new assertions, no regressions.
- Repeated with `OMADAWEBPS_STRICTMODE=1`: **Passed=667 Failed=0 Skipped=10**.
- `Invoke-ScriptAnalyzer -Severity Warning,Error` on every changed module file: clean. The one remaining `PSAvoidUsingEmptyCatchBlock` hit in the psm1 is at line 129, a pre-existing catch around `New-Item` that is unrelated to this change.
