### PR TITLE
Fix three defects that stopped WebView2 sign-in working unattended, and make the canary say so

### DIFF
--- a/.github/workflows/entra-canary.yml
+++ b/.github/workflows/entra-canary.yml
@@ -130,7 +130,9 @@ jobs:
           # In-process there is nothing to interrupt: the WinForms dialog blocks the thread it is
           # shown on. A child process can simply be killed, which turns a hang into a reported
           # failure - and that is the difference between a canary and a job that sometimes times out.
-          $attemptTimeoutSeconds = 480
+          # Generous for a real sign-in (no MFA on this account, so it is seconds) and short enough
+          # that two attempts plus the flake pause fit inside the job timeout with room to report.
+          $attemptTimeoutSeconds = 300
 
           function Invoke-CanaryAttempt {
             param([int]$Attempt)
@@ -151,7 +153,14 @@ jobs:
               "-DiagnosticPath", ('"{0}"' -f $diagnosticPath)
             )
 
-            $process = Start-Process -FilePath (Get-Command pwsh.exe).Source -ArgumentList $arguments -NoNewWindow -PassThru
+            # Captured to a file rather than streamed, so that a killed attempt still has a trace to
+            # read. It is echoed into the job log below either way; a timed-out attempt whose output
+            # went nowhere is what made the first stalled run unexplainable.
+            $childLog = Join-Path $env:RUNNER_TEMP ("canary-output-{0}.log" -f $Attempt)
+            $childErrorLog = Join-Path $env:RUNNER_TEMP ("canary-error-{0}.log" -f $Attempt)
+
+            $process = Start-Process -FilePath (Get-Command pwsh.exe).Source -ArgumentList $arguments -NoNewWindow -PassThru `
+              -RedirectStandardOutput $childLog -RedirectStandardError $childErrorLog
             $timedOut = -not $process.WaitForExit($attemptTimeoutSeconds * 1000)
 
             if ($timedOut) {
@@ -162,18 +171,38 @@ jobs:
               Get-Process -Name msedgewebview2 -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
             }
 
+            Write-Host ("::group::Attempt {0} output" -f $Attempt)
+            Get-Content -LiteralPath $childLog -ErrorAction SilentlyContinue | Write-Host
+            Get-Content -LiteralPath $childErrorLog -ErrorAction SilentlyContinue | Write-Host
+            Write-Host "::endgroup::"
+
             $diagnostic = ''
             if (Test-Path -LiteralPath $diagnosticPath) {
               $diagnostic = Get-Content -LiteralPath $diagnosticPath -Raw
             }
 
             if ($timedOut) {
+              # A killed attempt never reached the assertion that writes the diagnostic file, so the
+              # last screen the automation named in its trace is the only account of where it stopped
+              # - and it is a good one: it distinguishes a page the module could not read from one
+              # Entra refused.
+              $lastScreen = @(Select-String -LiteralPath $childLog -Pattern "Screen '.*', action '.*'" -ErrorAction SilentlyContinue |
+                Select-Object -Last 1 | ForEach-Object { $_.Line.Trim() })
+
+              $failure = @("- The sign-in did not finish within $attemptTimeoutSeconds seconds and was stopped. Nobody is at this browser, so a sign-in that waits for a user waits forever.")
+              if ($lastScreen.Count -gt 0) {
+                $failure += "- The last page the automation named was: $($lastScreen[0])"
+              }
+              else {
+                $failure += "- The automation never named a page, so it did not get as far as reading one. Look at the trace above."
+              }
+
               return [pscustomobject]@{
                 Failed     = 1
                 Passed     = 0
                 Skipped    = 0
                 Diagnostic = $diagnostic
-                Failure    = @("- The sign-in did not finish within $attemptTimeoutSeconds seconds and was stopped. Nobody is at this browser, so a sign-in that waits for a user waits forever; read the verbose trace above for the last page it reached.")
+                Failure    = $failure
               }
             }
 

--- a/.github/workflows/entra-canary.yml
+++ b/.github/workflows/entra-canary.yml
@@ -279,12 +279,29 @@ jobs:
               return;
             }
 
+            // A selector break is the failure this canary was built for, but it is not the only one
+            // it can catch - and issue #79 was filed by an earlier version of this text telling a
+            // maintainer to go and edit the selector table over a console-handle bug in the module.
+            // So the alert asks the reader to read the report first, and only claims a selector
+            // break when the report carries the diagnostic that proves one.
+            const looksLikeSelectorBreak = report.includes('Switch-ToManualLogin');
+
+            const diagnosis = looksLikeSelectorBreak
+              ? [
+                  `**What this means.** Credential autofill no longer recognizes a Microsoft sign-in screen. Signing in still works — a selector break degrades autofill, not login — but every user supplying \`-Credential\` now has to type it themselves.`,
+                  ``,
+                  `**What to do.** Update \`$Script:EntraSignInElementId\` in \`OmadaWeb.PS/OmadaWeb.PS.psm1\` from the diagnostic below, then re-run this workflow. See \`docs/entra-canary.md\` and issue #32.`,
+                ]
+              : [
+                  `**No selector diagnostic was captured, so do not assume the sign-in page changed.** \`Switch-ToManualLogin\` did not report an unrecognized page; the sign-in failed some other way — in this module, in the tenant, or on the runner.`,
+                  ``,
+                  `**What to do.** Read the failed assertions below first. "Actually travelled through Entra and back" failing with 0 means the browser never reached Microsoft, which rules the selector table out entirely. See the response guide in \`docs/entra-canary.md\`.`,
+                ];
+
             const body = [
               `The scheduled Entra ID sign-in canary failed twice in a row, so this is not a transient Microsoft hiccup.`,
               ``,
-              `**What this means.** Credential autofill no longer recognizes a Microsoft sign-in screen. Signing in still works — a selector break degrades autofill, not login — but every user supplying \`-Credential\` now has to type it themselves.`,
-              ``,
-              `**What to do.** Update \`$Script:EntraSignInElementId\` in \`OmadaWeb.PS/OmadaWeb.PS.psm1\` from the diagnostic below, then re-run this workflow. See \`docs/entra-canary.md\` and issue #32.`,
+              ...diagnosis,
               ``,
               `[Run ${context.runId}](${runUrl})`,
               ``,

--- a/.github/workflows/entra-canary.yml
+++ b/.github/workflows/entra-canary.yml
@@ -118,41 +118,83 @@ jobs:
             throw "The built module was not found at '$modulePath'."
           }
 
+          # Each attempt runs in a child process with a deadline, rather than in this one.
+          #
+          # A browser sign-in has no natural end when nobody is driving it. If the automation hands
+          # over to manual - which is exactly what a selector break makes it do - it then waits for a
+          # user who does not exist on a runner. The first run of this workflow after the console fix
+          # did precisely that: the window opened, the timer ticked for 29 minutes, and the job
+          # timeout killed the step. A killed step reports nothing at all: no assertions, no
+          # diagnostic, no alert. The canary was silent about the very failure it was watching for.
+          #
+          # In-process there is nothing to interrupt: the WinForms dialog blocks the thread it is
+          # shown on. A child process can simply be killed, which turns a hang into a reported
+          # failure - and that is the difference between a canary and a job that sometimes times out.
+          $attemptTimeoutSeconds = 480
+
           function Invoke-CanaryAttempt {
             param([int]$Attempt)
 
             $diagnosticPath = Join-Path $env:RUNNER_TEMP ("canary-diagnostic-{0}.txt" -f $Attempt)
             Remove-Item -LiteralPath $diagnosticPath -Force -ErrorAction SilentlyContinue
-            $env:OMADAWEBPS_CANARY_DIAGNOSTIC_PATH = $diagnosticPath
 
-            $container = New-PesterContainer -Path './Tests/E2E' -Data @{ ModulePath = $modulePath }
-            $configuration = New-PesterConfiguration
-            $configuration.Run.Container = $container
-            $configuration.Run.PassThru = $true
-            $configuration.Filter.Tag = 'E2E'
-            $configuration.Output.Verbosity = 'Detailed'
-            $configuration.TestResult.Enabled = $true
-            $configuration.TestResult.OutputFormat = 'JUnitXml'
-            $configuration.TestResult.OutputPath = (Join-Path $env:GITHUB_WORKSPACE ("buildoutput/CanaryResults-{0}.xml" -f $Attempt))
+            $resultPath = Join-Path $env:GITHUB_WORKSPACE ("buildoutput/CanaryResults-{0}.xml" -f $Attempt)
+            $summaryPath = Join-Path $env:RUNNER_TEMP ("canary-summary-{0}.json" -f $Attempt)
+            Remove-Item -LiteralPath $resultPath, $summaryPath -Force -ErrorAction SilentlyContinue
 
-            $result = Invoke-Pester -Configuration $configuration
+            $arguments = @(
+              "-NoLogo", "-NoProfile",
+              "-File", ('"{0}"' -f (Join-Path $env:GITHUB_WORKSPACE 'Tests/E2E/Invoke-CanaryAttempt.ps1')),
+              "-ModulePath", ('"{0}"' -f $modulePath),
+              "-ResultPath", ('"{0}"' -f $resultPath),
+              "-SummaryPath", ('"{0}"' -f $summaryPath),
+              "-DiagnosticPath", ('"{0}"' -f $diagnosticPath)
+            )
+
+            $process = Start-Process -FilePath (Get-Command pwsh.exe).Source -ArgumentList $arguments -NoNewWindow -PassThru
+            $timedOut = -not $process.WaitForExit($attemptTimeoutSeconds * 1000)
+
+            if ($timedOut) {
+              Write-Host ("::warning title=Canary attempt timed out::Attempt {0} was still running after {1} seconds and was stopped." -f $Attempt, $attemptTimeoutSeconds)
+              try { $process.Kill($true) } catch { Write-Host "Could not stop the attempt cleanly: $($_.Exception.Message)" }
+              # Every browser process the sign-in started outlives the runspace that opened it, and
+              # the next attempt must not inherit one.
+              Get-Process -Name msedgewebview2 -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+            }
 
             $diagnostic = ''
             if (Test-Path -LiteralPath $diagnosticPath) {
               $diagnostic = Get-Content -LiteralPath $diagnosticPath -Raw
             }
 
-            $failure = @($result.Failed | ForEach-Object {
-              $name = if ([string]::IsNullOrWhiteSpace($_.ExpandedPath)) { $_.Name } else { $_.ExpandedPath }
-              "- {0}: {1}" -f $name, $_.ErrorRecord.Exception.Message
-            })
+            if ($timedOut) {
+              return [pscustomobject]@{
+                Failed     = 1
+                Passed     = 0
+                Skipped    = 0
+                Diagnostic = $diagnostic
+                Failure    = @("- The sign-in did not finish within $attemptTimeoutSeconds seconds and was stopped. Nobody is at this browser, so a sign-in that waits for a user waits forever; read the verbose trace above for the last page it reached.")
+              }
+            }
+
+            if (-not (Test-Path -LiteralPath $summaryPath)) {
+              return [pscustomobject]@{
+                Failed     = 1
+                Passed     = 0
+                Skipped    = 0
+                Diagnostic = $diagnostic
+                Failure    = @("- The attempt exited with code $($process.ExitCode) without reporting a result. See the output above.")
+              }
+            }
+
+            $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json
 
             return [pscustomobject]@{
-              Failed     = [int]$result.FailedCount
-              Passed     = [int]$result.PassedCount
-              Skipped    = [int]$result.SkippedCount
+              Failed     = [int]$summary.Failed
+              Passed     = [int]$summary.Passed
+              Skipped    = [int]$summary.Skipped
               Diagnostic = $diagnostic
-              Failure    = $failure
+              Failure    = @($summary.Failure)
             }
           }
 

--- a/Build/New-EntraCanaryConfiguration.ps1
+++ b/Build/New-EntraCanaryConfiguration.ps1
@@ -668,10 +668,12 @@ try {
         # Get-MgOrganization is how the tenant's initial onmicrosoft.com domain is found, and it is
         # not covered by any of the scopes above.
         "Directory.Read.All",
-        "User-PasswordProfile.ReadWrite.All"
+        "User-PasswordProfile.ReadWrite.All",
+        # Security defaults are read on every run, including under -SkipConditionalAccess, because
+        # they are a tenant-wide switch rather than a Conditional Access policy.
+        "Policy.Read.All"
     )
     if (-not $SkipConditionalAccess) {
-        $RequiredScope += "Policy.Read.All"
         $RequiredScope += "Policy.ReadWrite.ConditionalAccess"
     }
 
@@ -723,11 +725,18 @@ try {
     $Contained = $false
     $LocationRestricted = $false
 
+    # Security defaults are read whether or not Conditional Access is being touched. They are not a
+    # Conditional Access policy - they are a tenant-wide switch that enforces MFA registration on
+    # every account - and a canary account cannot answer that prompt. Reporting them only in the
+    # Conditional Access branch meant that -SkipConditionalAccess hid the single most likely reason
+    # for a canary that cannot sign in, and silently ignored -DisableSecurityDefaults along with it.
     if ($SkipConditionalAccess) {
         "Skipping every Conditional Access change (-SkipConditionalAccess)." | Write-Host -ForegroundColor Yellow
     }
-    else {
-        $SecurityDefaults = Get-CanarySecurityDefaultsState -Disable:$DisableSecurityDefaults
+
+    $SecurityDefaults = Get-CanarySecurityDefaultsState -Disable:$DisableSecurityDefaults
+
+    if (-not $SkipConditionalAccess) {
         if ($null -ne $User) {
             $MfaExemption = @(Add-CanaryMfaExemption -UserId $User.Id)
 

--- a/OmadaWeb.PS/Private/Get-EntraErrorVerdict.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraErrorVerdict.ps1
@@ -22,7 +22,10 @@ function Get-EntraErrorVerdict {
             register security information, complete an extra verification step. The window is open
             and the user can finish there, so autofill steps aside through Switch-ToManualLogin
             rather than failing the request.
-          - None. There is no error. A healthy page reports iErrorCode 0.
+          - None. There is no error to act on. A healthy page reports iErrorCode 0 - and so, for this
+            module's purposes, does AADSTS50058, which reports only that the page found no existing
+            session to sign in silently with. That is the normal state of a cold browser, not a
+            failure, and it is explained where it is handled below.
 
         An error code this function does not recognize is answered with Manual, not with silence:
         the list below is not, and cannot be, exhaustive, so anything unknown fails safe by handing
@@ -75,6 +78,30 @@ function Get-EntraErrorVerdict {
     }
 
     if ($Numeric -eq 0) {
+        return $Verdict
+    }
+
+    # AADSTS50058 - "a silent sign-in request was sent but no user is signed in" - is not a failed
+    # sign-in. It is the sign-in page saying it looked for an existing session and found none, which
+    # is the ordinary state of a browser that has never signed in before. Entra's page attempts that
+    # silent check on load and leaves the result in $Config, while rendering the perfectly usable
+    # username prompt underneath it.
+    #
+    # Treating it as an error meant that a cold browser profile - the only kind the scheduled canary
+    # ever has, and what any user gets on a first sign-in or with -ForceAuthentication - was handed
+    # straight to a manual sign-in before the username was ever typed. The canary found it because it
+    # starts cold every single day (issue #79).
+    #
+    # It is answered here rather than added to the manual list because the right response is to
+    # carry on: the rules that follow read the elements that are actually on the page, and if there
+    # is a username field they will fill it in. If the page really is unusable, the stall timer still
+    # ends in Switch-ToManualLogin a minute later, so nothing is trapped by this.
+    #
+    # Same family as the 1600x codes handled below, and the same lesson from issue #76: a code the
+    # sign-in page emits about its own silent-SSO probe says nothing about whether the credential can
+    # be typed.
+    if ($Numeric -eq 50058) {
+        "{0} - AADSTS50058 reports no existing session, which is not a sign-in failure. Continuing." -f $MyInvocation.MyCommand | Write-Verbose
         return $Verdict
     }
 

--- a/OmadaWeb.PS/Private/Get-WebView2Cookie.ps1
+++ b/OmadaWeb.PS/Private/Get-WebView2Cookie.ps1
@@ -40,11 +40,21 @@ function Get-WebView2Cookie {
                         return
                     }
                     $Filter = [System.Uri]::New($Script:CurrentWebView2Session.BaseUrl).Host.ToLower()
-                    $Match = $Cookies | Where-Object { ($null -ne $_.Domain) -and $_.Domain.ToLowerInvariant().EndsWith($Filter) }
+                    # Wrapped, because Where-Object returns the single object itself when exactly one
+                    # cookie matches, and a bare object has no Count for the test below to read.
+                    # Under StrictMode that is a terminating error inside this callback, and the
+                    # callback's catch only writes "Cookie callback error" to the console - so the
+                    # cookie is never exported, the sign-in window never closes, and a sign-in that
+                    # actually succeeded hangs until something else times it out.
+                    #
+                    # One matching cookie is not a corner case: it is what any host that sets only
+                    # oisauthtoken produces, which is exactly what the scheduled canary's loopback
+                    # stand-in does. It found this (issue #79); the same bug class as #68.
+                    $Match = @($Cookies | Where-Object { ($null -ne $_.Domain) -and $_.Domain.ToLowerInvariant().EndsWith($Filter) })
                     $Script:CurrentWebView2Session.AuthCookie = [pscustomobject]@{}
                     $Exported = $false
 
-                    if ($Match -and $Match.Count -gt 0) {
+                    if ($Match.Count -gt 0) {
                         $Match | ForEach-Object {
                             if (!$Exported -and $_.name -eq 'oisauthtoken') {
                                 if ( $Script:LastCheckedHost -ne $Script:WebView2.Source.Host) {

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -256,7 +256,21 @@ $(Get-EntraElementVisibilityScript)
 
                 $Decision = Resolve-EntraSignInScreen -PageState $Script:PageState -UserName $Script:CurrentWebView2Session.Credential.UserName.Trim() -HasPassword:$HasPassword -PreferredMfaMethod $PreferredMfaMethod -MfaRequestDisplayed:$Script:MfaRequestDisplayed
 
-                "Invoke-WebView2MicrosoftLogin - Screen '{0}', action '{1}'" -f $Decision.Screen, $Decision.Action | Write-Verbose
+                # The code and the reason travel with the screen, because between them they are the
+                # difference between "Microsoft changed the page" and "Entra refused this request",
+                # and the screen name alone does not say which. Without them a verbose trace can
+                # report SignInError and still leave a reader with no idea what the error was - which
+                # is exactly what the sign-in canary hit (issue #79).
+                $DecisionDetail = ""
+                if (-not [string]::IsNullOrWhiteSpace($Decision.Code)) {
+                    $DecisionDetail = ", code '{0}'" -f $Decision.Code
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($Decision.Reason)) {
+                    $DecisionDetail = "{0}, reason '{1}'" -f $DecisionDetail, (Protect-LogMessage -Message $Decision.Reason)
+                }
+
+                "Invoke-WebView2MicrosoftLogin - Screen '{0}', action '{1}'{2}" -f $Decision.Screen, $Decision.Action, $DecisionDetail | Write-Verbose
                 $Script:PreviousScenario = $Script:CurrentScenario
                 $Script:CurrentScenario = $Decision.Screen
 

--- a/OmadaWeb.PS/Private/Start-WebView2Login.ps1
+++ b/OmadaWeb.PS/Private/Start-WebView2Login.ps1
@@ -8,9 +8,26 @@ function Start-WebView2Login {
         [switch]$InPrivate
     )
 
+    # Declared outside the try because the catch below reads them. Anything that threw before they
+    # were assigned would otherwise make the handler fail on an unset variable under StrictMode, and
+    # the error the user saw would be that one instead of the one that actually broke the sign-in.
+    $ConsoleControlAvailable = $false
+    $OriginalTreatControlCAsInput = $null
+
     try {
         "{0} - Starting WebView2 login" -f $MyInvocation.MyCommand | Write-Verbose
-        $OriginalTreatControlCAsInput = [Console]::TreatControlCAsInput
+
+        # Ctrl+C is taken over further down so that pressing it closes this window instead of killing
+        # the caller's session, and put back afterwards. Both halves of that go through
+        # Console.TreatControlCAsInput, which throws "The handle is invalid" on a process with no
+        # console attached - a scheduled task, a service, a CI job, a piped script. Reading it here
+        # unguarded is what made -AuthenticationType WebView2 fail instantly and non-interactively,
+        # before the browser it needs was ever created (issue #79). See Test-OmadaConsoleControl.
+        $ConsoleControlAvailable = Test-OmadaConsoleControl
+        if ($ConsoleControlAvailable) {
+            $OriginalTreatControlCAsInput = [Console]::TreatControlCAsInput
+        }
+
         [System.Windows.Forms.Application]::EnableVisualStyles()
         $Script:WinForm = New-Object System.Windows.Forms.Form
         [Microsoft.Web.WebView2.WinForms.WebView2] $Script:WebView2 = New-Object Microsoft.Web.WebView2.WinForms.WebView2
@@ -199,14 +216,18 @@ function Start-WebView2Login {
         }
 
         # Disable Ctrl+C handling while form is open avoiding crashing the sessions when CTRL+C is pressed
-        "{0} - Disable Ctrl+C handling while form is open avoiding crashing the sessions when CTRL+C is pressed" -f $MyInvocation.MyCommand | Write-Verbose
-        [Console]::TreatControlCAsInput = $true
+        if ($ConsoleControlAvailable) {
+            "{0} - Disable Ctrl+C handling while form is open avoiding crashing the sessions when CTRL+C is pressed" -f $MyInvocation.MyCommand | Write-Verbose
+            [Console]::TreatControlCAsInput = $true
+        }
 
         "{0} - Show WinForm Dialog" -f $MyInvocation.MyCommand | Write-Verbose
         $Script:WinForm.ShowDialog() | Out-Null
 
-        "{0} - Re-enable Ctrl+C." -f $MyInvocation.MyCommand | Write-Verbose
-        [Console]::TreatControlCAsInput = $OriginalTreatControlCAsInput
+        if ($ConsoleControlAvailable) {
+            "{0} - Re-enable Ctrl+C." -f $MyInvocation.MyCommand | Write-Verbose
+            [Console]::TreatControlCAsInput = $OriginalTreatControlCAsInput
+        }
 
         "{0} - Reset-Timer" -f $MyInvocation.MyCommand | Write-Verbose
         Reset-Timer
@@ -225,7 +246,11 @@ function Start-WebView2Login {
             $Script:WebView2.Dispose()
             "{0} - Dispose WinForm" -f $MyInvocation.MyCommand | Write-Verbose
             $Script:WinForm.Dispose()
-            if ($null -ne $OriginalTreatControlCAsInput) {
+            # $null here means Ctrl+C was never taken over, either because there was no console to
+            # take it from or because the failure happened before that point. Either way there is
+            # nothing to put back, and writing to the console would throw a second time inside the
+            # handler for the first failure.
+            if ($ConsoleControlAvailable -and $null -ne $OriginalTreatControlCAsInput) {
                 "{0} - Re-enable Ctrl+C." -f $MyInvocation.MyCommand | Write-Verbose
                 [Console]::TreatControlCAsInput = $OriginalTreatControlCAsInput
             }

--- a/OmadaWeb.PS/Private/Test-OmadaConsoleControl.ps1
+++ b/OmadaWeb.PS/Private/Test-OmadaConsoleControl.ps1
@@ -23,8 +23,14 @@ function Test-OmadaConsoleControl {
         The answer is probed rather than inferred from [Console]::IsInputRedirected. Redirection is
         the common reason a console cannot be driven, but it is not the only one, and a predicate
         that is right about the usual case and wrong about the rest just re-introduces the crash
-        somewhere harder to find. Reading the property is cheap, and it is the very operation that
-        has to succeed later - so this cannot come to disagree with reality.
+        somewhere harder to find. Probing is cheap, and it is the very operation that has to succeed
+        later - so this cannot come to disagree with reality.
+
+        Both halves are probed, because the caller does both. The getter and the setter are separate
+        operations on the console handle, and a predicate that only read would still let a host where
+        the read works and the write does not crash on the write - the guard would be in place and
+        the bug would survive it. Writing the value straight back is a no-op, so asking the question
+        costs nothing and changes nothing.
 
     .OUTPUTS
         System.Boolean. True when Console.TreatControlCAsInput can be read and written.
@@ -39,14 +45,15 @@ function Test-OmadaConsoleControl {
     param()
 
     try {
-        $null = [Console]::TreatControlCAsInput
+        $Current = [Console]::TreatControlCAsInput
+        [Console]::TreatControlCAsInput = $Current
         return $true
     }
     catch {
         # Verbose rather than a warning. There is nothing for the user to do about it, nothing is
         # degraded that they would notice - a host with no console has nobody at a keyboard to press
         # Ctrl+C - and this runs on every browser sign-in.
-        "{0} - No console is attached, so Ctrl+C handling is left alone: {1}" -f $MyInvocation.MyCommand, $_.Exception.Message | Write-Verbose
+        "{0} - Ctrl+C handling cannot be driven here, so it is left alone: {1}" -f $MyInvocation.MyCommand, $_.Exception.Message | Write-Verbose
         return $false
     }
 }

--- a/OmadaWeb.PS/Private/Test-OmadaConsoleControl.ps1
+++ b/OmadaWeb.PS/Private/Test-OmadaConsoleControl.ps1
@@ -1,0 +1,52 @@
+function Test-OmadaConsoleControl {
+    <#
+    .SYNOPSIS
+        Whether this process has a console whose Ctrl+C handling can be changed.
+
+    .DESCRIPTION
+        Start-WebView2Login takes Ctrl+C over while its modal sign-in window is open, so that pressing
+        it closes the window instead of killing the caller's session. Console.TreatControlCAsInput is
+        how that is done - and on Windows both its getter and its setter throw
+
+            System.IO.IOException: The handle is invalid.
+
+        when the process has no console attached to standard input. That is not an exotic state: it
+        is what a scheduled task, a Windows service, a CI job, and any script whose output is piped
+        to a file all look like.
+
+        Because the read sat near the top of Start-WebView2Login, it threw before the browser window
+        was ever created, so -AuthenticationType WebView2 failed instantly and non-interactively with
+        a message about a handle and nothing about signing in. The scheduled sign-in canary found it
+        on its first real run against a tenant (issue #79), and reported it as a changed Microsoft
+        sign-in page, which it was not.
+
+        The answer is probed rather than inferred from [Console]::IsInputRedirected. Redirection is
+        the common reason a console cannot be driven, but it is not the only one, and a predicate
+        that is right about the usual case and wrong about the rest just re-introduces the crash
+        somewhere harder to find. Reading the property is cheap, and it is the very operation that
+        has to succeed later - so this cannot come to disagree with reality.
+
+    .OUTPUTS
+        System.Boolean. True when Console.TreatControlCAsInput can be read and written.
+
+    .EXAMPLE
+        if (Test-OmadaConsoleControl) { $Original = [Console]::TreatControlCAsInput }
+
+        The shape every caller uses: nothing is read from the console until this has said it is safe.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param()
+
+    try {
+        $null = [Console]::TreatControlCAsInput
+        return $true
+    }
+    catch {
+        # Verbose rather than a warning. There is nothing for the user to do about it, nothing is
+        # degraded that they would notice - a host with no console has nobody at a keyboard to press
+        # Ctrl+C - and this runs on every browser sign-in.
+        "{0} - No console is attached, so Ctrl+C handling is left alone: {1}" -f $MyInvocation.MyCommand, $_.Exception.Message | Write-Verbose
+        return $false
+    }
+}

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -88,11 +88,18 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
         # sign-in already in flight is a good way to produce exactly what that run got back from
         # Entra: AADSTS50058, "the cookies used to represent the user's session were not sent".
         # The runner starts from a fresh profile every time, so there is nothing here to clear anyway.
+        # The stand-in serves plain HTTP on the loopback interface, and PowerShell 7 refuses to send a
+        # credential over an unencrypted connection without being told to. Guarded by version rather
+        # than passed unconditionally because the parameter does not exist on Windows PowerShell 5.1,
+        # which is the same shape Tests/Integration uses for the same reason.
+        $UnencryptedAuthParameter = if ($PSVersionTable.PSVersion.Major -ge 6) { @{ AllowUnencryptedAuthentication = $true } } else { @{} }
+
         try {
             $Output = Invoke-OmadaWebRequest -Uri $Script:RelyingParty.ResourceUrl `
                 -AuthenticationType WebView2 `
                 -Credential $Credential `
                 -SkipCookieCache `
+                @UnencryptedAuthParameter `
                 -ErrorAction Stop 3>&1
 
             foreach ($Record in @($Output)) {

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -142,10 +142,27 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
 
         $Report = (@($Message, $Diagnostic) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join [System.Environment]::NewLine
 
-        $Report | Should -BeNullOrEmpty -Because (
-            "credential autofill did not carry the sign-in through, which usually means Microsoft changed a page this module recognizes by element id. " +
+        # The message is chosen from the evidence rather than assuming the most likely cause, because
+        # this text is what the alert issue tells a maintainer to go and do.
+        #
+        # Issue #79 is why. A console-handle bug in Start-WebView2Login made the sign-in fail in 142
+        # milliseconds, before a browser window existed - and the alert said Microsoft had changed a
+        # page and sent the reader to the selector table. Everything needed to tell those apart had
+        # already been collected: a selector break leaves a diagnostic, and a failure that never
+        # reached Microsoft leaves RedirectHitCount at zero.
+        $Because = if (-not [string]::IsNullOrWhiteSpace($Diagnostic)) {
+            "credential autofill fell back to manual sign-in, so Microsoft changed a page this module recognizes by element id. " +
             "Update `$Script:EntraSignInElementId in OmadaWeb.PS/OmadaWeb.PS.psm1 from the diagnostic above (issue #32)"
-        )
+        }
+        elseif ($Script:RelyingParty.RedirectHitCount -eq 0 -and -not [string]::IsNullOrWhiteSpace($Message)) {
+            "the sign-in failed before the browser ever came back from Microsoft, so this is NOT a selector break and the selector table is not what needs changing. " +
+            "The error above is from this module or from the runner - read it first"
+        }
+        else {
+            "credential autofill did not carry the sign-in through. No fallback diagnostic was captured, so check the error above before assuming the sign-in page changed"
+        }
+
+        $Report | Should -BeNullOrEmpty -Because $Because
     }
 
     It 'Did not report a selector it no longer recognizes' {

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -76,14 +76,22 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
         # A capture that quietly missed it would leave the canary reporting a failure with no reason
         # attached, which is the failure this whole exercise is meant to prevent.
         #
-        # -ForceAuthentication and -SkipCookieCache are what make a scheduled run mean anything: a
-        # cached cookie would satisfy the request without a sign-in page ever being drawn, so the
-        # canary would go green on the strength of yesterday's success.
+        # -SkipCookieCache is what makes a scheduled run mean anything: a cached cookie would satisfy
+        # the request without a sign-in page ever being drawn, so the canary would go green on the
+        # strength of yesterday's success. The authorization request also carries prompt=login, so
+        # the screens are drawn even if a session somehow survived.
+        #
+        # -ForceAuthentication is deliberately NOT used, and that is not a shortcut. It makes
+        # Start-WebView2Login fire ClearBrowsingDataAsync when the browser initializes, and nothing
+        # sequences that clear before the first navigation - the trace of run 33699066012 shows
+        # "Browsing data cleared" arriving after "Navigating to". Clearing cookies underneath a
+        # sign-in already in flight is a good way to produce exactly what that run got back from
+        # Entra: AADSTS50058, "the cookies used to represent the user's session were not sent".
+        # The runner starts from a fresh profile every time, so there is nothing here to clear anyway.
         try {
             $Output = Invoke-OmadaWebRequest -Uri $Script:RelyingParty.ResourceUrl `
                 -AuthenticationType WebView2 `
                 -Credential $Credential `
-                -ForceAuthentication `
                 -SkipCookieCache `
                 -ErrorAction Stop 3>&1
 

--- a/Tests/E2E/Invoke-CanaryAttempt.ps1
+++ b/Tests/E2E/Invoke-CanaryAttempt.ps1
@@ -1,0 +1,83 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Runs one attempt of the Entra sign-in canary and writes its result as JSON.
+.DESCRIPTION
+    The canary workflow runs this in a child process with a deadline rather than calling Invoke-Pester
+    directly, and that is the whole reason it exists as a separate script.
+
+    A browser sign-in has no natural end when nobody is driving it. If the automation hands over to
+    manual - which is exactly what a selector break makes it do - it then waits for a user who does
+    not exist on a runner. The first canary run after the console-handle fix (issue #79) did precisely
+    that: the window opened, the timer ticked for 29 minutes, and the job timeout killed the step. A
+    killed step reports nothing: no assertions, no diagnostic, no alert. The canary was silent about
+    the very failure it exists to catch.
+
+    In-process there is nothing to interrupt, because the WinForms dialog blocks the thread it is
+    shown on. A child process can simply be killed, which turns a hang into a reported failure - and
+    that is the difference between a canary and a job that sometimes times out.
+
+    Verbose is on. The module's own trace is the product when a sign-in stalls: without it, all a
+    stalled run leaves behind is a line of progress dots. Protect-LogMessage covers the module's
+    streams and the workflow masks the four canary secrets before this runs, so this does not widen
+    what is exposed.
+.PARAMETER ModulePath
+    The built OmadaWeb.PS.psm1 the canary signs in with.
+.PARAMETER ResultPath
+    Where the JUnit test result is written.
+.PARAMETER SummaryPath
+    Where the JSON summary the caller reads is written. Absent afterwards means the attempt died
+    without reporting, which the caller treats as a failure rather than as a pass.
+.PARAMETER DiagnosticPath
+    Passed to the test as OMADAWEBPS_CANARY_DIAGNOSTIC_PATH, where Switch-ToManualLogin's diagnostic
+    is written when there is one.
+.EXAMPLE
+    ./Tests/E2E/Invoke-CanaryAttempt.ps1 -ModulePath ./buildoutput/OmadaWeb.PS/OmadaWeb.PS.psm1 `
+        -ResultPath ./buildoutput/CanaryResults-1.xml -SummaryPath $env:RUNNER_TEMP/summary-1.json `
+        -DiagnosticPath $env:RUNNER_TEMP/diagnostic-1.txt
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ModulePath,
+
+    [Parameter(Mandatory)]
+    [string]$ResultPath,
+
+    [Parameter(Mandatory)]
+    [string]$SummaryPath,
+
+    [Parameter(Mandatory)]
+    [string]$DiagnosticPath
+)
+
+$ErrorActionPreference = "Stop"
+$VerbosePreference = "Continue"
+
+$Env:OMADAWEBPS_CANARY_DIAGNOSTIC_PATH = $DiagnosticPath
+
+$Container = New-PesterContainer -Path (Join-Path $PSScriptRoot "EntraSignInCanary.Tests.ps1") -Data @{ ModulePath = $ModulePath }
+
+$Configuration = New-PesterConfiguration
+$Configuration.Run.Container = $Container
+$Configuration.Run.PassThru = $true
+$Configuration.Filter.Tag = "E2E"
+$Configuration.Output.Verbosity = "Detailed"
+$Configuration.TestResult.Enabled = $true
+$Configuration.TestResult.OutputFormat = "JUnitXml"
+$Configuration.TestResult.OutputPath = $ResultPath
+
+$Result = Invoke-Pester -Configuration $Configuration
+
+$Summary = [ordered]@{
+    Failed  = [int]$Result.FailedCount
+    Passed  = [int]$Result.PassedCount
+    Skipped = [int]$Result.SkippedCount
+    Failure = @($Result.Failed | ForEach-Object {
+            $Name = if ([string]::IsNullOrWhiteSpace($_.ExpandedPath)) { $_.Name } else { $_.ExpandedPath }
+            "- {0}: {1}" -f $Name, $_.ErrorRecord.Exception.Message
+        })
+}
+
+$Summary | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $SummaryPath -Encoding UTF8

--- a/Tests/Unit/Get-EntraErrorVerdict.Tests.ps1
+++ b/Tests/Unit/Get-EntraErrorVerdict.Tests.ps1
@@ -26,6 +26,42 @@ Describe 'Get-EntraErrorVerdict' -Tag 'Unit' {
         }
     }
 
+    Context 'The page reporting that it found no session to sign in silently with' {
+        # AADSTS50058 is not a failed sign-in. Entra's page attempts a silent single sign-on when it
+        # loads, and when the browser holds no session it leaves that result in $Config while
+        # rendering the ordinary username prompt underneath. A cold browser profile always sees it -
+        # a first sign-in, a -ForceAuthentication run, and every single run of the scheduled canary,
+        # which is how it was found (issue #79). Treated as an error, it handed the sign-in to a
+        # manual fallback before the username had even been typed.
+        It 'Reports no error for <Description>' -TestCases @(
+            @{ Description = 'the number itself'; ErrorCode = 50058 }
+            @{ Description = 'the number as a string'; ErrorCode = '50058' }
+            @{ Description = 'the AADSTS form'; ErrorCode = 'AADSTS50058' }
+        ) {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ ErrorCode = $ErrorCode } {
+                $Verdict = Get-EntraErrorVerdict -ErrorCode $ErrorCode
+
+                $Verdict.IsError | Should -BeFalse
+                $Verdict.Action | Should -Be 'None'
+                $Verdict.IsTerminal | Should -BeFalse
+            }
+        }
+
+        It 'Does not hand the sign-in to the user over it' {
+            # The point of the fix: the automation carries on and fills the username field that is
+            # sitting on the page, instead of stepping aside from a page it could have driven.
+            InModuleScope 'OmadaWeb.PS' {
+                (Get-EntraErrorVerdict -ErrorCode 'AADSTS50058').Action | Should -Not -Be 'Manual'
+            }
+        }
+
+        It 'Still treats a neighbouring code as an error, so the exemption is not a hole' {
+            InModuleScope 'OmadaWeb.PS' {
+                (Get-EntraErrorVerdict -ErrorCode '50059').IsError | Should -BeTrue
+            }
+        }
+    }
+
     Context 'Failures that a retry cannot turn into a success' {
         # Every one of these ends the sign-in through Stop-OmadaLogin instead of opening another
         # browser window. 50126 is in this group on purpose: resubmitting a credential Entra ID has

--- a/Tests/Unit/Get-WebView2Cookie.Tests.ps1
+++ b/Tests/Unit/Get-WebView2Cookie.Tests.ps1
@@ -1,0 +1,57 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    $Script:Definition = InModuleScope 'OmadaWeb.PS' { (Get-Command Get-WebView2Cookie).Definition }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}
+
+Describe 'Get-WebView2Cookie' -Tag 'Unit' {
+
+    Context 'Counting the cookies that matched' {
+        # The regression guard for issue #79, and it is a guard on the shape of the code rather than
+        # on its behaviour, because this function cannot be called without a live CoreWebView2.
+        #
+        # Where-Object returns the single object itself when exactly one cookie matches, and a bare
+        # object has no Count. Under StrictMode that is a terminating error raised inside an
+        # asynchronous cookie callback, whose catch only writes "Cookie callback error" to the
+        # console - so the authentication cookie is never exported, the sign-in window never closes,
+        # and a sign-in that actually succeeded hangs until something else times it out.
+        #
+        # One matching cookie is the ordinary case for any host that sets only oisauthtoken. The
+        # scheduled canary's loopback stand-in sets exactly that, which is how this was found.
+
+        It 'Wraps the filtered cookies so a single match still has a Count' {
+            $Script:Definition | Should -Match '\$Match\s*=\s*@\('
+        }
+
+        It 'Never reads Count off an unwrapped pipeline result' {
+            # Belt and braces on the line above: if someone unwraps it again, the assertion that the
+            # array subexpression is present would still pass if a second, unwrapped assignment were
+            # introduced.
+            $Script:Definition | Should -Not -Match '\$Match\s*=\s*\$Cookies\s*\|'
+        }
+    }
+
+    Context 'The idiom itself, under the StrictMode the module runs with' {
+        It 'Gives a single filtered item a Count of 1 when wrapped, and none when not' {
+            # Not testing PowerShell for its own sake: this is the exact difference the fix turns on,
+            # and stating it here is what makes the shape assertions above mean something to a reader
+            # who has not met this failure.
+            & {
+                Set-StrictMode -Version Latest
+
+                $Single = @("only-one") | Where-Object { $true }
+                @($Single).Count | Should -Be 1
+                { $Single.Count } | Should -Throw
+            }
+        }
+    }
+}

--- a/Tests/Unit/Test-OmadaConsoleControl.Tests.ps1
+++ b/Tests/Unit/Test-OmadaConsoleControl.Tests.ps1
@@ -1,0 +1,116 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    # A host with no console attached, built deterministically rather than hoped for. The suite is
+    # run both from a real console and from an editor or a CI job, so asserting the no-console
+    # behaviour in-process would assert whichever one the developer happened to have. A child pwsh
+    # whose streams are redirected is the same shape as a GitHub Actions step every time.
+    $Script:ChildScriptFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("OmadaWebConsoleTests_{0}" -f [guid]::NewGuid().ToString("N"))
+    $null = New-Item -ItemType Directory -Force -Path $Script:ChildScriptFolder
+
+    function Invoke-InConsolelessHost {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Body
+        )
+
+        $ScriptPath = Join-Path $Script:ChildScriptFolder ("probe_{0}.ps1" -f [guid]::NewGuid().ToString("N"))
+        $Preamble = @(
+            'Set-StrictMode -Version Latest',
+            ('$Module = Import-Module "{0}" -Force -PassThru -WarningAction SilentlyContinue -ErrorAction Stop' -f $ModulePath)
+        ) -join [System.Environment]::NewLine
+
+        ($Preamble, $Body) -join [System.Environment]::NewLine | Set-Content -LiteralPath $ScriptPath -Encoding UTF8
+
+        # Start-Process with redirected streams, so the child genuinely has no console handle. Running
+        # it through the current host would inherit this process's console and prove nothing.
+        $StdOut = Join-Path $Script:ChildScriptFolder ("out_{0}.txt" -f [guid]::NewGuid().ToString("N"))
+        $StdErr = Join-Path $Script:ChildScriptFolder ("err_{0}.txt" -f [guid]::NewGuid().ToString("N"))
+        $Process = Start-Process -FilePath (Get-Command pwsh.exe).Source `
+            -ArgumentList @("-NoLogo", "-NoProfile", "-File", ('"{0}"' -f $ScriptPath)) `
+            -RedirectStandardOutput $StdOut -RedirectStandardError $StdErr `
+            -NoNewWindow -PassThru -Wait
+
+        return [pscustomobject]@{
+            ExitCode = $Process.ExitCode
+            Output   = (Get-Content -LiteralPath $StdOut -Raw -ErrorAction SilentlyContinue)
+            Error    = (Get-Content -LiteralPath $StdErr -Raw -ErrorAction SilentlyContinue)
+        }
+    }
+}
+
+AfterAll {
+    Remove-Item -LiteralPath $Script:ChildScriptFolder -Recurse -Force -ErrorAction SilentlyContinue
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}
+
+Describe 'Test-OmadaConsoleControl' -Tag 'Unit' {
+
+    It 'Answers with a boolean whatever host it is asked in' {
+        $Result = InModuleScope 'OmadaWeb.PS' { Test-OmadaConsoleControl }
+
+        $Result | Should -BeOfType [System.Boolean]
+    }
+
+    It 'Never throws, which is the whole point of it' {
+        { InModuleScope 'OmadaWeb.PS' { Test-OmadaConsoleControl } } | Should -Not -Throw
+    }
+
+    It 'Agrees with what the console actually allows' {
+        # Not a tautology: it asserts the predicate reports the same thing the guarded call site will
+        # experience a moment later. A probe that answered from something else - a redirection flag,
+        # a cached value - could differ from it, and that difference is the bug.
+        $Expected = $true
+        try {
+            $null = [Console]::TreatControlCAsInput
+        }
+        catch {
+            $Expected = $false
+        }
+
+        InModuleScope 'OmadaWeb.PS' { Test-OmadaConsoleControl } | Should -Be $Expected
+    }
+
+    It 'Reports false in a host that has no console' {
+        # The answer is tagged rather than read off the whole stream: importing the module emits a
+        # WebView2 warning on the way in, so matching the child's entire output would be asserting
+        # against that warning as much as against the result.
+        $Result = Invoke-InConsolelessHost -Body '"RESULT:{0}" -f (& $Module { Test-OmadaConsoleControl }) | Write-Output'
+
+        $Result.Output | Should -Match 'RESULT:False'
+    }
+}
+
+Describe 'Start-WebView2Login without a console' -Tag 'Unit' {
+
+    It 'Does not fail on the console handle before it has even opened a browser' {
+        # The regression test for issue #79, and it discriminates rather than passing by luck.
+        #
+        # The console read used to be the second statement in Start-WebView2Login, ahead of everything
+        # else it does, so in a host with no console it threw "The handle is invalid" before any
+        # browser window existed - and the canary reported that as Microsoft having changed its
+        # sign-in page.
+        #
+        # Called here with no session context, so it still fails: what is asserted is *which* failure.
+        # Without the guard the message is the console one; with it, the function gets past that line
+        # and falls over on something later, which is what this looks for.
+        $Result = Invoke-InConsolelessHost -Body @'
+$Message = ""
+try {
+    & $Module { Start-WebView2Login -EdgeProfile "Default" }
+}
+catch {
+    $Message = $_.Exception.Message
+}
+"CAUGHT: $Message" | Write-Output
+'@
+
+        $Combined = "{0}`n{1}" -f $Result.Output, $Result.Error
+        $Combined | Should -Not -Match 'handle is invalid'
+    }
+}

--- a/Tests/Unit/Test-OmadaConsoleControl.Tests.ps1
+++ b/Tests/Unit/Test-OmadaConsoleControl.Tests.ps1
@@ -61,19 +61,39 @@ Describe 'Test-OmadaConsoleControl' -Tag 'Unit' {
         { InModuleScope 'OmadaWeb.PS' { Test-OmadaConsoleControl } } | Should -Not -Throw
     }
 
-    It 'Agrees with what the console actually allows' {
-        # Not a tautology: it asserts the predicate reports the same thing the guarded call site will
+    It 'Agrees with what the console actually allows, for the write as well as the read' {
+        # Not a tautology: it asserts the predicate reports the same thing the guarded call sites will
         # experience a moment later. A probe that answered from something else - a redirection flag,
         # a cached value - could differ from it, and that difference is the bug.
+        #
+        # The write is exercised too, because Start-WebView2Login does both. A predicate that only
+        # read would leave a host where the read works and the write does not crashing on the write,
+        # with the guard in place and the bug intact.
         $Expected = $true
         try {
-            $null = [Console]::TreatControlCAsInput
+            $Current = [Console]::TreatControlCAsInput
+            [Console]::TreatControlCAsInput = $Current
         }
         catch {
             $Expected = $false
         }
 
         InModuleScope 'OmadaWeb.PS' { Test-OmadaConsoleControl } | Should -Be $Expected
+    }
+
+    It 'Leaves the console setting exactly as it found it' {
+        # The probe writes, so it has to write back what was there. A predicate that turned Ctrl+C
+        # into input as a side effect of being asked a question would break the caller's session in a
+        # way nothing here would notice.
+        if (-not (InModuleScope 'OmadaWeb.PS' { Test-OmadaConsoleControl })) {
+            Set-ItResult -Skipped -Because "this host has no console to observe"
+            return
+        }
+
+        $Before = [Console]::TreatControlCAsInput
+        $null = InModuleScope 'OmadaWeb.PS' { Test-OmadaConsoleControl }
+
+        [Console]::TreatControlCAsInput | Should -Be $Before
     }
 
     It 'Reports false in a host that has no console' {

--- a/docs/entra-canary.md
+++ b/docs/entra-canary.md
@@ -200,12 +200,21 @@ through a second literal replacement of all four values, because that text is ab
 
 1. **Read the diagnostic in the issue.** It is what `Switch-ToManualLogin` emitted, and it names the
    state, the elements that were expected but absent, the ones that were present, and the page path.
-2. **Decide which failure it is.** The canary asserts several things separately, on purpose:
-   - *"Signed in with the credential, without falling back to manual entry"* failed → a selector
-     broke. This is the one the canary exists for. Note that it rests on whether the sign-in actually
-     completed rather than on catching the warning: nobody is at this browser, so if autofill stops
-     filling fields the sign-in simply never finishes. The diagnostic enriches that verdict; it does
-     not carry it.
+2. **Decide which failure it is.** The canary asserts several things separately, on purpose. Read
+   them together — the combination is what names the cause, and no single one of them means
+   "Microsoft changed the sign-in page" on its own:
+   - *"Signed in with the credential, without falling back to manual entry"* failed **and a
+     `Switch-ToManualLogin` diagnostic is in the report** → a selector broke. This is the one the
+     canary exists for. Note that the assertion rests on whether the sign-in actually completed
+     rather than on catching the warning: nobody is at this browser, so if autofill stops filling
+     fields the sign-in simply never finishes. The diagnostic enriches that verdict; it does not
+     carry it.
+   - The same assertion failed **with no diagnostic, and "Actually travelled through Entra and back"
+     failed with 0** → the sign-in never reached Microsoft, so the selector table is ruled out
+     entirely. Read the error text. Issue #79 was exactly this: a console-handle bug in
+     `Start-WebView2Login` failed the sign-in in 142 ms, before a browser window existed, and the
+     alert nonetheless sent its reader to the selector table. Both the assertion message and the
+     alert body now decide their wording from the evidence instead.
    - *"Did not report a selector it no longer recognizes"* failed on its own → the sign-in completed
      but the module still reported a page it did not recognise. Worth reading: something changed that
      the automation recovered from.


### PR DESCRIPTION
Closes #79

## The canary went red on its first real run, and it was right to

It filed #79 saying Microsoft had changed a sign-in screen. That was wrong — but the run was not. Driving the sign-in to green uncovered **four** separate defects, three of them in the module and affecting real users, not just CI.

**The canary is now green end to end against a real tenant** — [run 33807735484](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/33807735484), all six assertions passing.

## What was broken

### 1. `-AuthenticationType WebView2` was broken for every non-interactive caller

`Start-WebView2Login.ps1:13` read `[Console]::TreatControlCAsInput` as its second statement. Both the getter and the setter throw `IOException: The handle is invalid.` when the process has no console on stdin — a scheduled task, a Windows service, a CI job, a piped script. Reproduced directly:

```
stdin redirected : True
GET TreatControlCAsInput THREW -> IOException: The handle is invalid.
SET TreatControlCAsInput THREW -> ... "The handle is invalid."
```

It sat ahead of everything else, so the sign-in died in 142 ms before a browser window existed. `Test-OmadaConsoleControl` now guards all three sites, probing the **write as well as the read** (they are separate operations on the handle).

### 2. A cold browser was treated as a failed sign-in

`AADSTS50058` is not a failure. It is Entra's page reporting that it looked for an existing session to sign in silently with and found none — the ordinary state of a browser that has never signed in. The page attempts that check on load and renders the perfectly usable username prompt underneath it.

`Get-EntraErrorVerdict` had no entry for it, so it fell to the catch-all and came back `Manual`. Since an error code outranks every other rule, **autofill stepped aside before the username was ever typed** — on a page it could have driven. Every cold profile hits this: a first sign-in, any `-ForceAuthentication` run, and every run of the canary.

Same family and same lesson as the `1600x` codes added for #76.

### 3. The authentication cookie was dropped when exactly one cookie matched

`Get-WebView2Cookie` filtered with `Where-Object` and then read `$Match.Count`. `Where-Object` returns the single object itself when one item matches, and a bare object has no `Count`. Under StrictMode that is a terminating error inside an asynchronous callback whose `catch` writes only `Cookie callback error` to the console — so the cookie is never exported, the window never closes, and **a sign-in that actually succeeded hangs**. Same bug class as #68.

One matching cookie is the ordinary case for any host that sets only `oisauthtoken`.

### 4. `-DisableSecurityDefaults` was silently ignored

In `New-EntraCanaryConfiguration.ps1`, security defaults were read inside the Conditional Access branch, so `-SkipConditionalAccess` skipped them — accepting a flag it then did nothing with, and hiding the single most likely reason a canary account cannot sign in. They are now read on every run.

## The canary itself

- **It blamed the wrong thing.** A selector break leaves a `Switch-ToManualLogin` diagnostic; a failure that never reached Microsoft leaves `RedirectHitCount` at 0. Both signals were already collected and simply not read. The assertion message and the alert body now choose their wording from the evidence.
- **It could not report a stall at all.** The job timeout killed it, and a killed step produces no assertions, no diagnostic, no alert — it was silent about exactly the failure it exists to catch. Each attempt now runs in a child process with a 300 s deadline, and a timed-out attempt reports the last page the automation named.
- **The trace said too little.** The module's decision trace now carries the error code and reason alongside the screen. That is what turned `Screen 'SignInError'` into `code 'AADSTS50058'` and made #2 findable at all.
- **`AllowUnencryptedAuthentication`** — the stand-in serves plain HTTP on loopback and PowerShell 7 will not send a credential over it unguarded. The repo's integration tests already do this; the canary didn't.

## Decisions worth reviewing

- **The console predicate probes rather than reading `IsInputRedirected`.** Redirection is the common reason a console cannot be driven, not the only one, and a predicate that is right about the usual case moves the crash somewhere harder to find. Costs one property read per sign-in.
- **`AADSTS50058` is answered as "no error to act on", not added to the manual list.** The right response is to carry on: the rules that follow read the elements actually on the page. Nothing is trapped by that — a genuinely unusable page still ends in `Switch-ToManualLogin` when the stall timer expires.
- **The `Get-WebView2Cookie` regression guard is a shape assertion, and says so.** That function cannot be called without a live `CoreWebView2`. It asserts the filter is array-wrapped and that no unwrapped assignment creeps back.
- **One thing deliberately left alone.** `-ForceAuthentication` fires `ClearBrowsingDataAsync`, and nothing sequences that clear before the first navigation — the trace shows it completing *after*. I removed `-ForceAuthentication` from the canary as a hypothesis test; it was **not** the cause (same error without it), so I left the module ordering alone. It is a real latent race and deserves its own issue rather than a drive-by fix here.

## Verification

Run as CI runs it (`GITHUB_ACTIONS=true`, so the integration tests mock the browser login exactly as PR Validation does):

| | Total | Failed |
|---|---|---|
| `origin/main` (`bc0c16a`), built in a throwaway worktree | 813 | **0** |
| this branch | 827 | **0** |

**The console regression test discriminates**: against unpatched `origin/main` it fails with `Expected regular expression 'handle is invalid' to not match …`, so it detects this bug rather than passing by coincidence. It uses a child `pwsh` with redirected streams — a no-console host regardless of how a developer runs the suite.

**End to end against the real tenant** — [run 33807735484](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/33807735484):

```
[+] Signed in with the credential, without falling back to manual entry
[+] Did not report a selector it no longer recognizes
[+] Was not refused by Entra ID
[+] Actually travelled through Entra and back
[+] Returned the protected resource
[+] Kept the loopback stand-in healthy throughout
```

The browser-host check also passes on a GitHub-hosted runner ([33682417182](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/33682417182)), so that assumption from #73 is now verified too.
