### PR TITLE
Name the account, the tenant and the application a cross-tenant refusal is about

### DIFF
--- a/OmadaWeb.PS/Private/Get-EntraTenantMismatchDetail.ps1
+++ b/OmadaWeb.PS/Private/Get-EntraTenantMismatchDetail.ps1
@@ -1,0 +1,144 @@
+function Get-EntraTenantMismatchDetail {
+    <#
+    .SYNOPSIS
+        Reads the identifiers Entra ID names when it refuses a sign-in from another tenant.
+
+    .DESCRIPTION
+        A federated sign-in that fails because the account belongs to a different tenant than the
+        application comes back through Omada's logon page as one long sentence:
+
+            OpenIdConnectMessage.Error was not null, indicating an error. Error: 'invalid_request'.
+            Error_Description (may be empty): 'AADSTS50178: User account '{EUII Hidden}' from
+            identity provider 'https://sts.windows.net/<tenant id>/' does not exist in tenant
+            '<tenant name>' and cannot access the application '<application id>'(<application name>)
+            in that tenant. ... Trace ID: <guid> Correlation ID: <guid> Timestamp: <utc>'
+
+        Everything a person needs in order to act on it is in there, and none of it is where they
+        can see it: the tenant the account came from, the tenant and application it was refused by,
+        and the correlation ID that finds the attempt in the sign-in logs. This function lifts those
+        out so the refusal can be reported as facts instead of as one wall of quoted text.
+
+        WHAT IT CANNOT RECOVER
+
+        The account name. Entra deliberately replaces it with the literal '{EUII Hidden}', because
+        the sentence is rendered by the application and end-user identifiable information does not
+        belong there. AccountNameWithheld records that this happened, so the caller can say the name
+        is withheld by Entra rather than leave a reader hunting for a name that was never sent - and
+        point at the correlation ID, which is how the account is looked up in the tenant that
+        refused it.
+
+        WHY THE PATTERNS ARE LOOSE
+
+        The numbers and identifiers are stable across languages, the sentence around them is not, and
+        neither is the shape of what Entra quotes. The tenant identifier is taken as the last
+        identifier-shaped segment of the issuer URL rather than as a strict GUID, because the same
+        clause carries a v2.0 issuer ('.../<tenant id>/v2.0') as well as the classic one, and because
+        a value that does not parse as a GUID is still worth reporting. Anything that cannot be found
+        is left null rather than guessed at, and HasDetail says whether anything was found at all.
+
+    .PARAMETER Message
+        The error text read off the Omada logon page.
+
+    .OUTPUTS
+        PSCustomObject with the members HasDetail, AccountTenantId, ResourceTenant, ApplicationId,
+        ApplicationName, TraceId, CorrelationId, Timestamp and AccountNameWithheld.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    param(
+        [Parameter(Position = 0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    $Detail = [pscustomobject]@{
+        HasDetail           = $false
+        AccountTenantId     = $null
+        ResourceTenant      = $null
+        ApplicationId       = $null
+        ApplicationName     = $null
+        TraceId             = $null
+        CorrelationId       = $null
+        Timestamp           = $null
+        AccountNameWithheld = $false
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Message)) {
+        return $Detail
+    }
+
+    # The page text arrives with the line breaks and indentation of the markup around it, exactly as
+    # Test-OmadaLogonPageError receives it, so the patterns below can assume single spaces.
+    $Text = ($Message -replace '\s+', ' ').Trim()
+
+    # The issuer of the account's own tenant. Quoted as a URL, so the identifier is the last segment
+    # that looks like one - which is the tenant id for both 'https://sts.windows.net/<id>/' and
+    # 'https://login.microsoftonline.com/<id>/v2.0'.
+    $IssuerMatch = [regex]::Match($Text, "(?i)identity provider\s+'([^']+)'")
+    if ($IssuerMatch.Success) {
+        $Segment = @($IssuerMatch.Groups[1].Value -split '/' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $Identifier = @($Segment | Where-Object { $_ -match '^[0-9a-fA-F][0-9a-fA-F-]{7,}$' })
+        if ($Identifier.Count -gt 0) {
+            $Detail.AccountTenantId = $Identifier[-1]
+        }
+        elseif ($Segment.Count -gt 0) {
+            $Detail.AccountTenantId = $Segment[-1]
+        }
+    }
+
+    $TenantMatch = [regex]::Match($Text, "(?i)does not exist in tenant\s+'([^']*)'")
+    if ($TenantMatch.Success -and -not [string]::IsNullOrWhiteSpace($TenantMatch.Groups[1].Value)) {
+        $Detail.ResourceTenant = $TenantMatch.Groups[1].Value
+    }
+
+    # The application is quoted as '<id>'(<display name>), and the display name is free text that
+    # routinely contains brackets of its own - "Contoso (Omada)" is the shape this was written
+    # against. Closing on the ')' that precedes 'in that tenant' therefore keeps the whole name; the
+    # fallback exists for a sentence in another language, where the trailing clause reads
+    # differently but the brackets do not move.
+    $ApplicationMatch = [regex]::Match($Text, "(?i)application\s+'([^']+)'\s*\((.+?)\)\s*in that tenant")
+    if (-not $ApplicationMatch.Success) {
+        $ApplicationMatch = [regex]::Match($Text, "(?i)application\s+'([^']+)'\s*\(([^)]*)\)")
+    }
+    if (-not $ApplicationMatch.Success) {
+        $ApplicationMatch = [regex]::Match($Text, "(?i)application\s+'([^']+)'")
+    }
+    if ($ApplicationMatch.Success) {
+        $Detail.ApplicationId = $ApplicationMatch.Groups[1].Value
+        if ($ApplicationMatch.Groups.Count -gt 2 -and -not [string]::IsNullOrWhiteSpace($ApplicationMatch.Groups[2].Value)) {
+            $Detail.ApplicationName = $ApplicationMatch.Groups[2].Value.Trim()
+        }
+    }
+
+    $TraceMatch = [regex]::Match($Text, "(?i)Trace ID:\s*([^\s']+)")
+    if ($TraceMatch.Success) {
+        $Detail.TraceId = $TraceMatch.Groups[1].Value
+    }
+
+    $CorrelationMatch = [regex]::Match($Text, "(?i)Correlation ID:\s*([^\s']+)")
+    if ($CorrelationMatch.Success) {
+        $Detail.CorrelationId = $CorrelationMatch.Groups[1].Value
+    }
+
+    # Reported as Entra wrote it - it is UTC, and re-formatting it would only invite a reader to
+    # compare it against a local clock.
+    $TimestampMatch = [regex]::Match($Text, "(?i)Timestamp:\s*(\d{4}-\d{2}-\d{2}[ T][\d:.]+Z?)")
+    if ($TimestampMatch.Success) {
+        $Detail.Timestamp = $TimestampMatch.Groups[1].Value.Trim()
+    }
+
+    $Detail.AccountNameWithheld = $Text -match '(?i)\{EUII Hidden\}'
+
+    # A plain loop rather than a pipeline: HasDetail is a boolean the callers branch on, and a
+    # pipeline that filters to nothing yields $null instead of $false - which is the difference
+    # between "no detail" and a terminating error under StrictMode.
+    foreach ($Value in @($Detail.AccountTenantId, $Detail.ResourceTenant, $Detail.ApplicationId, $Detail.TraceId, $Detail.CorrelationId)) {
+        if (-not [string]::IsNullOrWhiteSpace($Value)) {
+            $Detail.HasDetail = $true
+            break
+        }
+    }
+
+    return $Detail
+}

--- a/OmadaWeb.PS/Private/Get-WebDriverLogonPageError.ps1
+++ b/OmadaWeb.PS/Private/Get-WebDriverLogonPageError.ps1
@@ -82,7 +82,7 @@ function Get-WebDriverLogonPageError {
 
     "Get-WebDriverLogonPageError - Terminal logon page error found in '{0}'" -f $Verdict.Source | Write-Verbose
 
-    Stop-OmadaLogin -Message $Verdict.Message -Code $Verdict.Code -Reason $Verdict.Reason -Url $PageUrl -Engine "EdgeWebDriver" | Out-Null
+    Stop-OmadaLogin -Message $Verdict.Message -Code $Verdict.Code -Reason $Verdict.Reason -Url $PageUrl -Engine "EdgeWebDriver" -Category $Verdict.Category | Out-Null
 
     return $true
 }

--- a/OmadaWeb.PS/Private/Get-WebView2LogonPageError.ps1
+++ b/OmadaWeb.PS/Private/Get-WebView2LogonPageError.ps1
@@ -108,7 +108,7 @@ function Get-WebView2LogonPageError {
 
     "Get-WebView2LogonPageError - Terminal logon page error found in '{0}'" -f $Verdict.Source | Write-Verbose
 
-    Stop-OmadaLogin -Message $Verdict.Message -Code $Verdict.Code -Reason $Verdict.Reason -Url $PageUrl -Engine "WebView2" | Out-Null
+    Stop-OmadaLogin -Message $Verdict.Message -Code $Verdict.Code -Reason $Verdict.Reason -Url $PageUrl -Engine "WebView2" -Category $Verdict.Category | Out-Null
 
     # The watchdog counters belong to the window that is closing, not to the next one.
     $Script:OmadaWatchdogStart = $null

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -293,7 +293,25 @@ $(Get-EntraElementVisibilityScript)
                         $ScenarioName = $Decision.Screen
                     }
 
-                    Switch-ToManualLogin -State ("Deciding/{0}" -f $ScenarioName) -MissingElementId $MissingElementId -FoundElementId $Present -Url $Script:WebView2.Source.AbsoluteUri -Reason $Decision.Reason | Out-Null
+                    # Two very different things reach this line. Usually the page matched nothing and
+                    # the markup is the suspect, which is what the default cause says. But a screen
+                    # that was recognized and answered with "wait" is not a stall at all: it asks for
+                    # something the caller never supplied - a password left out of the credential, a
+                    # code that exists only on the user's phone - and it will keep asking until the
+                    # person types it. Reporting that as a changed sign-in page blamed Microsoft for a
+                    # sign-in working exactly as designed, and sent the user to the issue tracker to
+                    # report their own password prompt.
+                    #
+                    # The screens are named rather than derived from the action, because 'Wait' is
+                    # also the value a decision carries when nothing matched at all.
+                    $Cause = "UnrecognizedScreen"
+                    $StallMissingElementId = $MissingElementId
+                    if ($Decision.Action -eq "Wait" -and $Decision.Screen -in @("PasswordRequired", "OneTimeCode")) {
+                        $Cause = "WaitingForUserInput"
+                        $StallMissingElementId = @()
+                    }
+
+                    Switch-ToManualLogin -State ("Deciding/{0}" -f $ScenarioName) -MissingElementId $StallMissingElementId -FoundElementId $Present -Url $Script:WebView2.Source.AbsoluteUri -Reason $Decision.Reason -Cause $Cause | Out-Null
                     return $false
                 }
 

--- a/OmadaWeb.PS/Private/Stop-OmadaLogin.ps1
+++ b/OmadaWeb.PS/Private/Stop-OmadaLogin.ps1
@@ -41,6 +41,11 @@ function Stop-OmadaLogin {
     .PARAMETER Engine
         Which login driver hit this, for the diagnostic.
 
+    .PARAMETER Category
+        What kind of refusal this is, from Test-OmadaLogonPageError. It selects the closing advice
+        and is recorded on $Script:LoginAbortReason, where the WebView2 driver reads it to decide
+        whether offering the user another account could get past this.
+
     .OUTPUTS
         System.Boolean. True when this call recorded the refusal, false when one was already
         recorded for this sign-in.
@@ -64,7 +69,10 @@ function Stop-OmadaLogin {
         [string]$Url,
 
         [ValidateSet("WebView2", "EdgeWebDriver")]
-        [string]$Engine = "WebView2"
+        [string]$Engine = "WebView2",
+
+        [ValidateSet("WrongAccount", "Authorization", "AppRegistration", "IdentityProvider", "Unknown", "None")]
+        [string]$Category = "Unknown"
     )
 
     if ($null -ne $Script:LoginAbortReason) {
@@ -87,12 +95,19 @@ function Stop-OmadaLogin {
 
     $SafeMessage = Protect-LogMessage -Message $Message
 
+    # The identifiers Entra names in a cross-tenant refusal, lifted out of the sentence so they can
+    # be reported as facts. Nothing is invented when they are absent: Detail.HasDetail is false and
+    # not a line of this is printed.
+    $Detail = Get-EntraTenantMismatchDetail -Message $Message
+
     $Script:LoginAbortReason = [pscustomobject]@{
-        Message = $SafeMessage
-        Code    = $Code
-        Reason  = $Reason
-        Url     = $PageAddress
-        Engine  = $Engine
+        Message  = $SafeMessage
+        Code     = $Code
+        Reason   = $Reason
+        Url      = $PageAddress
+        Engine   = $Engine
+        Category = $Category
+        Detail   = $Detail
     }
 
     # Autofill has nothing left to do on a sign-in that is over, and leaving it armed would let the
@@ -113,7 +128,55 @@ function Stop-OmadaLogin {
     if (-not [string]::IsNullOrWhiteSpace($Reason)) {
         $Lines.Add("  Meaning    : {0}" -f $Reason)
     }
-    $Lines.Add("Opening the sign-in window again would land on this same page, so no further attempts are made. Resolve this with the account or the application registration - for example by signing in with an account from the application's own tenant - and then retry, using -ForceAuthentication to start from a clean sign-in.")
+
+    # Everything below is quoted straight out of the page's own error text, which the drivers only
+    # ever read off login pages, so there is no secret here to redact - and every line of it is
+    # something the reader has to type into a portal search box to get any further.
+    if ($Detail.HasDetail) {
+        if (-not [string]::IsNullOrWhiteSpace($Detail.AccountTenantId)) {
+            $Lines.Add("  Account in : tenant {0}" -f $Detail.AccountTenantId)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($Detail.ResourceTenant)) {
+            $Lines.Add("  Needed in  : tenant '{0}'" -f $Detail.ResourceTenant)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($Detail.ApplicationId)) {
+            $Application = $Detail.ApplicationId
+            if (-not [string]::IsNullOrWhiteSpace($Detail.ApplicationName)) {
+                $Application = "{0} ({1})" -f $Detail.ApplicationName, $Detail.ApplicationId
+            }
+            $Lines.Add("  Application: {0}" -f $Application)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($Detail.CorrelationId)) {
+            $Lines.Add("  Correlation: {0}" -f $Detail.CorrelationId)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($Detail.TraceId)) {
+            # Not the identifier the sign-in logs are searched by - that is the correlation id above -
+            # but the one Microsoft support asks for, and it costs a line to keep both together.
+            $Lines.Add("  Trace      : {0}" -f $Detail.TraceId)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($Detail.Timestamp)) {
+            $Lines.Add("  Timestamp  : {0}" -f $Detail.Timestamp)
+        }
+    }
+
+    if ($Category -eq "WrongAccount") {
+        # The one refusal where the remedy is the user's to apply, so it is spelled out instead of
+        # being left as "resolve this with the account or the application registration".
+        $TenantName = "the application's tenant"
+        if (-not [string]::IsNullOrWhiteSpace($Detail.ResourceTenant)) {
+            $TenantName = "tenant '{0}'" -f $Detail.ResourceTenant
+        }
+
+        $Lines.Add("This account cannot be used for this application however often the sign-in is repeated, so no further attempts are made. Sign in with an account of {0}, or have this account invited into it as a guest, and try again." -f $TenantName)
+
+        if ($Detail.AccountNameWithheld) {
+            # Saying this out loud saves the next reader from looking for a name that was never sent.
+            $Lines.Add("Entra ID withholds the account name from this message because it identifies an end user. Look the attempt up by its correlation ID in the sign-in logs of the tenant that refused it to see which account was used.")
+        }
+    }
+    else {
+        $Lines.Add("Opening the sign-in window again would land on this same page, so no further attempts are made. Resolve this with the account or the application registration - for example by signing in with an account from the application's own tenant - and then retry, using -ForceAuthentication to start from a clean sign-in.")
+    }
 
     ($Lines -join [System.Environment]::NewLine) | Write-Warning
 

--- a/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
+++ b/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
@@ -16,8 +16,8 @@ function Switch-ToManualLogin {
         browser is on - the three things needed to fix the selector table afterwards.
 
         Not every handover is a selector break, though, and saying so when it is not is worse than
-        saying nothing. -Cause names which of three things happened, and only the wording follows
-        from it - the switch itself is made the same way in all three cases:
+        saying nothing. -Cause names which of the four cases below happened, and only the wording
+        follows from it - the switch itself is made the same way in every one of them:
 
           - UnrecognizedScreen. The page matched no known sign-in step. This is the case the
             function was written for: the markup is the suspect, the missing selectors are the

--- a/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
+++ b/OmadaWeb.PS/Private/Switch-ToManualLogin.ps1
@@ -30,6 +30,12 @@ function Switch-ToManualLogin {
             the user's behalf, such as a request to pick an account. Nothing is broken, nothing is
             missing, and asking for a bug report would send a user to the issue tracker for a
             normal day at work (issue #76).
+          - WaitingForUserInput. The page was recognized, the automation read it correctly, and what
+            it asks for is something the caller never supplied - a password that was not part of the
+            credential, or a one-time code that only exists on the user's device. The sign-in is not
+            stuck: it is waiting for the person the window is open in front of. Nothing is missing,
+            nothing changed, and the handover exists only to stop the automation from polling a page
+            it has nothing left to do on.
 
         Only the path of the page URL is reported. Sign-in URLs carry client_id, state and nonce
         query parameters, and this text is written to a stream that users routinely capture into
@@ -52,7 +58,7 @@ function Switch-ToManualLogin {
         [AllowNull()]
         [string]$Reason,
 
-        [ValidateSet("UnrecognizedScreen", "UnrecognizedCode", "RecognizedCondition")]
+        [ValidateSet("UnrecognizedScreen", "UnrecognizedCode", "RecognizedCondition", "WaitingForUserInput")]
         [string]$Cause = "UnrecognizedScreen"
     )
 
@@ -91,8 +97,24 @@ function Switch-ToManualLogin {
         $MissingText = "unknown"
     }
 
+    # A page the automation understood perfectly has no missing selector to report, and naming one
+    # would send the next reader looking for a break that did not happen.
+    if ($Cause -eq "WaitingForUserInput") {
+        $MissingText = $null
+    }
+
     $Lines = [System.Collections.Generic.List[string]]::new()
-    $Lines.Add("Automated Microsoft sign-in could not continue - handing control back to you.")
+
+    # The opening line is the one a user reads first, and "could not continue" is a failure report.
+    # It is the truth for a page that matched nothing; it is not the truth for a page that is simply
+    # waiting for a password. Both keep the same prefix, because that prefix is what the sign-in
+    # canary and every support log search for.
+    if ($Cause -eq "WaitingForUserInput") {
+        $Lines.Add("Automated Microsoft sign-in is waiting for you - handing control back to you.")
+    }
+    else {
+        $Lines.Add("Automated Microsoft sign-in could not continue - handing control back to you.")
+    }
     $Lines.Add("  State            : {0}" -f $State)
     if (-not [string]::IsNullOrWhiteSpace($MissingText)) {
         $Lines.Add("  Missing elements : {0}" -f $MissingText)
@@ -114,6 +136,13 @@ function Switch-ToManualLogin {
             # had changed would be false, and asking for a bug report would be asking a user to
             # report a sign-in working as designed.
             $Lines.Add("Entra ID asked for something that only you can do. Please sign in yourself in the browser window that is open - nothing about the page is broken, and there is nothing to report.")
+        }
+
+        "WaitingForUserInput" {
+            # The sign-in is not broken and the automation is not lost: what is missing is an input
+            # only the user has. Saying anything about selectors here would be false, and asking for
+            # a bug report would be asking somebody to report having to type their own password.
+            $Lines.Add("Entra ID is asking for something that was not supplied to this command - a password, or a verification code from your device. Please complete the sign-in yourself in the browser window that is open; it stays open and waits for you. Nothing is broken and there is nothing to report.")
         }
 
         "UnrecognizedCode" {

--- a/OmadaWeb.PS/Private/Test-OmadaLogonPageError.ps1
+++ b/OmadaWeb.PS/Private/Test-OmadaLogonPageError.ps1
@@ -30,6 +30,15 @@ function Test-OmadaLogonPageError {
             deliberately limited to a sign-in page: an error on an ordinary Omada page says nothing
             about a sign-in that may still be in progress, so there only the first rule applies.
 
+        A terminal error is also classified, because "this will never work" and "this will never work
+        with this account" are not the same message and do not deserve the same answer. Category is
+        one of WrongAccount, Authorization, AppRegistration, IdentityProvider, Unknown or None, and
+        Recoverable is true for exactly one of them: WrongAccount, where the account signing in is
+        simply not an account of the application's tenant and signing in as somebody else is the
+        whole fix. Nothing in this function acts on that - it is the caller that decides whether to
+        offer the user another go - but the classification is written here because this is where the
+        evidence is.
+
     .PARAMETER Message
         The error text read off the page. An empty value means no error was shown.
 
@@ -44,8 +53,8 @@ function Test-OmadaLogonPageError {
         about the sign-in rather than about the application.
 
     .OUTPUTS
-        PSCustomObject with the members IsError, IsFatal, Message, Code, Reason and Source. IsError
-        is false when the page shows no error at all.
+        PSCustomObject with the members IsError, IsFatal, Message, Code, Reason, Source, Category and
+        Recoverable. IsError is false when the page shows no error at all.
     #>
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSCustomObject])]
@@ -65,12 +74,14 @@ function Test-OmadaLogonPageError {
     )
 
     $Verdict = [pscustomobject]@{
-        IsError = $false
-        IsFatal = $false
-        Message = $null
-        Code    = $null
-        Reason  = $null
-        Source  = $Source
+        IsError     = $false
+        IsFatal     = $false
+        Message     = $null
+        Code        = $null
+        Reason      = $null
+        Source      = $Source
+        Category    = "None"
+        Recoverable = $false
     }
 
     if ([string]::IsNullOrWhiteSpace($Message)) {
@@ -100,27 +111,39 @@ function Test-OmadaLogonPageError {
     # to do next than the AADSTS number it is quoted with.
     # PowerShell's -match is case-insensitive, which is what these are matched with below.
     $FatalSignature = [ordered]@{
-        'does not exist in tenant'                                           = "The account that signed in is not known in the tenant the Omada application is registered in."
-        'needs to be added as an external user'                              = "The account that signed in has to be invited into the application's tenant as a guest first."
-        'cannot access the application'                                      = "The account that signed in is not permitted to use the Omada application."
-        '\bconsent_required\b|\bAADSTS65001\b|\bAADSTS90094\b'               = "The application needs consent that this account cannot grant."
-        '\baccess_denied\b'                                                  = "The identity provider denied the sign-in."
-        '\b(invalid_client|unauthorized_client|unsupported_response_type)\b' = "The identity provider rejected the application registration behind this sign-in."
-        '\binvalid_request\b'                                                = "The identity provider rejected the sign-in request."
-        'OpenIdConnectMessage\.Error'                                        = "The identity provider returned an error instead of a token."
-        '\bAADSTS\d{3,}\b'                                                   = "Microsoft Entra ID refused the sign-in."
+        'does not exist in tenant'                                           = @{ Category = "WrongAccount"; Reason = "The account that signed in is not known in the tenant the Omada application is registered in." }
+        'needs to be added as an external user'                              = @{ Category = "WrongAccount"; Reason = "The account that signed in has to be invited into the application's tenant as a guest first." }
+        # The codes for the same condition, matched after the English sentences and before anything
+        # more general: a sign-in page served in another language carries the number and not the
+        # words, and reporting that as a refusal nobody can act on would lose the one remedy that
+        # works. AADSTS50020 and AADSTS50178 are both emitted for an account of another tenant, and
+        # AADSTS51004 is the same fact stated from the directory's side.
+        '\bAADSTS(50020|50178|51004)\b'                                      = @{ Category = "WrongAccount"; Reason = "The account that signed in is not known in the tenant the Omada application is registered in." }
+        'cannot access the application'                                      = @{ Category = "Authorization"; Reason = "The account that signed in is not permitted to use the Omada application." }
+        '\bconsent_required\b|\bAADSTS65001\b|\bAADSTS90094\b'               = @{ Category = "AppRegistration"; Reason = "The application needs consent that this account cannot grant." }
+        '\baccess_denied\b'                                                  = @{ Category = "IdentityProvider"; Reason = "The identity provider denied the sign-in." }
+        '\b(invalid_client|unauthorized_client|unsupported_response_type)\b' = @{ Category = "AppRegistration"; Reason = "The identity provider rejected the application registration behind this sign-in." }
+        '\binvalid_request\b'                                                = @{ Category = "IdentityProvider"; Reason = "The identity provider rejected the sign-in request." }
+        'OpenIdConnectMessage\.Error'                                        = @{ Category = "IdentityProvider"; Reason = "The identity provider returned an error instead of a token." }
+        '\bAADSTS\d{3,}\b'                                                   = @{ Category = "IdentityProvider"; Reason = "Microsoft Entra ID refused the sign-in." }
     }
 
     foreach ($Signature in $FatalSignature.Keys) {
         if ($Text -match $Signature) {
             $Verdict.IsFatal = $true
-            $Verdict.Reason = $FatalSignature[$Signature]
+            $Verdict.Reason = $FatalSignature[$Signature].Reason
+            $Verdict.Category = $FatalSignature[$Signature].Category
+
+            # The one category a second sign-in can get past. Everything else answers every account
+            # the same way, so re-opening a window for it would only spend the user's time.
+            $Verdict.Recoverable = $Verdict.Category -eq "WrongAccount"
             return $Verdict
         }
     }
 
     if ($OnLogonPage -and -not $HasLogonForm) {
         $Verdict.IsFatal = $true
+        $Verdict.Category = "Unknown"
         $Verdict.Reason = "The logon page reports an error and offers no way to sign in again, so a new browser window would land on the same page."
         return $Verdict
     }

--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ The warning names the state, the elements that were expected but absent, and the
 
 The module waits 60 seconds without progress before it gives up on autofill, so a slow round trip to Microsoft is not mistaken for a changed page. Waiting for you to approve a sign-in request in your authenticator app does not count against that.
 
+A page that asks for something the command was never given is not a changed page, and is not reported as one. A `-Credential` that carries a user name but no password is a normal way to use the module: the user name is filled in, an empty password is never submitted, and when Entra insists on a password anyway the module says so and leaves the window open for you.
+
+```text
+WARNING: Automated Microsoft sign-in is waiting for you - handing control back to you.
+  State            : Deciding/PasswordRequired
+  Page URL         : https://login.microsoftonline.com/common/login
+  Reason           : The credential has no password and this page offers no way to sign in without one.
+Entra ID is asking for something that was not supplied to this command - a password, or a verification code from your device. Please complete the sign-in yourself in the browser window that is open; it stays open and waits for you. Nothing is broken and there is nothing to report.
+```
+
+No selector is named there, and no bug report is asked for, because nothing about the page is broken.
+
 You should not normally be the one to find out. A scheduled job signs in to Entra ID once a day in a real browser and opens an issue when autofill stops recognising a screen, so a change on Microsoft's side is usually already known - and often already fixed - by the time you meet it. See [the Entra sign-in canary](docs/entra-canary.md).
 
 ### When Omada refuses the sign-in
@@ -260,10 +272,18 @@ WARNING: Sign-in was refused and will not be retried.
   Engine     : WebView2
   Message    : AADSTS50178: User account '...' from identity provider '...' does not exist in tenant 'Example' and cannot access the application '...' in that tenant. The account needs to be added as an external user in the tenant first.
   Meaning    : The account that signed in is not known in the tenant the Omada application is registered in.
-Opening the sign-in window again would land on this same page, so no further attempts are made. ...
+  Account in : tenant be4c52b6-1a23-493e-a8ce-f36325d16462
+  Needed in  : tenant 'Example'
+  Application: example.com (Omada) (a1880835-5fff-4d48-b926-44471e6f3c6c)
+  Correlation: 53b30bf1-f9c9-4ad1-8bba-5442011f3a7c
+  Trace      : c5936087-19ec-4f9d-bbfa-9202d9218900
+This account cannot be used for this application however often the sign-in is repeated, so no further attempts are made. Sign in with an account of tenant 'Example', or have this account invited into it as a guest, and try again.
+Entra ID withholds the account name from this message because it identifies an end user. Look the attempt up by its correlation ID in the sign-in logs of the tenant that refused it to see which account was used.
 ```
 
-The request then fails with that same message rather than with a bare "could not authenticate", so what to do next - sign in with an account from the application's own tenant, or have yours invited into it - is in the error itself. Add `-ForceAuthentication` to the retry so the sign-in starts from a clean browser session.
+The request then fails with that same message rather than with a bare "could not authenticate", so what to do next is in the error itself. Add `-ForceAuthentication` to the retry so the sign-in starts from a clean browser session.
+
+Everything under `Meaning` is lifted out of the message Entra wrote, because all of it is something you have to paste into a portal to get any further and none of it was anywhere you could see it. One thing is deliberately missing: the account name. Entra replaces it with `{EUII Hidden}` in a message it hands to an application, so the sign-in logs of the tenant that refused the sign-in - searched by the correlation ID above - are the only place the account can be identified.
 
 **Only errors a retry cannot change stop the sign-in.** An error you can correct in the window that is open - a wrong password on Omada's own logon form - is reported once and otherwise left alone, and so is one the identity provider may recover from by itself, such as `server_error` or `temporarily_unavailable`. An error whose wording the module does not recognize is treated as final only when the page offers no way to sign in again, which is what a failed federated sign-in looks like whatever the Omada version calls it.
 

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -124,7 +124,7 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
 
         # The diagnostic that names a broken selector: the state, the selectors expected but absent,
         # the ones present, and the page path. Reported verbatim rather than summarized.
-        $Script:FallbackWarning = @($Script:CanaryWarning | Where-Object { $_ -match 'Automated Microsoft sign-in could not continue' })
+        $Script:FallbackWarning = @($Script:CanaryWarning | Where-Object { $_ -match 'Automated Microsoft sign-in' })
 
         if ($Script:FallbackWarning.Count -gt 0) {
             "::group::Entra sign-in canary diagnostic" | Write-Host

--- a/Tests/Unit/Get-EntraTenantMismatchDetail.Tests.ps1
+++ b/Tests/Unit/Get-EntraTenantMismatchDetail.Tests.ps1
@@ -1,0 +1,130 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Get-EntraTenantMismatchDetail' -Tag 'Unit' {
+
+    BeforeAll {
+        # The message this function was written for, with the tenant, application and account of the
+        # report it came from replaced. The shape is untouched, including the brackets inside the
+        # application's display name - which is what makes the application name hard to read out.
+        $Script:TenantError = "OpenIdConnectMessage.Error was not null, indicating an error. Error: 'invalid_request'. Error_Description (may be empty): 'AADSTS50178: User account '{EUII Hidden}' from identity provider 'https://sts.windows.net/be4c52b6-1a23-493e-a8ce-f36325d16462/' does not exist in tenant 'Example productie' and cannot access the application 'a1880835-5fff-4d48-b926-44471e6f3c6c'(example.com (Omada)) in that tenant. The account needs to be added as an external user in the tenant first. Sign out and sign in again with a different Azure Active Directory user account. Trace ID: c5936087-19ec-4f9d-bbfa-9202d9218900 Correlation ID: 53b30bf1-f9c9-4ad1-8bba-5442011f3a7c Timestamp: 2026-09-10 09:08:39Z'."
+    }
+
+    Context 'A message that carries nothing to report' {
+        It 'Reports no detail for an empty message' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Detail = Get-EntraTenantMismatchDetail -Message ''
+
+                $Detail.HasDetail | Should -BeFalse
+                $Detail.AccountTenantId | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Reports no detail for an unrelated banner' {
+            InModuleScope 'OmadaWeb.PS' {
+                (Get-EntraTenantMismatchDetail -Message 'The user name or password is incorrect.').HasDetail | Should -BeFalse
+            }
+        }
+
+        It 'Returns a boolean rather than nothing, so a caller can branch on it' {
+            # A pipeline that filters to nothing yields $null, and $null is not $false under the
+            # StrictMode the suite runs with.
+            InModuleScope 'OmadaWeb.PS' {
+                (Get-EntraTenantMismatchDetail -Message 'Nothing here.').HasDetail | Should -BeOfType [bool]
+            }
+        }
+    }
+
+    Context 'The cross-tenant refusal' {
+        It 'Names the tenant the account belongs to' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                (Get-EntraTenantMismatchDetail -Message $TenantError).AccountTenantId | Should -Be 'be4c52b6-1a23-493e-a8ce-f36325d16462'
+            }
+        }
+
+        It 'Names the tenant the application lives in' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                (Get-EntraTenantMismatchDetail -Message $TenantError).ResourceTenant | Should -Be 'Example productie'
+            }
+        }
+
+        It 'Names the application by id' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                (Get-EntraTenantMismatchDetail -Message $TenantError).ApplicationId | Should -Be 'a1880835-5fff-4d48-b926-44471e6f3c6c'
+            }
+        }
+
+        It 'Keeps the brackets that are part of the application display name' {
+            # 'example.com (Omada)' closes with two brackets in a row. Stopping at the first one
+            # loses the half of the name that says which application this is.
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                (Get-EntraTenantMismatchDetail -Message $TenantError).ApplicationName | Should -Be 'example.com (Omada)'
+            }
+        }
+
+        It 'Carries the correlation id, which is how the attempt is found in the sign-in logs' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                $Detail = Get-EntraTenantMismatchDetail -Message $TenantError
+
+                $Detail.CorrelationId | Should -Be '53b30bf1-f9c9-4ad1-8bba-5442011f3a7c'
+                $Detail.TraceId | Should -Be 'c5936087-19ec-4f9d-bbfa-9202d9218900'
+                $Detail.Timestamp | Should -Be '2026-09-10 09:08:39Z'
+            }
+        }
+
+        It 'Records that Entra withheld the account name' {
+            # The one thing the reader will look for and not find. Saying so is the difference
+            # between an answer and a hunt.
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                (Get-EntraTenantMismatchDetail -Message $TenantError).AccountNameWithheld | Should -BeTrue
+            }
+        }
+
+        It 'Reads the message however the markup wrapped it' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                $Wrapped = $TenantError -replace ' ', "`r`n    "
+
+                (Get-EntraTenantMismatchDetail -Message $Wrapped).ResourceTenant | Should -Be 'Example productie'
+            }
+        }
+    }
+
+    Context 'The shapes the same error also arrives in' {
+        It 'Takes the tenant id out of a v2.0 issuer rather than its version segment' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Message = "AADSTS50020: User account from identity provider 'https://login.microsoftonline.com/be4c52b6-1a23-493e-a8ce-f36325d16462/v2.0' does not exist in tenant 'Example' and cannot access the application 'a1880835-5fff-4d48-b926-44471e6f3c6c'(example.com (Omada)) in that tenant."
+
+                (Get-EntraTenantMismatchDetail -Message $Message).AccountTenantId | Should -Be 'be4c52b6-1a23-493e-a8ce-f36325d16462'
+            }
+        }
+
+        It 'Reports an application that is named without a display name' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Message = "AADSTS50178: User account does not exist in tenant 'Example' and cannot access the application 'a1880835-5fff-4d48-b926-44471e6f3c6c' in that tenant."
+                $Detail = Get-EntraTenantMismatchDetail -Message $Message
+
+                $Detail.ApplicationId | Should -Be 'a1880835-5fff-4d48-b926-44471e6f3c6c'
+                $Detail.ApplicationName | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Reports what it found when the rest of the sentence is in another language' {
+            # Only the identifiers are stable across languages, so a message whose words do not match
+            # must still yield the identifiers that do.
+            InModuleScope 'OmadaWeb.PS' {
+                $Message = "AADSTS50178: Trace ID: c5936087-19ec-4f9d-bbfa-9202d9218900 Correlation ID: 53b30bf1-f9c9-4ad1-8bba-5442011f3a7c"
+                $Detail = Get-EntraTenantMismatchDetail -Message $Message
+
+                $Detail.HasDetail | Should -BeTrue
+                $Detail.CorrelationId | Should -Be '53b30bf1-f9c9-4ad1-8bba-5442011f3a7c'
+                $Detail.ResourceTenant | Should -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/Tests/Unit/Stop-OmadaLogin.Tests.ps1
+++ b/Tests/Unit/Stop-OmadaLogin.Tests.ps1
@@ -101,4 +101,75 @@ Describe 'Stop-OmadaLogin' -Tag 'Unit' {
 
 AfterAll {
     Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+
+    Context 'A sign-in refused because the account belongs to another tenant' {
+
+        BeforeAll {
+            $Script:TenantError = "OpenIdConnectMessage.Error was not null, indicating an error. Error: 'invalid_request'. Error_Description (may be empty): 'AADSTS50178: User account '{EUII Hidden}' from identity provider 'https://sts.windows.net/be4c52b6-1a23-493e-a8ce-f36325d16462/' does not exist in tenant 'Example productie' and cannot access the application 'a1880835-5fff-4d48-b926-44471e6f3c6c'(example.com (Omada)) in that tenant. Trace ID: c5936087-19ec-4f9d-bbfa-9202d9218900 Correlation ID: 53b30bf1-f9c9-4ad1-8bba-5442011f3a7c Timestamp: 2026-09-10 09:08:39Z'."
+        }
+
+        It 'Names the tenants, the application and the correlation id' {
+            # Everything in this list is something the reader has to paste into a portal to get any
+            # further, and all of it was already in the message - just not where anyone could see it.
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                Stop-OmadaLogin -Message $TenantError -Code 'AADSTS50178' -Reason 'Account unknown in the tenant.' -Category 'WrongAccount' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                $Warning = $Warnings -join "`n"
+
+                $Warning | Should -BeLike '*be4c52b6-1a23-493e-a8ce-f36325d16462*'
+                $Warning | Should -BeLike "*Example productie*"
+                $Warning | Should -BeLike '*example.com (Omada)*'
+                $Warning | Should -BeLike '*53b30bf1-f9c9-4ad1-8bba-5442011f3a7c*'
+            }
+        }
+
+        It 'Says that this account will never work, and what does' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                Stop-OmadaLogin -Message $TenantError -Category 'WrongAccount' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                $Warning = $Warnings -join "`n"
+
+                $Warning | Should -BeLike '*no further attempts are made*'
+                $Warning | Should -BeLike "*Sign in with an account of tenant 'Example productie'*"
+                $Warning | Should -BeLike '*invited into it as a guest*'
+            }
+        }
+
+        It 'Explains that Entra withheld the account name, instead of leaving a reader to hunt for it' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                Stop-OmadaLogin -Message $TenantError -Category 'WrongAccount' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                ($Warnings -join "`n") | Should -BeLike '*withholds the account name*'
+            }
+        }
+
+        It 'Records the category and the detail for the driver to act on' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                Stop-OmadaLogin -Message $TenantError -Category 'WrongAccount' -WarningAction SilentlyContinue | Out-Null
+
+                $Script:LoginAbortReason.Category | Should -Be 'WrongAccount'
+                $Script:LoginAbortReason.Detail.ResourceTenant | Should -Be 'Example productie'
+            }
+        }
+
+        It 'Keeps the general advice for a refusal that is not about the account' {
+            InModuleScope 'OmadaWeb.PS' {
+                Stop-OmadaLogin -Message "Error: 'unauthorized_client'." -Category 'AppRegistration' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                $Warning = $Warnings -join "`n"
+
+                $Warning | Should -BeLike '*no further attempts are made*'
+                $Warning | Should -Not -BeLike '*invited into it as a guest*'
+            }
+        }
+
+        It 'Prints no detail lines when the message carries none' {
+            InModuleScope 'OmadaWeb.PS' {
+                Stop-OmadaLogin -Message 'Access denied.' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                ($Warnings -join "`n") | Should -Not -BeLike '*Correlation*'
+            }
+        }
+    }
+
 }

--- a/Tests/Unit/Stop-OmadaLogin.Tests.ps1
+++ b/Tests/Unit/Stop-OmadaLogin.Tests.ps1
@@ -97,10 +97,6 @@ Describe 'Stop-OmadaLogin' -Tag 'Unit' {
             $Script:LoginAbortReason.Url | Should -Be 'unknown'
         }
     }
-}
-
-AfterAll {
-    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
 
     Context 'A sign-in refused because the account belongs to another tenant' {
 
@@ -171,5 +167,8 @@ AfterAll {
             }
         }
     }
+}
 
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
 }

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -681,4 +681,39 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
 
 AfterAll {
     Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+
+    Context 'Handing over because the sign-in is waiting for the user' {
+        It 'Says what is being waited for, and asks for no bug report' {
+            # A password that was never supplied is not a broken selector, and issue #76 is the
+            # standing reminder of what happens when the two are reported the same way.
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'Deciding/PasswordRequired' -Cause 'WaitingForUserInput' -Reason 'The credential has no password and this page offers no way to sign in without one.' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                $Warning = $Warnings -join "`n"
+
+                $Warning | Should -BeLike '*asking for something that was not supplied*'
+                $Warning | Should -BeLike '*stays open and waits for you*'
+                $Warning | Should -Not -BeLike '*github.com/Fortigi/OmadaWeb.PS/issues*'
+                $Warning | Should -Not -BeLike '*Microsoft changed it*'
+            }
+        }
+
+        It 'Names no missing selector, because none was missing' {
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'Deciding/PasswordRequired' -Cause 'WaitingForUserInput' -MissingElementId @('i0118') -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                ($Warnings -join "`n") | Should -Not -BeLike '*Missing elements*'
+            }
+        }
+
+        It 'Still turns the automation off, exactly like every other handover' {
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'Deciding/OneTimeCode' -Cause 'WaitingForUserInput' -WarningAction SilentlyContinue | Should -BeTrue
+
+                $Script:MicrosoftOnlineLogin | Should -BeFalse
+                $Script:ManualLoginFallbackActive | Should -BeTrue
+            }
+        }
+    }
+
 }

--- a/Tests/Unit/Switch-ToManualLogin.Tests.ps1
+++ b/Tests/Unit/Switch-ToManualLogin.Tests.ps1
@@ -156,6 +156,40 @@ Describe 'Switch-ToManualLogin' -Tag 'Unit' {
             }
         }
     }
+
+    Context 'Handing over because the sign-in is waiting for the user' {
+        It 'Says what is being waited for, and asks for no bug report' {
+            # A password that was never supplied is not a broken selector, and issue #76 is the
+            # standing reminder of what happens when the two are reported the same way.
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'Deciding/PasswordRequired' -Cause 'WaitingForUserInput' -Reason 'The credential has no password and this page offers no way to sign in without one.' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                $Warning = $Warnings -join "`n"
+
+                $Warning | Should -BeLike '*asking for something that was not supplied*'
+                $Warning | Should -BeLike '*stays open and waits for you*'
+                $Warning | Should -Not -BeLike '*github.com/Fortigi/OmadaWeb.PS/issues*'
+                $Warning | Should -Not -BeLike '*Microsoft changed it*'
+            }
+        }
+
+        It 'Names no missing selector, because none was missing' {
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'Deciding/PasswordRequired' -Cause 'WaitingForUserInput' -MissingElementId @('i0118') -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
+
+                ($Warnings -join "`n") | Should -Not -BeLike '*Missing elements*'
+            }
+        }
+
+        It 'Still turns the automation off, exactly like every other handover' {
+            InModuleScope 'OmadaWeb.PS' {
+                Switch-ToManualLogin -State 'Deciding/OneTimeCode' -Cause 'WaitingForUserInput' -WarningAction SilentlyContinue | Should -BeTrue
+
+                $Script:MicrosoftOnlineLogin | Should -BeFalse
+                $Script:ManualLoginFallbackActive | Should -BeTrue
+            }
+        }
+    }
 }
 
 Describe 'Reset-LoginAutomationState' -Tag 'Unit' {
@@ -681,39 +715,4 @@ Describe 'Invoke-WebView2MicrosoftLogin selector fallback' -Tag 'Unit' {
 
 AfterAll {
     Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
-
-    Context 'Handing over because the sign-in is waiting for the user' {
-        It 'Says what is being waited for, and asks for no bug report' {
-            # A password that was never supplied is not a broken selector, and issue #76 is the
-            # standing reminder of what happens when the two are reported the same way.
-            InModuleScope 'OmadaWeb.PS' {
-                Switch-ToManualLogin -State 'Deciding/PasswordRequired' -Cause 'WaitingForUserInput' -Reason 'The credential has no password and this page offers no way to sign in without one.' -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
-
-                $Warning = $Warnings -join "`n"
-
-                $Warning | Should -BeLike '*asking for something that was not supplied*'
-                $Warning | Should -BeLike '*stays open and waits for you*'
-                $Warning | Should -Not -BeLike '*github.com/Fortigi/OmadaWeb.PS/issues*'
-                $Warning | Should -Not -BeLike '*Microsoft changed it*'
-            }
-        }
-
-        It 'Names no missing selector, because none was missing' {
-            InModuleScope 'OmadaWeb.PS' {
-                Switch-ToManualLogin -State 'Deciding/PasswordRequired' -Cause 'WaitingForUserInput' -MissingElementId @('i0118') -WarningVariable Warnings -WarningAction SilentlyContinue | Out-Null
-
-                ($Warnings -join "`n") | Should -Not -BeLike '*Missing elements*'
-            }
-        }
-
-        It 'Still turns the automation off, exactly like every other handover' {
-            InModuleScope 'OmadaWeb.PS' {
-                Switch-ToManualLogin -State 'Deciding/OneTimeCode' -Cause 'WaitingForUserInput' -WarningAction SilentlyContinue | Should -BeTrue
-
-                $Script:MicrosoftOnlineLogin | Should -BeFalse
-                $Script:ManualLoginFallbackActive | Should -BeTrue
-            }
-        }
-    }
-
 }

--- a/Tests/Unit/Test-OmadaLogonPageError.Tests.ps1
+++ b/Tests/Unit/Test-OmadaLogonPageError.Tests.ps1
@@ -157,4 +157,77 @@ Describe 'Test-OmadaLogonPageError' -Tag 'Unit' {
 
 AfterAll {
     Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+
+    Context 'Classifying what kind of refusal it is' {
+        It 'Calls an account of another tenant a WrongAccount, which a different account can get past' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ TenantError = $Script:TenantError } {
+                $Verdict = Test-OmadaLogonPageError -Message $TenantError -OnLogonPage
+
+                $Verdict.Category | Should -Be 'WrongAccount'
+                $Verdict.Recoverable | Should -BeTrue
+            }
+        }
+
+        It 'Recognizes the same condition by its code alone, for a page served in another language' {
+            # Only the number survives translation, and losing the category there would lose the one
+            # remedy that works.
+            InModuleScope 'OmadaWeb.PS' {
+                foreach ($Code in @('AADSTS50020', 'AADSTS50178', 'AADSTS51004')) {
+                    $Verdict = Test-OmadaLogonPageError -Message ("{0}: Fout bij aanmelden." -f $Code) -OnLogonPage
+
+                    $Verdict.Category | Should -Be 'WrongAccount' -Because "$Code names an account the tenant does not know"
+                    $Verdict.Recoverable | Should -BeTrue
+                }
+            }
+        }
+
+        It 'Does not offer another account for an application the tenant rejected' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Verdict = Test-OmadaLogonPageError -Message "Error: 'unauthorized_client'. The client does not exist." -OnLogonPage
+
+                $Verdict.Category | Should -Be 'AppRegistration'
+                $Verdict.Recoverable | Should -BeFalse
+            }
+        }
+
+        It 'Does not offer another account for an account that is simply not assigned' {
+            # Same tenant, no assignment. Another account is a guess, and the answer is usually an
+            # administrator's to give.
+            InModuleScope 'OmadaWeb.PS' {
+                $Verdict = Test-OmadaLogonPageError -Message 'AADSTS50105: The signed in user cannot access the application.' -OnLogonPage
+
+                $Verdict.Category | Should -Be 'Authorization'
+                $Verdict.Recoverable | Should -BeFalse
+            }
+        }
+
+        It 'Leaves a page without an error uncategorized' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Verdict = Test-OmadaLogonPageError -Message ''
+
+                $Verdict.Category | Should -Be 'None'
+                $Verdict.Recoverable | Should -BeFalse
+            }
+        }
+
+        It 'Does not categorize an error the user can still correct in the open window' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Verdict = Test-OmadaLogonPageError -Message 'The user name or password is incorrect.' -OnLogonPage -HasLogonForm
+
+                $Verdict.IsFatal | Should -BeFalse
+                $Verdict.Recoverable | Should -BeFalse
+            }
+        }
+
+        It 'Marks a page that is final only by its shape as Unknown rather than recoverable' {
+            InModuleScope 'OmadaWeb.PS' {
+                $Verdict = Test-OmadaLogonPageError -Message 'Something went wrong.' -OnLogonPage
+
+                $Verdict.IsFatal | Should -BeTrue
+                $Verdict.Category | Should -Be 'Unknown'
+                $Verdict.Recoverable | Should -BeFalse
+            }
+        }
+    }
+
 }

--- a/Tests/Unit/Test-OmadaLogonPageError.Tests.ps1
+++ b/Tests/Unit/Test-OmadaLogonPageError.Tests.ps1
@@ -153,10 +153,6 @@ Describe 'Test-OmadaLogonPageError' -Tag 'Unit' {
             }
         }
     }
-}
-
-AfterAll {
-    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
 
     Context 'Classifying what kind of refusal it is' {
         It 'Calls an account of another tenant a WrongAccount, which a different account can get past' {
@@ -229,5 +225,8 @@ AfterAll {
             }
         }
     }
+}
 
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
 }


### PR DESCRIPTION
First of four. Diagnosis only - no behaviour changes, no new parameters.

## The report

A sign-in was refused with the message this module has printed since #63:

```
Could not authenticate to 'https://<host>': "OpenIdConnectMessage.Error was not null, indicating an error.
Error: 'invalid_request'. Error_Description (may be empty): 'AADSTS50178: User account '{EUII Hidden}' from
identity provider 'https://sts.windows.net/<tenant id>/' does not exist in tenant '<tenant> productie' and
cannot access the application '<app id>'(<name> (Omada)) in that tenant. ...'"
(The account that signed in is not known in the tenant ...
```

Everything the reader has to act on is in that sentence, and none of it is where anyone can see it.

## What changes

**`Get-EntraTenantMismatchDetail`** (new) lifts the identifiers out: the tenant the account belongs to, the tenant and application that refused it, the correlation and trace ids, and the timestamp. Nothing is invented - a value that is not there stays null, and `HasDetail` says whether anything was found. The application display name routinely contains brackets of its own (`Contoso (Omada)`), which is why the pattern closes on the bracket before `in that tenant` rather than on the first one it meets.

**`Stop-OmadaLogin`** prints them as named lines, and says the one thing the message does not carry:

```text
WARNING: Sign-in was refused and will not be retried.
  Error code : AADSTS50178
  Page URL   : https://example.omada.cloud/logon.aspx
  Engine     : WebView2
  Message    : AADSTS50178: User account '{EUII Hidden}' from identity provider ...
  Meaning    : The account that signed in is not known in the tenant the Omada application is registered in.
  Account in : tenant be4c52b6-1a23-493e-a8ce-f36325d16462
  Needed in  : tenant 'Example productie'
  Application: example.com (Omada) (a1880835-5fff-4d48-b926-44471e6f3c6c)
  Correlation: 53b30bf1-f9c9-4ad1-8bba-5442011f3a7c
  Trace      : c5936087-19ec-4f9d-bbfa-9202d9218900
This account cannot be used for this application however often the sign-in is repeated, so no further attempts
are made. Sign in with an account of tenant 'Example productie', or have this account invited into it as a
guest, and try again.
Entra ID withholds the account name from this message because it identifies an end user. Look the attempt up by
its correlation ID in the sign-in logs of the tenant that refused it to see which account was used.
```

**`Test-OmadaLogonPageError`** classifies a terminal error as well as detecting it:

| Category | Example | Recoverable |
|---|---|---|
| `WrongAccount` | `does not exist in tenant`, `needs to be added as an external user`, AADSTS50020/50178/51004 | yes |
| `Authorization` | account is in the right tenant but not assigned | no |
| `AppRegistration` | `invalid_client`, `unauthorized_client`, `consent_required` | no |
| `IdentityProvider` | everything else Entra refused | no |

`WrongAccount` is the only class a different account can get past. The category rides on `$Script:LoginAbortReason` where a driver can act on it - which is what the next PR in this series does. The AADSTS numbers are matched alongside the English sentences, because a sign-in page served in another language carries the number and not the words.

## Second fix, same theme

A recognized screen that answers "wait" - a password the credential did not carry, a one-time code that exists only on the user's phone - ran into the 60-second stall detector and was handed over with the paragraph written for a page that matched nothing: *the sign-in page no longer matches what this module knows about it, Microsoft probably changed it, please report this at the issue tracker*. Three false statements and a request to file a bug for having to type your own password. #77 fixed exactly this for Entra error codes and this path was missed.

`Switch-ToManualLogin` gains a `WaitingForUserInput` cause - names no selector, asks for no report:

```text
WARNING: Automated Microsoft sign-in is waiting for you - handing control back to you.
  State            : Deciding/PasswordRequired
  Page URL         : https://login.microsoftonline.com/common/login
  Reason           : The credential has no password and this page offers no way to sign in without one.
Entra ID is asking for something that was not supplied to this command - a password, or a verification code
from your device. Please complete the sign-in yourself in the browser window that is open; it stays open and
waits for you. Nothing is broken and there is nothing to report.
```

The opening line changes with the cause, keeping the `Automated Microsoft sign-in` prefix the canary and support logs search for; the canary's capture is widened to match it.

## Tests

- `Tests/Unit/Get-EntraTenantMismatchDetail.Tests.ps1` (new): the real message with its identifiers replaced, a v2.0 issuer (the tenant id, not the `v2.0` segment), an application without a display name, a message wrapped by the markup, and a message whose sentence is in another language but whose identifiers are not.
- `Test-OmadaLogonPageError`: the category matrix, including the codes-only path and the two classes that must **not** offer another account.
- `Stop-OmadaLogin`: the detail lines, both closing paragraphs, and that nothing is printed when the message carries no detail.
- `Switch-ToManualLogin`: the new cause names no selector, asks for no bug report, and still turns autofill off.

## Not in this PR

Choosing a different account (#2 of 4), the automatic single recovery attempt (#3), and the canary scenarios that exercise both against the real tenant (#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry1rBzPbM1vjfyK9ezEDC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry1rBzPbM1vjfyK9ezEDC6)_