### PR TITLE
Let the caller say which account signs in, with or without a password

### DIFF
--- a/OmadaWeb.PS/OmadaWeb.PS.psm1
+++ b/OmadaWeb.PS/OmadaWeb.PS.psm1
@@ -263,6 +263,13 @@ $Script:UnmatchedPageSince = $null
 # It is cleared once per sign-in rather than once per window: surviving the window closing is exactly
 # what lets the driver see why the window closed.
 $Script:LoginAbortReason = $null
+# Per-window state of the account the sign-in request asks for. The counter is the loop guard on the
+# navigation rewrite in Initialize-WebView2 - a redirect chain may carry more than one authorization
+# request, but a browser going round the same loop is worse than one that stops trying. The flag
+# keeps "no account was named" to one line per window instead of one per 150 ms tick. Both are
+# cleared by Reset-LoginAutomationState.
+$Script:EntraSignInRequestRewriteCount = 0
+$Script:EntraSignInAccountReported = $false
 # State of the logon-page scrape in Get-WebView2LogonPageError. Per browser window, so it is cleared
 # by Reset-LoginAutomationState along with the rest of the per-window automation state.
 $Script:LogonPageErrorTask = $null

--- a/OmadaWeb.PS/Private/Get-OmadaCookieFileName.ps1
+++ b/OmadaWeb.PS/Private/Get-OmadaCookieFileName.ps1
@@ -8,7 +8,10 @@ function Get-OmadaCookieFileName {
         [System.Management.Automation.PSCredential]$Credential,
 
         [AllowNull()]
-        [string]$SessionKey
+        [string]$SessionKey,
+
+        [AllowNull()]
+        [string]$UserName
     )
 
     # Matches Get-OmadaSessionKey's identity resolution (including case normalization), so a given
@@ -19,7 +22,10 @@ function Get-OmadaCookieFileName {
     # Windows filenames, so it's replaced rather than passed through.
     $Authority = $Uri.Authority.ToLowerInvariant() -replace ":", "_"
     $Identity = $null
-    if ($null -ne $Credential -and -not [string]::IsNullOrWhiteSpace($Credential.UserName)) {
+    if (-not [string]::IsNullOrWhiteSpace($UserName)) {
+        $Identity = $UserName.Trim().ToLowerInvariant()
+    }
+    elseif ($null -ne $Credential -and -not [string]::IsNullOrWhiteSpace($Credential.UserName)) {
         $Identity = $Credential.UserName.Trim().ToLowerInvariant()
     }
     elseif (-not [string]::IsNullOrWhiteSpace($SessionKey)) {

--- a/OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1
+++ b/OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1
@@ -38,6 +38,11 @@ function Get-OmadaSessionContext {
         BaseUrl             = $null
         AuthCookie          = $AuthCookie
         Credential          = $null
+        # The account this session signs in as, from -UserName or from the user name of -Credential.
+        # It is what the sign-in request is told to ask for, so it has to outlive the call that
+        # supplied it: the WebView2 window runs in a blocking dialog that cannot see the call stack.
+        UserName            = $null
+        SelectAccount       = $false
         PreferredMfaMethod  = $null
         LastSessionType     = $null
         WebView2Used        = $false
@@ -48,6 +53,10 @@ function Get-OmadaSessionContext {
         LoginCount          = 0
         WebView2ProfilePath = (Join-Path $Script:WebView2UserProfileBasePath ("OmadaWebView2Profile_{0}" -f $KeyHash.Substring(0, 16)))
         WebViewEnv          = $null
+        # Which way single sign-on with the Windows account was configured when WebViewEnv was
+        # created. A CoreWebView2Environment cannot be reconfigured after the fact, so a later call
+        # that asks for a different answer has to be given a new one - see Start-WebView2Login.
+        WebViewEnvSingleSignOn = $null
     }
 
     $Script:OmadaSessions[$Key] = $SessionContext

--- a/OmadaWeb.PS/Private/Get-OmadaSessionKey.ps1
+++ b/OmadaWeb.PS/Private/Get-OmadaSessionKey.ps1
@@ -11,11 +11,21 @@ function Get-OmadaSessionKey {
         [System.Management.Automation.PSCredential]$Credential,
 
         [AllowNull()]
-        [string]$SessionKey
+        [string]$SessionKey,
+
+        [AllowNull()]
+        [string]$UserName
     )
 
     $Identity = ""
-    if ($null -ne $Credential -and -not [string]::IsNullOrWhiteSpace($Credential.UserName)) {
+    # -UserName is read first because it is the more explicit of the two, and because it is the one
+    # that can be supplied without a password. Two accounts against the same host must never share a
+    # session: they do not share a cookie, and they must not share the browser profile that decides
+    # which of them signs in silently next time.
+    if (-not [string]::IsNullOrWhiteSpace($UserName)) {
+        $Identity = $UserName.Trim().ToLowerInvariant()
+    }
+    elseif ($null -ne $Credential -and -not [string]::IsNullOrWhiteSpace($Credential.UserName)) {
         $Identity = $Credential.UserName.Trim().ToLowerInvariant()
     }
     elseif (-not [string]::IsNullOrWhiteSpace($SessionKey)) {

--- a/OmadaWeb.PS/Private/Get-OmadaSignInAccount.ps1
+++ b/OmadaWeb.PS/Private/Get-OmadaSignInAccount.ps1
@@ -1,0 +1,61 @@
+function Get-OmadaSignInAccount {
+    <#
+    .SYNOPSIS
+        Answers which account a browser sign-in should use, and whether to ask instead.
+
+    .DESCRIPTION
+        Two things decide that, and they arrive by different routes: -UserName is put on the session
+        by Invoke-BrowserAuthentication, while -Credential carries a user name of its own and has done
+        since long before there was a session to put anything on. Asking the session for one and
+        forgetting the other is how a sign-in ends up driving nothing at all, so the question is asked
+        in exactly one place - here - and everything that needs the answer calls it.
+
+        Both members are read through the property bag rather than directly. A session context is a
+        PSCustomObject, and under the StrictMode the test suite runs with, reading a member that is not
+        there is a terminating error rather than $null. That matters for more than tidiness: this is
+        called from a WinForms timer handler, where a terminating error is not a failed sign-in but a
+        window that stops responding.
+
+    .PARAMETER SessionContext
+        The session the sign-in belongs to.
+
+    .OUTPUTS
+        PSCustomObject with the members UserName - the account, or $null when nobody named one - and
+        SelectAccount, true when the caller asked to be shown the picker instead.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    param(
+        [AllowNull()]
+        $SessionContext
+    )
+
+    $Account = [pscustomobject]@{
+        UserName      = $null
+        SelectAccount = $false
+    }
+
+    if ($null -eq $SessionContext) {
+        return $Account
+    }
+
+    $UserNameProperty = $SessionContext.PSObject.Properties["UserName"]
+    if ($null -ne $UserNameProperty -and -not [string]::IsNullOrWhiteSpace($UserNameProperty.Value)) {
+        $Account.UserName = ([string]$UserNameProperty.Value).Trim()
+    }
+    else {
+        # -Credential names the account as well, and a session built before -UserName existed - or by
+        # anything that sets the credential directly - carries it nowhere else.
+        $CredentialProperty = $SessionContext.PSObject.Properties["Credential"]
+        if ($null -ne $CredentialProperty -and $null -ne $CredentialProperty.Value -and -not [string]::IsNullOrWhiteSpace($CredentialProperty.Value.UserName)) {
+            $Account.UserName = $CredentialProperty.Value.UserName.Trim()
+        }
+    }
+
+    $SelectAccountProperty = $SessionContext.PSObject.Properties["SelectAccount"]
+    if ($null -ne $SelectAccountProperty -and $null -ne $SelectAccountProperty.Value) {
+        $Account.SelectAccount = [bool]$SelectAccountProperty.Value
+    }
+
+    return $Account
+}

--- a/OmadaWeb.PS/Private/Initialize-Webview2.ps1
+++ b/OmadaWeb.PS/Private/Initialize-Webview2.ps1
@@ -111,12 +111,20 @@ function Initialize-WebView2 {
                                     # A failure here must not take the sign-in with it: without the
                                     # rewrite the browser simply chooses the account itself, which is
                                     # what it did before this existed.
-                                    [Console]::WriteLine("Error in NavigationStarting: $_")
+                                    #
+                                    # Reported by type and not by message. The exception raised while
+                                    # rewriting a sign-in request routinely quotes the URI it was
+                                    # given, and that URI is the one place the account name appears -
+                                    # so printing the message here would put an account name on the
+                                    # console for a failure that is not even fatal. The type says
+                                    # which of the two steps broke, which is what a reader needs.
+                                    [Console]::WriteLine("Error in NavigationStarting: {0}" -f $_.Exception.GetType().FullName)
                                 }
                             })
                     }
                     catch {
-                        [Console]::WriteLine("Could not watch navigation for the sign-in account: $_")
+                        # Same rule as the handler above: the type, not the message.
+                        [Console]::WriteLine("Could not watch navigation for the sign-in account: {0}" -f $_.Exception.GetType().FullName)
                     }
 
                     $Script:WebView2.Visible = $true

--- a/OmadaWeb.PS/Private/Initialize-Webview2.ps1
+++ b/OmadaWeb.PS/Private/Initialize-Webview2.ps1
@@ -81,7 +81,8 @@ function Initialize-WebView2 {
                                         return
                                     }
 
-                                    $Rewritten = New-EntraSignInUri -Uri $NavigationArgs.Uri -UserName $Script:CurrentWebView2Session.UserName -SelectAccount:$Script:CurrentWebView2Session.SelectAccount
+                                    $SignInAccount = Get-OmadaSignInAccount -SessionContext $Script:CurrentWebView2Session
+                                    $Rewritten = New-EntraSignInUri -Uri $NavigationArgs.Uri -UserName $SignInAccount.UserName -SelectAccount:$SignInAccount.SelectAccount
                                     if ([string]::IsNullOrWhiteSpace($Rewritten)) {
                                         return
                                     }

--- a/OmadaWeb.PS/Private/Initialize-Webview2.ps1
+++ b/OmadaWeb.PS/Private/Initialize-Webview2.ps1
@@ -61,6 +61,63 @@ function Initialize-WebView2 {
 
                     "Initialize-WebView2 - WebView2 Settings:`n{0}" -f ($sender.CoreWebView2.Settings | Format-List | Out-String) | Write-Verbose
 
+                    # Which account signs in is settled in the authorization request, not on the page
+                    # it leads to. Omada builds that request and Entra ID answers it - and when the
+                    # browser already holds a session, it answers it without drawing anything at all,
+                    # which is how a sign-in ends up being made as an account nobody chose. By the
+                    # time the timer below sees a page, the choice has been made.
+                    #
+                    # NavigationStarting is the last point at which it can be influenced. It fires for
+                    # redirects as well as for typed navigations, which is what this needs: the
+                    # authorization request arrives as a redirect from Omada. Cancelling and
+                    # navigating to the rewritten request is the documented way to do this, and only
+                    # ever adds parameters, so what Entra validates is still the request Omada built.
+                    try {
+                        $sender.CoreWebView2.add_NavigationStarting({
+                                param($NavigationSender, $NavigationArgs)
+
+                                try {
+                                    if ($null -eq $Script:CurrentWebView2Session) {
+                                        return
+                                    }
+
+                                    $Rewritten = New-EntraSignInUri -Uri $NavigationArgs.Uri -UserName $Script:CurrentWebView2Session.UserName -SelectAccount:$Script:CurrentWebView2Session.SelectAccount
+                                    if ([string]::IsNullOrWhiteSpace($Rewritten)) {
+                                        return
+                                    }
+
+                                    # A redirect chain can legitimately carry more than one
+                                    # authorization request, so this is a cap rather than a single
+                                    # shot - but a browser going round the same loop is worse than one
+                                    # that stops trying, and the sign-in still works without the
+                                    # rewrite. It just picks the account itself, which is the
+                                    # behaviour this module had before.
+                                    if ($Script:EntraSignInRequestRewriteCount -ge 3) {
+                                        "Initialize-WebView2 - The sign-in request has already been redirected {0} times to ask for this account, so it is left alone now." -f $Script:EntraSignInRequestRewriteCount | Write-Verbose
+                                        return
+                                    }
+
+                                    $Script:EntraSignInRequestRewriteCount++
+
+                                    # The account name is in that URI, so only its path is reported -
+                                    # the same rule every other diagnostic here follows.
+                                    "Initialize-WebView2 - Asking Entra ID for the account this call named, on {0}" -f ([System.Uri]::new($Rewritten)).GetLeftPart([System.UriPartial]::Path) | Write-Verbose
+
+                                    $NavigationArgs.Cancel = $true
+                                    $NavigationSender.Navigate($Rewritten)
+                                }
+                                catch {
+                                    # A failure here must not take the sign-in with it: without the
+                                    # rewrite the browser simply chooses the account itself, which is
+                                    # what it did before this existed.
+                                    [Console]::WriteLine("Error in NavigationStarting: $_")
+                                }
+                            })
+                    }
+                    catch {
+                        [Console]::WriteLine("Could not watch navigation for the sign-in account: $_")
+                    }
+
                     $Script:WebView2.Visible = $true
                     $Script:OmadaWatchdogStart = $null
                     $Script:OmadaWatchdogRunning = $false

--- a/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
+++ b/OmadaWeb.PS/Private/Invoke-BrowserAuthentication.ps1
@@ -24,6 +24,21 @@ function Invoke-BrowserAuthentication {
         $SessionContext.Credential = $BoundParams['Credential']
     }
 
+    # One account, from either of the two places a caller can name it. Resolved here so that nothing
+    # downstream has to ask the question twice, and carried on the session for the same reason the
+    # credential is: the WebView2 sign-in runs inside a blocking dialog whose handlers cannot see
+    # this call stack. Left null when nobody named an account, which is what keeps the default
+    # behaviour - the browser decides - exactly as it was.
+    $SessionContext.UserName = $null
+    if ($BoundParams.keys -contains "UserName" -and -not [string]::IsNullOrWhiteSpace($BoundParams['UserName'])) {
+        $SessionContext.UserName = $BoundParams['UserName'].Trim()
+    }
+    elseif ($null -ne $SessionContext.Credential -and -not [string]::IsNullOrWhiteSpace($SessionContext.Credential.UserName)) {
+        $SessionContext.UserName = $SessionContext.Credential.UserName.Trim()
+    }
+
+    $SessionContext.SelectAccount = $BoundParams.keys -contains "SelectAccount" -and [bool]$BoundParams['SelectAccount']
+
     # Carried on the session rather than passed down: the WebView2 sign-in runs inside a blocking
     # WinForm dialog whose event handlers cannot see this call stack, and the session context is how
     # everything else - the credential included - reaches them.
@@ -120,7 +135,7 @@ function Invoke-BrowserAuthentication {
         # filename (previously this used the cookie's own .domain attribute, which may lack the port,
         # producing a different filename than what the read path looked for). Built from
         # $BoundParams['Uri'] directly rather than relying on the caller's $Uri local.
-        $CookieFileName = Get-OmadaCookieFileName -Uri ([System.Uri]::new($BoundParams['Uri'])) -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey']
+        $CookieFileName = Get-OmadaCookieFileName -Uri ([System.Uri]::new($BoundParams['Uri'])) -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey'] -UserName $BoundParams['UserName']
         $CookiePath = (Join-Path $($BoundParams['CookiePath']) -ChildPath $CookieFileName)
 
         # Protected at rest, through the same writer as the default cache below. This used to be a

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -113,7 +113,7 @@ function Invoke-OmadaRequest {
             # Reusable session state (cookie, base URL, WebView2 profile, etc.) is keyed by
             # (tenant base URL, auth type, identity) instead of single unkeyed module variables,
             # so concurrent sessions to different tenants/users don't clobber each other.
-            $SessionKey = Get-OmadaSessionKey -Uri $Uri -AuthenticationType $BoundParams['AuthenticationType'] -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey']
+            $SessionKey = Get-OmadaSessionKey -Uri $Uri -AuthenticationType $BoundParams['AuthenticationType'] -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey'] -UserName $BoundParams['UserName']
             $SessionContext = Get-OmadaSessionContext -Key $SessionKey -AuthorityHost $Uri.Host
             $SessionContext.BaseUrl = $BaseUrl
             # Computed unconditionally (not just lazily inside the encrypted-cache branch below) so it's
@@ -129,7 +129,7 @@ function Invoke-OmadaRequest {
             if ($BoundParams.Keys -contains "CookiePath") {
                 # -CookiePath is authoritative on every call (not just when no cookie is cached yet),
                 # so callers can force a specific session's cookie to be used for a given call.
-                $CookieFileName = Get-OmadaCookieFileName -Uri $Uri -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey']
+                $CookieFileName = Get-OmadaCookieFileName -Uri $Uri -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey'] -UserName $BoundParams['UserName']
                 $CookiePath = (Join-Path $($BoundParams['CookiePath']) -ChildPath $CookieFileName)
                 "{0} - Loading custom cookie: {1}" -f $MyInvocation.MyCommand, $CookiePath | Write-Verbose
                 if (!(Test-Path $CookiePath -PathType Leaf)) {
@@ -173,6 +173,35 @@ function Invoke-OmadaRequest {
             }
 
             "{0} - Authentication type: {1}" -f $MyInvocation.MyCommand, $($BoundParams['AuthenticationType']) | Write-Verbose
+
+            # -UserName and -SelectAccount are two answers to one question - which account signs in -
+            # and Entra ID takes one of them, never both: an account name is sent as login_hint, an
+            # account picker as prompt=select_account, and its OpenID Connect documentation states
+            # that the two cannot be combined. Refused here rather than resolved, because either way
+            # of resolving it silently drops half of what the caller asked for.
+            $NamedUserName = $BoundParams.ContainsKey("UserName") -and -not [string]::IsNullOrWhiteSpace($BoundParams['UserName'])
+            $NamedSelectAccount = $BoundParams.ContainsKey("SelectAccount") -and [bool]$BoundParams['SelectAccount']
+            $NamedCredential = $null -ne $BoundParams['Credential'] -and -not [string]::IsNullOrWhiteSpace($BoundParams['Credential'].UserName)
+
+            if ($NamedUserName -and $NamedCredential) {
+                "{0} - Cannot combine -UserName with -Credential: both name the account to sign in with, and honouring one would silently drop the other. Supply the account either as -UserName or as the user name of -Credential." -f $MyInvocation.MyCommand | Write-Error -ErrorAction "Stop"
+            }
+
+            if ($NamedSelectAccount -and ($NamedUserName -or $NamedCredential)) {
+                "{0} - Cannot combine -SelectAccount with an account name: Entra ID accepts an account name or an account picker, not both." -f $MyInvocation.MyCommand | Write-Error -ErrorAction "Stop"
+            }
+
+            # Both parameters act on the sign-in request the WebView2 engine navigates, so every other
+            # authentication type would accept them and quietly do nothing - the same reason
+            # -PreferredMfaMethod is refused below, and the same three ways of reaching WebView2.
+            if ($NamedUserName -or $NamedSelectAccount) {
+                $UsesWebView2ForAccount = $BoundParams['AuthenticationType'] -eq "WebView2" -or
+                    ($BoundParams['AuthenticationType'] -eq "Browser" -and (($BoundParams.ContainsKey("UseWebView2") -and $BoundParams['UseWebView2']) -or $SessionContext.WebView2Used))
+                if (-not $UsesWebView2ForAccount) {
+                    $Named = if ($NamedUserName) { "-UserName" } else { "-SelectAccount" }
+                    "{0} - {1} only applies to -AuthenticationType WebView2, got '{2}'" -f $MyInvocation.MyCommand, $Named, $BoundParams['AuthenticationType'] | Write-Error -ErrorAction "Stop"
+                }
+            }
 
             # -PreferredMfaMethod drives the Entra ID sign-in screens, which only the WebView2 engine
             # automates. Every other authentication type would accept the parameter and quietly do
@@ -431,7 +460,7 @@ function Invoke-OmadaRequest {
                         # so the freshly re-authenticated cookie must be persisted here first - otherwise the
                         # recursive call below would immediately reload and clobber it with the stale cookie
                         # still on disk (the one that caused this 401 in the first place), looping forever.
-                        $RetryCookieFileName = Get-OmadaCookieFileName -Uri $Uri -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey']
+                        $RetryCookieFileName = Get-OmadaCookieFileName -Uri $Uri -Credential $BoundParams['Credential'] -SessionKey $BoundParams['SessionKey'] -UserName $BoundParams['UserName']
                         $RetryCookiePath = Join-Path $BoundParams['CookiePath'] -ChildPath $RetryCookieFileName
                         if (!(Export-OmadaCookieFile -Path $RetryCookiePath -AuthCookie $SessionContext.AuthCookie)) {
                             "{0} - Failed to update cookie file '{1}' after re-authentication." -f $MyInvocation.MyCommand, $RetryCookiePath | Write-Verbose

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -177,9 +177,10 @@ $(Get-EntraElementVisibilityScript)
 
         # No user name means nothing to fill in, so the user signs in by hand in the open window. The
         # account can be named without a password - -UserName, or a credential carrying only a user
-        # name - which is why this asks the session for the account rather than the credential for
-        # its user name.
-        if ([string]::IsNullOrWhiteSpace($Script:CurrentWebView2Session.UserName)) {
+        # name - so the question of which account this is goes to Get-OmadaSignInAccount, which knows
+        # about both routes.
+        $SignInAccount = Get-OmadaSignInAccount -SessionContext $Script:CurrentWebView2Session
+        if ([string]::IsNullOrWhiteSpace($SignInAccount.UserName)) {
             # Said once per window, and worth saying: this is the module deciding to do nothing, and
             # a trace that shows the browser reaching Entra and then falling silent otherwise looks
             # like a failure. It is also what tells a reader that the account was the browser's
@@ -272,7 +273,7 @@ $(Get-EntraElementVisibilityScript)
                     $PreferredMfaMethod = [string]$Script:CurrentWebView2Session.PreferredMfaMethod
                 }
 
-                $Decision = Resolve-EntraSignInScreen -PageState $Script:PageState -UserName $Script:CurrentWebView2Session.UserName.Trim() -HasPassword:$HasPassword -PreferredMfaMethod $PreferredMfaMethod -MfaRequestDisplayed:$Script:MfaRequestDisplayed
+                $Decision = Resolve-EntraSignInScreen -PageState $Script:PageState -UserName (Get-OmadaSignInAccount -SessionContext $Script:CurrentWebView2Session).UserName -HasPassword:$HasPassword -PreferredMfaMethod $PreferredMfaMethod -MfaRequestDisplayed:$Script:MfaRequestDisplayed
 
                 # The code and the reason travel with the screen, because between them they are the
                 # difference between "Microsoft changed the page" and "Entra refused this request",

--- a/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
+++ b/OmadaWeb.PS/Private/Invoke-WebView2MicrosoftLogin.ps1
@@ -175,8 +175,19 @@ $(Get-EntraElementVisibilityScript)
             return $false
         }
 
-        # No user name means nothing to fill in, so the user signs in by hand in the open window.
-        if (-not $Script:CurrentWebView2Session.Credential -or [string]::IsNullOrWhiteSpace($Script:CurrentWebView2Session.Credential.UserName)) {
+        # No user name means nothing to fill in, so the user signs in by hand in the open window. The
+        # account can be named without a password - -UserName, or a credential carrying only a user
+        # name - which is why this asks the session for the account rather than the credential for
+        # its user name.
+        if ([string]::IsNullOrWhiteSpace($Script:CurrentWebView2Session.UserName)) {
+            # Said once per window, and worth saying: this is the module deciding to do nothing, and
+            # a trace that shows the browser reaching Entra and then falling silent otherwise looks
+            # like a failure. It is also what tells a reader that the account was the browser's
+            # choice rather than the caller's.
+            if (-not $Script:EntraSignInAccountReported) {
+                $Script:EntraSignInAccountReported = $true
+                "Invoke-WebView2MicrosoftLogin - No account was named for this sign-in, so the browser decides which account to use and the page is left to you." | Write-Verbose
+            }
             return $false
         }
 
@@ -243,10 +254,17 @@ $(Get-EntraElementVisibilityScript)
             }
 
             "Deciding" {
+                # A sign-in can be driven with an account name and no password at all: -UserName
+                # supplies no credential, and a PSCredential is allowed to carry an empty one. The
+                # network credential is therefore read only when there is a credential to read, and
+                # everything below asks $HasPassword rather than assuming one exists.
                 $HasPassword = $false
-                $NetworkCredential = $Script:CurrentWebView2Session.Credential.GetNetworkCredential()
-                if (-not [string]::IsNullOrEmpty($NetworkCredential.Password)) {
-                    $HasPassword = $true
+                $NetworkCredential = $null
+                if ($null -ne $Script:CurrentWebView2Session.Credential) {
+                    $NetworkCredential = $Script:CurrentWebView2Session.Credential.GetNetworkCredential()
+                    if (-not [string]::IsNullOrEmpty($NetworkCredential.Password)) {
+                        $HasPassword = $true
+                    }
                 }
 
                 $PreferredMfaMethod = $null
@@ -254,7 +272,7 @@ $(Get-EntraElementVisibilityScript)
                     $PreferredMfaMethod = [string]$Script:CurrentWebView2Session.PreferredMfaMethod
                 }
 
-                $Decision = Resolve-EntraSignInScreen -PageState $Script:PageState -UserName $Script:CurrentWebView2Session.Credential.UserName.Trim() -HasPassword:$HasPassword -PreferredMfaMethod $PreferredMfaMethod -MfaRequestDisplayed:$Script:MfaRequestDisplayed
+                $Decision = Resolve-EntraSignInScreen -PageState $Script:PageState -UserName $Script:CurrentWebView2Session.UserName.Trim() -HasPassword:$HasPassword -PreferredMfaMethod $PreferredMfaMethod -MfaRequestDisplayed:$Script:MfaRequestDisplayed
 
                 # The code and the reason travel with the screen, because between them they are the
                 # difference between "Microsoft changed the page" and "Entra refused this request",
@@ -395,6 +413,16 @@ $(Get-EntraElementVisibilityScript)
                         $Value = $Decision.Value
                         if ($Decision.ValueSource -eq "Password") {
                             # Read here and nowhere else, so the secret never travels in the decision.
+                            #
+                            # The resolver only asks for a password when it was told there is one, so
+                            # reaching this with no credential at all would be a bug in that agreement
+                            # rather than a state to type an empty string into: an empty password is
+                            # one of the attempts an account has before Entra ID locks it out.
+                            if ($null -eq $NetworkCredential) {
+                                "Invoke-WebView2MicrosoftLogin - The sign-in page asked for a password and none was supplied, so nothing is submitted." | Write-Verbose
+                                return $false
+                            }
+
                             $Value = $NetworkCredential.Password
                         }
 

--- a/OmadaWeb.PS/Private/New-EntraSignInUri.ps1
+++ b/OmadaWeb.PS/Private/New-EntraSignInUri.ps1
@@ -1,0 +1,182 @@
+function New-EntraSignInUri {
+    <#
+    .SYNOPSIS
+        Rewrites a Microsoft sign-in request so that it asks for the account the caller named.
+
+    .DESCRIPTION
+        Omada, not this module, builds the authorization request: the browser is sent to the Omada
+        instance and Omada redirects it to Entra ID. Everything the module knows about which account
+        should sign in therefore arrives too late to matter. Entra has already picked one - from the
+        browser profile, or from the Windows account WebView2 signs in with - and by the time a
+        sign-in screen could be filled in, there is no screen, only a redirect back to Omada carrying
+        whichever identity was already there. That is the whole of AADSTS50178: the wrong account was
+        chosen silently, before anything this module drives had a say.
+
+        The one place to intervene is the navigation itself, and the parameters to intervene with are
+        Entra's own:
+
+          - login_hint names the account, and is paired with prompt=login so that an existing session
+            for somebody else cannot answer the request instead.
+          - prompt=select_account asks Entra to show the account picker, including the option to use
+            an account it has never seen.
+
+        The two are mutually exclusive: Microsoft's OpenID Connect documentation states plainly that
+        login_hint and select_account cannot both be sent, so this function refuses the combination
+        rather than sending a request Entra would have to resolve by guessing.
+
+        WHAT IT WILL NOT TOUCH
+
+          - Any host but the Microsoft sign-in hosts. The value comes from a live navigation, and a
+            login_hint appended to some other identity provider's request would be handing an account
+            name to a party the caller never named.
+          - Any path but an authorization endpoint. A redirect chain passes through several requests
+            on the same host - the credential post, the "keep me signed in" page - and none of them
+            takes these parameters.
+          - A request that already carries the parameter. Omada's own request may set prompt itself,
+            and overriding it would be this module overruling the application it is signing in to.
+          - state, nonce, redirect_uri or anything else already in the query. Only parameters are
+            added, so the request Entra validates is still the request Omada built, and the
+            correlation cookie the application set for it still matches.
+
+        WS-Federation is answered with wfresh=0 instead, which is that protocol's way of saying the
+        session must be re-established rather than reused. It cannot name an account, so a user name
+        only turns into "sign in again" there - still the difference between choosing an account and
+        being handed one.
+
+    .PARAMETER Uri
+        The URI the browser is about to navigate to.
+
+    .PARAMETER UserName
+        The account the caller named, if any.
+
+    .PARAMETER SelectAccount
+        Ask Entra ID for the account picker.
+
+    .OUTPUTS
+        System.String, the rewritten URI - or $null when this request is not one to rewrite, which is
+        the ordinary case and is not a failure.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Uri,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$UserName,
+
+        [switch]$SelectAccount
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Uri)) {
+        return $null
+    }
+
+    $HasUserName = -not [string]::IsNullOrWhiteSpace($UserName)
+    if (-not $HasUserName -and -not $SelectAccount) {
+        # Nothing was asked for, so the request Omada built is the request that is sent. This is the
+        # default and it is deliberately indistinguishable from the module not being here at all.
+        return $null
+    }
+
+    if ($HasUserName -and $SelectAccount) {
+        # Refused rather than resolved: Entra accepts one or the other, and picking one here would
+        # silently drop what the caller asked for.
+        "New-EntraSignInUri - A user name and -SelectAccount cannot both be sent to Entra ID, so the request is left alone." | Write-Verbose
+        return $null
+    }
+
+    $Address = $null
+    try {
+        $Address = [System.Uri]::new($Uri)
+    }
+    catch {
+        return $null
+    }
+
+    if ($Address.Scheme -ne "https") {
+        return $null
+    }
+
+    # The sign-in hosts this module drives. Kept as an explicit list rather than a pattern over
+    # microsoft.com, because what is added to these requests is an account name.
+    $SignInHost = @(
+        "login.microsoftonline.com",
+        "login.microsoftonline.us",
+        "login.partner.microsoftonline.cn"
+    )
+    if ($Address.Host.ToLowerInvariant() -notin $SignInHost) {
+        return $null
+    }
+
+    $Path = $Address.AbsolutePath.TrimEnd("/").ToLowerInvariant()
+    $IsAuthorize = $Path.EndsWith("/oauth2/authorize") -or $Path.EndsWith("/oauth2/v2.0/authorize")
+    $IsWsFederation = $Path.EndsWith("/wsfed") -or $Path.EndsWith("/wsfederation")
+
+    if (-not $IsAuthorize -and -not $IsWsFederation) {
+        return $null
+    }
+
+    $Query = $Address.Query
+    if ($Query.StartsWith("?")) {
+        $Query = $Query.Substring(1)
+    }
+
+    $Addition = [System.Collections.Generic.List[string]]::new()
+
+    if ($IsWsFederation) {
+        # WS-Federation has no login_hint and no account picker. wfresh=0 is what it does have: the
+        # existing session is not good enough, authenticate again.
+        if ($Query -match '(?i)(^|&)wfresh=') {
+            return $null
+        }
+        $Addition.Add("wfresh=0")
+    }
+    else {
+        $HasPrompt = $Query -match '(?i)(^|&)prompt='
+        $HasLoginHint = $Query -match '(?i)(^|&)login_hint='
+
+        if ($SelectAccount) {
+            if ($HasPrompt) {
+                return $null
+            }
+            $Addition.Add("prompt=select_account")
+        }
+        else {
+            if ($HasLoginHint -and $HasPrompt) {
+                return $null
+            }
+
+            if (-not $HasLoginHint) {
+                $Addition.Add("login_hint={0}" -f [System.Uri]::EscapeDataString($UserName.Trim()))
+            }
+
+            # Without this an existing session for another account answers the request before the
+            # hint is ever read, which is the failure this function exists to prevent.
+            if (-not $HasPrompt) {
+                $Addition.Add("prompt=login")
+            }
+        }
+    }
+
+    if ($Addition.Count -eq 0) {
+        return $null
+    }
+
+    $Separator = "?"
+    if (-not [string]::IsNullOrEmpty($Query)) {
+        $Separator = "&"
+    }
+
+    # Rebuilt from the parts rather than from the string, so a fragment - which Entra does use for
+    # some response modes - stays behind the query instead of swallowing what is appended.
+    $Rebuilt = "{0}{1}{2}" -f $Address.GetLeftPart([System.UriPartial]::Path), $Address.Query, ($Separator + ($Addition -join "&"))
+    if (-not [string]::IsNullOrEmpty($Address.Fragment)) {
+        $Rebuilt = "{0}{1}" -f $Rebuilt, $Address.Fragment
+    }
+
+    return $Rebuilt
+}

--- a/OmadaWeb.PS/Private/Reset-LoginAutomationState.ps1
+++ b/OmadaWeb.PS/Private/Reset-LoginAutomationState.ps1
@@ -43,4 +43,11 @@ function Reset-LoginAutomationState {
     $Script:LogonPageErrorTask = $null
     $Script:LogonPageErrorLastCheck = $null
     $Script:LogonPageErrorReported = $null
+
+    # Per-window state of the account the sign-in request asks for. The counter is a loop guard: the
+    # navigation handler rewrites an authorization request and navigates to the rewritten one, and a
+    # redirect chain can legitimately produce more than one such request - but never many, and a
+    # browser that kept being sent round the same loop would be worse than one that stopped trying.
+    $Script:EntraSignInRequestRewriteCount = 0
+    $Script:EntraSignInAccountReported = $false
 }

--- a/OmadaWeb.PS/Private/Set-DynamicParameter.ps1
+++ b/OmadaWeb.PS/Private/Set-DynamicParameter.ps1
@@ -170,6 +170,24 @@ The values are the method identifiers Entra ID itself uses, so they mean the sam
 When the account does not offer the requested method, a warning is written and the most secure method it does offer is used instead, so a preference never fails a sign-in that would otherwise succeed.
 
 IMPORTANT: This parameter only applies to -AuthenticationType WebView2, and to -AuthenticationType Browser once that runs on WebView2. Supplying it with any other authentication type raises a terminating error.'
+    New-DynamicParam -Name "UserName" -Type "string" -ParameterSetName $ParameterObjectSetNames -DPDictionary $Dictionary -HelpMessage "The account to sign in with, as its user principal name. Use it when the browser would otherwise sign in as somebody else - the Windows account you are logged on with, or whoever used this session last - which is what happens when a tenant has more than one identity available and nobody says which one to use.
+
+The name is sent to Entra ID as part of the sign-in request itself (login_hint, with prompt=login), so it decides which account is used before any sign-in screen is drawn. That is the difference between this parameter and typing a name into the window: an existing session for another account can no longer answer the request silently.
+
+No password is needed. When one is supplied, through -Credential, it is filled in as before; when it is not, the account name is filled in and the sign-in waits in the open window for you to complete it - with a passwordless method, or by typing the password yourself.
+
+Each account gets its own session: its own cookie cache and its own browser profile. Signing in to the same environment as two different accounts therefore does not require signing out in between.
+
+Leave it out to keep the current behaviour, where the browser decides which account to use.
+
+IMPORTANT: This parameter only applies to -AuthenticationType WebView2, and to -AuthenticationType Browser once that runs on WebView2. It cannot be combined with -Credential, which carries a user name of its own, nor with -SelectAccount, because Entra ID accepts an account name or an account picker but not both."
+    New-DynamicParam -Name "SelectAccount" -Type "System.Management.Automation.SwitchParameter" -ParameterSetName $ParameterObjectSetNames -DPDictionary $Dictionary -HelpMessage "Ask Entra ID which account to sign in with, instead of letting it choose one.
+
+The sign-in request is sent with prompt=select_account, so Entra shows the account picker - every account the browser already knows, and the option to use one it does not. Use it when you do not want to name an account in advance but the automatic choice is wrong, which is what an 'AADSTS50178 ... does not exist in tenant' refusal means.
+
+Single sign-on with the Windows account is turned off for this sign-in, since it is the thing that made the choice being overruled.
+
+IMPORTANT: This parameter only applies to -AuthenticationType WebView2, and to -AuthenticationType Browser once that runs on WebView2. It cannot be combined with -UserName or with the user name of -Credential: Entra ID accepts an account name or an account picker, not both."
     New-DynamicParam -Name "DebugWebView2" -Type "System.Management.Automation.SwitchParameter" -ParameterSetName $ParameterObjectSetNames -DPDictionary $Dictionary -HelpMessage "Use this parameter to enable WebView2 browser debugging options like Developer Tools"
     New-DynamicParam -Name "SessionKey" -Type "string" -ParameterSetName $ParameterObjectSetNames -DPDictionary $Dictionary -HelpMessage "Explicitly discriminate the reusable authentication session (cookie, base URL, WebView2/Selenium profile) to use for this call, in addition to the base URL, -AuthenticationType and -Credential (when supplied). Use this to keep multiple concurrent sessions apart when they would otherwise share the same base URL, authentication type and credential - for example two interactive Browser/WebView2 logins to the same tenant before either has a known user identity. Has no effect on which cookie/base URL etc. is used beyond distinguishing sessions from each other; defaults to an empty value, which reproduces prior single-session-per-(base URL, AuthenticationType, Credential) behavior."
 

--- a/OmadaWeb.PS/Private/Set-RequestParameter.ps1
+++ b/OmadaWeb.PS/Private/Set-RequestParameter.ps1
@@ -27,7 +27,7 @@
         # cmdlets would accept them: the retry policy is implemented by Invoke-OmadaRetryableRequest
         # around the call, so passing them on as well would nest a second, differently behaving
         # retry loop inside each attempt of the first.
-        $ExcludedParameters = @("SkipCookieCache", "CookiePath", "InPrivate", "ForceAuthentication", "NoInteractiveAuthentication", "AuthenticationType", "EntraIdTenantId", "RequestType", "EdgeProfile", "UseWebView2", "EntraApplicationIdUri", "OAuthUri", "OAuthScope", "ClientId", "OAuthCertificate", "OAuthCertificateThumbprint", "OAuthCertificatePath", "OAuthCertificatePassword", "DebugWebView2", "PreferredMfaMethod", "Paged", "SessionKey", "SkipBodyRedaction", "MaximumRetryCount", "RetryIntervalSec")
+        $ExcludedParameters = @("SkipCookieCache", "CookiePath", "InPrivate", "ForceAuthentication", "NoInteractiveAuthentication", "UserName", "SelectAccount", "AuthenticationType", "EntraIdTenantId", "RequestType", "EdgeProfile", "UseWebView2", "EntraApplicationIdUri", "OAuthUri", "OAuthScope", "ClientId", "OAuthCertificate", "OAuthCertificateThumbprint", "OAuthCertificatePath", "OAuthCertificatePassword", "DebugWebView2", "PreferredMfaMethod", "Paged", "SessionKey", "SkipBodyRedaction", "MaximumRetryCount", "RetryIntervalSec")
     }
 
     $Parameters = @{}

--- a/OmadaWeb.PS/Private/Start-WebView2Login.ps1
+++ b/OmadaWeb.PS/Private/Start-WebView2Login.ps1
@@ -164,23 +164,43 @@ function Start-WebView2Login {
         $Script:WebView2.ZoomFactor = 1
         $Script:WebView2.add_SourceChanged($Script:WebView_SourceChanged)
 
+        # Single sign-on with the Windows account is what makes the ordinary sign-in instant: WebView2
+        # presents the account the machine is logged on with and Entra waves it through. It is also
+        # precisely what takes the choice away when that account is the wrong one - which is what an
+        # 'AADSTS50178 ... does not exist in tenant' refusal is. So it stays on by default, and is
+        # turned off for exactly the sign-ins where the caller has said which account to use, or has
+        # asked to be shown the picker.
+        $UseOsPrimaryAccount = [string]::IsNullOrWhiteSpace($Script:CurrentWebView2Session.UserName) -and -not $Script:CurrentWebView2Session.SelectAccount
+
         # Create the env once per session and reuse it for all WebView2 instances of that session -
         # a CoreWebView2Environment is bound 1:1 to the UserDataFolder it was created against, so it
         # must be scoped to the same session as the profile folder above.
+        #
+        # It is also bound to the options it was created with, and those cannot be changed afterwards.
+        # A session that signed in once without naming an account and is now asked for a different one
+        # would otherwise silently reuse an environment that still signs in with the Windows account,
+        # and the parameter the caller passed would do nothing at all.
+        if ($null -ne $Script:CurrentWebView2Session.WebViewEnv -and $Script:CurrentWebView2Session.WebViewEnvSingleSignOn -ne $UseOsPrimaryAccount) {
+            "{0} - Single sign-on with the Windows account is now {1} for this session, which the existing WebView2 environment cannot be told, so a new one is created." -f $MyInvocation.MyCommand, $(if ($UseOsPrimaryAccount) { "wanted" } else { "not wanted" }) | Write-Verbose
+            $Script:CurrentWebView2Session.WebViewEnv = $null
+        }
+
         if ($null -eq $Script:CurrentWebView2Session.WebViewEnv) {
-            "{0} - Creating CoreWebView2Environment..." -f $MyInvocation.MyCommand | Write-Verbose
+            "{0} - Creating CoreWebView2Environment (single sign-on with the Windows account: {1})..." -f $MyInvocation.MyCommand, $UseOsPrimaryAccount | Write-Verbose
             $EnvOptions = [Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions]::new()
-            $EnvOptions.AllowSingleSignOnUsingOSPrimaryAccount = $true
+            $EnvOptions.AllowSingleSignOnUsingOSPrimaryAccount = $UseOsPrimaryAccount
             try {
                 "{0} - Try to start CoreWebView2Environment using implicit configuration..." -f $MyInvocation.MyCommand | Write-Verbose
                 $Task = [Microsoft.Web.WebView2.Core.CoreWebView2Environment]::CreateAsync($null, $WebView2ProfilePath, $EnvOptions)
                 $Script:CurrentWebView2Session.WebViewEnv = $Task.GetAwaiter().GetResult()
+                $Script:CurrentWebView2Session.WebViewEnvSingleSignOn = $UseOsPrimaryAccount
             }
             catch {
                 try {
                     "{0} - Failed to start CoreWebView2Environment using implicit configuration, now try explicit Edge WebView path: '{1}'..." -f $MyInvocation.MyCommand, $Script:InstalledEdgeWebView2Path | Write-Verbose
                     $Task = [Microsoft.Web.WebView2.Core.CoreWebView2Environment]::CreateAsync($Script:InstalledEdgeWebView2Path, $WebView2ProfilePath, $EnvOptions)
                     $Script:CurrentWebView2Session.WebViewEnv = $Task.GetAwaiter().GetResult()
+                    $Script:CurrentWebView2Session.WebViewEnvSingleSignOn = $UseOsPrimaryAccount
                 }
                 catch {
                     $Script:StopError = $true

--- a/OmadaWeb.PS/Private/Start-WebView2Login.ps1
+++ b/OmadaWeb.PS/Private/Start-WebView2Login.ps1
@@ -180,8 +180,17 @@ function Start-WebView2Login {
         # A session that signed in once without naming an account and is now asked for a different one
         # would otherwise silently reuse an environment that still signs in with the Windows account,
         # and the parameter the caller passed would do nothing at all.
+        $PreviousWebViewEnv = $null
         if ($null -ne $Script:CurrentWebView2Session.WebViewEnv -and $Script:CurrentWebView2Session.WebViewEnvSingleSignOn -ne $UseOsPrimaryAccount) {
             "{0} - Single sign-on with the Windows account is now {1} for this session, which the existing WebView2 environment cannot be told, so a new one is created." -f $MyInvocation.MyCommand, $(if ($UseOsPrimaryAccount) { "wanted" } else { "not wanted" }) | Write-Verbose
+
+            # Kept, not dropped. WebView2 refuses to create a second environment over a user data
+            # folder that is still in use with different options, and a browser process from the
+            # window that just closed can still be on its way out. Failing the sign-in over that
+            # would be the wrong trade: the option only decides whether the Windows account is
+            # offered without being asked for, while what actually settles the account is the prompt
+            # parameter on the request itself, which is sent either way.
+            $PreviousWebViewEnv = $Script:CurrentWebView2Session.WebViewEnv
             $Script:CurrentWebView2Session.WebViewEnv = $null
         }
 
@@ -203,8 +212,17 @@ function Start-WebView2Login {
                     $Script:CurrentWebView2Session.WebViewEnvSingleSignOn = $UseOsPrimaryAccount
                 }
                 catch {
-                    $Script:StopError = $true
-                    "{0} - Error creating CoreWebView2Environment. You can consider to install the Evergreen Standalone Installer from 'https://developer.microsoft.com/en-us/Microsoft-edge/webview2/' and try again: {1}" -f $MyInvocation.MyCommand, $_.Exception | Write-Error -ErrorAction Stop
+                    if ($null -ne $PreviousWebViewEnv) {
+                        # Only the reconfiguration failed. The sign-in itself has an environment to
+                        # run in, and the request still carries the parameter that decides the
+                        # account, so it goes ahead in the one this session already had.
+                        "{0} - Could not create a WebView2 environment with single sign-on {1}, so this sign-in reuses the environment this session already has: {2}" -f $MyInvocation.MyCommand, $(if ($UseOsPrimaryAccount) { "enabled" } else { "disabled" }), $_.Exception.Message | Write-Verbose
+                        $Script:CurrentWebView2Session.WebViewEnv = $PreviousWebViewEnv
+                    }
+                    else {
+                        $Script:StopError = $true
+                        "{0} - Error creating CoreWebView2Environment. You can consider to install the Evergreen Standalone Installer from 'https://developer.microsoft.com/en-us/Microsoft-edge/webview2/' and try again: {1}" -f $MyInvocation.MyCommand, $_.Exception | Write-Error -ErrorAction Stop
+                    }
                 }
             }
         }

--- a/OmadaWeb.PS/Private/Start-WebView2Login.ps1
+++ b/OmadaWeb.PS/Private/Start-WebView2Login.ps1
@@ -170,7 +170,8 @@ function Start-WebView2Login {
         # 'AADSTS50178 ... does not exist in tenant' refusal is. So it stays on by default, and is
         # turned off for exactly the sign-ins where the caller has said which account to use, or has
         # asked to be shown the picker.
-        $UseOsPrimaryAccount = [string]::IsNullOrWhiteSpace($Script:CurrentWebView2Session.UserName) -and -not $Script:CurrentWebView2Session.SelectAccount
+        $SignInAccount = Get-OmadaSignInAccount -SessionContext $Script:CurrentWebView2Session
+        $UseOsPrimaryAccount = [string]::IsNullOrWhiteSpace($SignInAccount.UserName) -and -not $SignInAccount.SelectAccount
 
         # Create the env once per session and reuse it for all WebView2 instances of that session -
         # a CoreWebView2Environment is bound 1:1 to the UserDataFolder it was created against, so it

--- a/README.md
+++ b/README.md
@@ -223,6 +223,50 @@ Two things worth knowing:
 
 A session still has to be established once, interactively, before any of this works - the switch uses a session, it never creates one.
 
+### Choosing the account to sign in with
+
+By default the browser decides. It signs in with the account Windows is logged on with, or with whoever used this session last, and for a workstation that belongs to the tenant you are administering that is exactly right - the sign-in is instant and nobody is asked anything.
+
+It is wrong the moment more than one identity is in play. A consultant's own account, a guest account in the customer's tenant, an acceptance account and a production account: the browser picks one silently, and Entra ID answers with a refusal that names neither what it picked nor what it wanted.
+
+```text
+AADSTS50178: User account '{EUII Hidden}' from identity provider 'https://sts.windows.net/<tenant id>/'
+does not exist in tenant '<tenant> production' and cannot access the application ... in that tenant.
+```
+
+Two parameters take that choice back:
+
+```powershell
+# Sign in as a named account. No password is needed.
+Invoke-OmadaRestMethod -Uri "https://example.omada.cloud/api/..." -UserName "mark@example.com"
+
+# Or be shown the account picker, including the option to use an account the browser does not know.
+Invoke-OmadaRestMethod -Uri "https://example.omada.cloud/api/..." -SelectAccount
+```
+
+**The account is named in the sign-in request, not typed into the page.** `-UserName` is sent to Entra ID as `login_hint` together with `prompt=login`, and `-SelectAccount` as `prompt=select_account`. That is the whole point: a session for somebody else can no longer answer the request before a page is ever drawn, which is what the refusal above is. Single sign-on with the Windows account is turned off for these sign-ins for the same reason.
+
+Nothing else in the request is touched - `state`, `nonce` and the redirect URI stay exactly as Omada built them, and a `prompt` that Omada sets itself is left alone.
+
+| | |
+|---|---|
+| `-UserName "mark@example.com"` | that account signs in |
+| `-Credential $Credential` | the credential's user name is the account; its password is filled in when it has one |
+| `-SelectAccount` | Entra asks which account to use |
+| neither | unchanged: the browser decides |
+
+The two cannot be combined - Entra ID accepts an account name or an account picker, not both - and `-UserName` cannot be combined with `-Credential`, which carries a user name of its own. Both apply to `-AuthenticationType "WebView2"` (and to `"Browser"` once it runs on WebView2); supplying them with any other type is refused rather than silently ignored.
+
+**A password is optional.** `-UserName` supplies none at all, and a `-Credential` may carry an empty one:
+
+```powershell
+$Credential = [System.Management.Automation.PSCredential]::new("mark@example.com", [System.Security.SecureString]::new())
+```
+
+The account name is filled in, an empty password is never submitted - that is one of the attempts an account has before Entra ID locks it out - and if Entra offers a passwordless method the module takes it. When it insists on a password anyway, the window stays open and waits for you to type it.
+
+**Each account gets its own session**, meaning its own cookie cache and its own browser profile, keyed on the account name exactly as `-Credential` and `-SessionKey` already are. Two accounts against the same Omada environment therefore no longer need signing out in between, and neither can be silently signed in as the other.
+
 ### Signing in, and what happens when Microsoft changes the sign-in page
 
 Every browser-based authentication type signs in the same way a person does: a browser window opens on your Omada instance, and you complete the sign-in there. Passing a `-Credential` for an Entra tenant adds one convenience on top of that - the module recognizes the Microsoft sign-in pages and fills the fields in for you.

--- a/Tests/Unit/Get-OmadaCookieFileName.Tests.ps1
+++ b/Tests/Unit/Get-OmadaCookieFileName.Tests.ps1
@@ -59,10 +59,6 @@ Describe 'Get-OmadaCookieFileName' -Tag 'Unit' {
             $NameBoth | Should -Be $NameCredentialOnly
         }
     }
-}
-
-AfterAll {
-    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
 
     It 'Should give an account named with -UserName its own cookie file' {
         InModuleScope 'OmadaWeb.PS' {
@@ -85,5 +81,8 @@ AfterAll {
                 Should -Be (Get-OmadaCookieFileName -Uri $Uri -Credential $Credential)
         }
     }
+}
 
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
 }

--- a/Tests/Unit/Get-OmadaCookieFileName.Tests.ps1
+++ b/Tests/Unit/Get-OmadaCookieFileName.Tests.ps1
@@ -63,4 +63,27 @@ Describe 'Get-OmadaCookieFileName' -Tag 'Unit' {
 
 AfterAll {
     Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+
+    It 'Should give an account named with -UserName its own cookie file' {
+        InModuleScope 'OmadaWeb.PS' {
+            $Uri = [System.Uri]::new('http://localhost:19000/')
+
+            $Name = Get-OmadaCookieFileName -Uri $Uri -UserName 'user-a@example.com'
+
+            $Name | Should -BeLike 'localhost_19000_*.cookie'
+            $Name | Should -Not -Be (Get-OmadaCookieFileName -Uri $Uri -UserName 'user-b@example.com')
+        }
+    }
+
+    It 'Should resolve -UserName and the same name on a Credential to one file' {
+        # The two are the same account named two ways, and they must not end up with two cookies.
+        InModuleScope 'OmadaWeb.PS' {
+            $Uri = [System.Uri]::new('http://localhost:19000/')
+            $Credential = New-Object System.Management.Automation.PSCredential('user-a@example.com', (ConvertTo-SecureString 'x' -AsPlainText -Force))
+
+            Get-OmadaCookieFileName -Uri $Uri -UserName 'USER-A@example.com' |
+                Should -Be (Get-OmadaCookieFileName -Uri $Uri -Credential $Credential)
+        }
+    }
+
 }

--- a/Tests/Unit/Get-OmadaSessionKey.Tests.ps1
+++ b/Tests/Unit/Get-OmadaSessionKey.Tests.ps1
@@ -85,10 +85,6 @@ Describe 'Get-OmadaSessionKey' -Tag 'Unit' {
             $Key1 | Should -Be $Key2
         }
     }
-}
-
-AfterAll {
-    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
 
     It 'Should keep two accounts named with -UserName in separate sessions' {
         # Separate sessions mean separate cookies and separate browser profiles, which is what stops
@@ -121,5 +117,8 @@ AfterAll {
                 Should -Not -Be (Get-OmadaSessionKey -Uri $Uri -AuthenticationType 'WebView2')
         }
     }
+}
 
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
 }

--- a/Tests/Unit/Get-OmadaSessionKey.Tests.ps1
+++ b/Tests/Unit/Get-OmadaSessionKey.Tests.ps1
@@ -89,4 +89,37 @@ Describe 'Get-OmadaSessionKey' -Tag 'Unit' {
 
 AfterAll {
     Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+
+    It 'Should keep two accounts named with -UserName in separate sessions' {
+        # Separate sessions mean separate cookies and separate browser profiles, which is what stops
+        # the browser signing the second account in silently as the first.
+        InModuleScope 'OmadaWeb.PS' {
+            $Uri = [System.Uri]::new('https://example.omada.cloud/')
+
+            $KeyA = Get-OmadaSessionKey -Uri $Uri -AuthenticationType 'WebView2' -UserName 'user-a@example.com'
+            $KeyB = Get-OmadaSessionKey -Uri $Uri -AuthenticationType 'WebView2' -UserName 'user-b@example.com'
+
+            $KeyA | Should -Not -Be $KeyB
+        }
+    }
+
+    It 'Should resolve -UserName and the user name of a Credential to the same session' {
+        InModuleScope 'OmadaWeb.PS' {
+            $Uri = [System.Uri]::new('https://example.omada.cloud/')
+            $Credential = New-Object System.Management.Automation.PSCredential('user-a@example.com', (ConvertTo-SecureString 'x' -AsPlainText -Force))
+
+            Get-OmadaSessionKey -Uri $Uri -AuthenticationType 'WebView2' -UserName 'USER-A@example.com' |
+                Should -Be (Get-OmadaSessionKey -Uri $Uri -AuthenticationType 'WebView2' -Credential $Credential)
+        }
+    }
+
+    It 'Should keep an account out of the session of a call that named none' {
+        InModuleScope 'OmadaWeb.PS' {
+            $Uri = [System.Uri]::new('https://example.omada.cloud/')
+
+            Get-OmadaSessionKey -Uri $Uri -AuthenticationType 'WebView2' -UserName 'user-a@example.com' |
+                Should -Not -Be (Get-OmadaSessionKey -Uri $Uri -AuthenticationType 'WebView2')
+        }
+    }
+
 }

--- a/Tests/Unit/Get-OmadaSignInAccount.Tests.ps1
+++ b/Tests/Unit/Get-OmadaSignInAccount.Tests.ps1
@@ -1,0 +1,87 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Get-OmadaSignInAccount' -Tag 'Unit' {
+
+    It 'Takes the account the caller named' {
+        InModuleScope 'OmadaWeb.PS' {
+            $SessionContext = [PSCustomObject]@{ UserName = '  mark@example.com  '; Credential = $null; SelectAccount = $false }
+
+            (Get-OmadaSignInAccount -SessionContext $SessionContext).UserName | Should -Be 'mark@example.com'
+        }
+    }
+
+    It 'Falls back to the user name of the credential' {
+        # The regression this function exists for. A session that carries only a credential - which is
+        # every session built before -UserName existed, and every one built by something other than
+        # Invoke-BrowserAuthentication - still names an account, and autofill has to find it there.
+        InModuleScope 'OmadaWeb.PS' {
+            $SessionContext = [PSCustomObject]@{
+                Credential = New-Object System.Management.Automation.PSCredential('user@contoso.com', (ConvertTo-SecureString 'password' -AsPlainText -Force))
+            }
+
+            (Get-OmadaSignInAccount -SessionContext $SessionContext).UserName | Should -Be 'user@contoso.com'
+        }
+    }
+
+    It 'Prefers the named account over the one on the credential' {
+        InModuleScope 'OmadaWeb.PS' {
+            $SessionContext = [PSCustomObject]@{
+                UserName   = 'named@example.com'
+                Credential = New-Object System.Management.Automation.PSCredential('other@example.com', (ConvertTo-SecureString 'x' -AsPlainText -Force))
+            }
+
+            (Get-OmadaSignInAccount -SessionContext $SessionContext).UserName | Should -Be 'named@example.com'
+        }
+    }
+
+    It 'Treats a blank name as no name at all' {
+        InModuleScope 'OmadaWeb.PS' {
+            $SessionContext = [PSCustomObject]@{
+                UserName   = '   '
+                Credential = New-Object System.Management.Automation.PSCredential('fallback@example.com', (ConvertTo-SecureString 'x' -AsPlainText -Force))
+            }
+
+            (Get-OmadaSignInAccount -SessionContext $SessionContext).UserName | Should -Be 'fallback@example.com'
+        }
+    }
+
+    It 'Reports no account when nobody named one' {
+        InModuleScope 'OmadaWeb.PS' {
+            (Get-OmadaSignInAccount -SessionContext ([PSCustomObject]@{ UserName = $null; Credential = $null })).UserName | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Survives a session that carries none of these members' {
+        # Read through the property bag, because under StrictMode a member that is not there is a
+        # terminating error - and this is called from a timer handler, where that is not a failed
+        # sign-in but a window that stops responding.
+        InModuleScope 'OmadaWeb.PS' {
+            $Account = Get-OmadaSignInAccount -SessionContext ([PSCustomObject]@{})
+
+            $Account.UserName | Should -BeNullOrEmpty
+            $Account.SelectAccount | Should -BeFalse
+        }
+    }
+
+    It 'Survives no session at all' {
+        InModuleScope 'OmadaWeb.PS' {
+            $Account = Get-OmadaSignInAccount -SessionContext $null
+
+            $Account.UserName | Should -BeNullOrEmpty
+            $Account.SelectAccount | Should -BeFalse
+        }
+    }
+
+    It 'Reports the account picker when it was asked for' {
+        InModuleScope 'OmadaWeb.PS' {
+            (Get-OmadaSignInAccount -SessionContext ([PSCustomObject]@{ SelectAccount = $true })).SelectAccount | Should -BeTrue
+        }
+    }
+}

--- a/Tests/Unit/New-EntraSignInUri.Tests.ps1
+++ b/Tests/Unit/New-EntraSignInUri.Tests.ps1
@@ -1,0 +1,151 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'New-EntraSignInUri' -Tag 'Unit' {
+
+    BeforeAll {
+        $Script:Authorize = 'https://login.microsoftonline.com/be4c52b6-1a23-493e-a8ce-f36325d16462/oauth2/v2.0/authorize?client_id=abc&state=xyz'
+    }
+
+    Context 'When nobody named an account' {
+        It 'Leaves the request exactly as the application built it' {
+            # The default has to be indistinguishable from this function not existing.
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                New-EntraSignInUri -Uri $Authorize | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Treats a blank user name as no account at all' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                New-EntraSignInUri -Uri $Authorize -UserName '   ' | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Asking for a named account' {
+        It 'Sends the account as a login hint, and refuses an existing session for anybody else' {
+            # login_hint alone is a suggestion: a session for another account answers the request
+            # before the hint is read, which is the failure this whole function exists to prevent.
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                New-EntraSignInUri -Uri $Authorize -UserName 'mark@example.com' |
+                    Should -Be ('{0}&login_hint=mark%40example.com&prompt=login' -f $Authorize)
+            }
+        }
+
+        It 'Escapes the account name instead of pasting it into the query' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                $Rewritten = New-EntraSignInUri -Uri $Authorize -UserName 'mark@example.com&prompt=none'
+
+                $Rewritten | Should -BeLike '*login_hint=mark%40example.com%26prompt%3Dnone*'
+                $Rewritten | Should -Not -BeLike '*prompt=none*'
+            }
+        }
+
+        It 'Adds the parameters to a request that carries no query at all' {
+            InModuleScope 'OmadaWeb.PS' {
+                New-EntraSignInUri -Uri 'https://login.microsoftonline.com/common/oauth2/authorize' -UserName 'mark@example.com' |
+                    Should -Be 'https://login.microsoftonline.com/common/oauth2/authorize?login_hint=mark%40example.com&prompt=login'
+            }
+        }
+    }
+
+    Context 'Asking for the account picker' {
+        It 'Sends prompt=select_account' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                New-EntraSignInUri -Uri $Authorize -SelectAccount | Should -Be ('{0}&prompt=select_account' -f $Authorize)
+            }
+        }
+
+        It 'Refuses to combine an account name with the picker' {
+            # Entra ID accepts one or the other; sending both would have it resolve by guessing.
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                New-EntraSignInUri -Uri $Authorize -UserName 'mark@example.com' -SelectAccount | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Requests it must not touch' {
+        It 'Leaves another identity provider alone, so no account name is handed to it' {
+            InModuleScope 'OmadaWeb.PS' {
+                New-EntraSignInUri -Uri 'https://sso.contoso.com/oauth2/v2.0/authorize?client_id=abc' -UserName 'mark@example.com' | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Leaves a plain HTTP request alone' {
+            InModuleScope 'OmadaWeb.PS' {
+                New-EntraSignInUri -Uri 'http://login.microsoftonline.com/common/oauth2/authorize' -SelectAccount | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Leaves every request in the chain that is not an authorization request' {
+            # A sign-in is a series of navigations on the same host. Only the first one takes these
+            # parameters; the rest would be rewritten for nothing, or broken.
+            InModuleScope 'OmadaWeb.PS' {
+                foreach ($Uri in @(
+                        'https://login.microsoftonline.com/common/login?x=1',
+                        'https://login.microsoftonline.com/kmsi',
+                        'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+                    )) {
+                    New-EntraSignInUri -Uri $Uri -SelectAccount | Should -BeNullOrEmpty -Because "$Uri is not an authorization request"
+                }
+            }
+        }
+
+        It 'Leaves a prompt the application set itself alone' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                New-EntraSignInUri -Uri ('{0}&prompt=login' -f $Authorize) -SelectAccount | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Leaves a login hint the application set itself alone, and only insists on a fresh sign-in' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                $WithHint = '{0}&login_hint=other%40example.com' -f $Authorize
+
+                New-EntraSignInUri -Uri $WithHint -UserName 'mark@example.com' | Should -Be ('{0}&prompt=login' -f $WithHint)
+            }
+        }
+
+        It 'Does nothing when the request already carries both' {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ Authorize = $Script:Authorize } {
+                New-EntraSignInUri -Uri ('{0}&login_hint=other%40example.com&prompt=login' -f $Authorize) -UserName 'mark@example.com' | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Survives a value that is not a URI at all' {
+            InModuleScope 'OmadaWeb.PS' {
+                New-EntraSignInUri -Uri 'not a uri' -SelectAccount | Should -BeNullOrEmpty
+                New-EntraSignInUri -Uri '' -SelectAccount | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'WS-Federation, which cannot name an account' {
+        It 'Asks for a fresh sign-in instead' {
+            InModuleScope 'OmadaWeb.PS' {
+                New-EntraSignInUri -Uri 'https://login.microsoftonline.com/common/wsfed?wa=wsignin1.0' -UserName 'mark@example.com' |
+                    Should -Be 'https://login.microsoftonline.com/common/wsfed?wa=wsignin1.0&wfresh=0'
+            }
+        }
+
+        It 'Leaves a request that already asks for one alone' {
+            InModuleScope 'OmadaWeb.PS' {
+                New-EntraSignInUri -Uri 'https://login.microsoftonline.com/common/wsfed?wa=wsignin1.0&wfresh=0' -SelectAccount | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'The other Microsoft clouds' {
+        It 'Rewrites a US Government sign-in the same way' {
+            InModuleScope 'OmadaWeb.PS' {
+                New-EntraSignInUri -Uri 'https://login.microsoftonline.us/common/oauth2/v2.0/authorize' -SelectAccount |
+                    Should -Be 'https://login.microsoftonline.us/common/oauth2/v2.0/authorize?prompt=select_account'
+            }
+        }
+    }
+}

--- a/Tests/Unit/Set-DynamicParameter.Tests.ps1
+++ b/Tests/Unit/Set-DynamicParameter.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Set-DynamicParameter' -Tag 'Unit' {
         InModuleScope 'OmadaWeb.PS' {
             $Dictionary = Set-DynamicParameter -FunctionName 'Invoke-RestMethod'
             $Dictionary | Should -BeOfType [System.Management.Automation.RuntimeDefinedParameterDictionary]
-            foreach ($Name in @('AuthenticationType', 'EntraIdTenantId', 'CookiePath', 'ForceAuthentication', 'InPrivate', 'UseWebView2', 'SessionKey')) {
+            foreach ($Name in @('AuthenticationType', 'EntraIdTenantId', 'CookiePath', 'ForceAuthentication', 'InPrivate', 'UseWebView2', 'SessionKey', 'UserName', 'SelectAccount')) {
                 $Dictionary.ContainsKey($Name) | Should -Be $true
             }
         }

--- a/Tests/Unit/SignInAccount.Tests.ps1
+++ b/Tests/Unit/SignInAccount.Tests.ps1
@@ -27,6 +27,14 @@ Describe 'Naming the account a sign-in uses' -Tag 'Unit' {
                 # tests are about - and no browser is opened to find that out.
                 $SessionContext.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = ([System.Uri]::new($BaseUrl)).Host }
 
+                # Invoke-BrowserAuthentication ends by writing the cookie cache, whose path
+                # Invoke-OmadaRequest normally fills in. These tests are about the account it resolves
+                # on the way there, and a unit test has no business writing one, so the caching is
+                # switched off rather than pointed somewhere.
+                if (-not $BoundParams.ContainsKey("SkipCookieCache")) {
+                    $BoundParams["SkipCookieCache"] = $true
+                }
+
                 return New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext $SessionContext
             }
         }

--- a/Tests/Unit/SignInAccount.Tests.ps1
+++ b/Tests/Unit/SignInAccount.Tests.ps1
@@ -1,0 +1,166 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Naming the account a sign-in uses' -Tag 'Unit' {
+
+    BeforeAll {
+        InModuleScope 'OmadaWeb.PS' {
+            # Same fixture shape as NoInteractiveAuthentication.Tests.ps1.
+            function Script:New-TestRequestContext {
+                param(
+                    [hashtable]$BoundParams,
+                    [string]$Key,
+                    [string]$BaseUrl = 'http://localhost:19000/'
+                )
+
+                $SessionContext = Get-OmadaSessionContext -Key $Key
+                $SessionContext.BaseUrl = $BaseUrl
+
+                # A usable cookie, so Invoke-BrowserAuthentication takes its "already signed in"
+                # branch. The account is resolved before that branch is chosen, which is what these
+                # tests are about - and no browser is opened to find that out.
+                $SessionContext.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = ([System.Uri]::new($BaseUrl)).Host }
+
+                return New-OmadaRequestContext -BoundParams $BoundParams -Session ([Microsoft.PowerShell.Commands.WebRequestSession]::new()) -SessionContext $SessionContext
+            }
+        }
+    }
+
+    Context 'Refusing to guess which account was meant' {
+        It 'Should refuse -UserName together with -Credential' {
+            # Two names for the account, and honouring either would silently discard the other.
+            { Invoke-OmadaRestMethod -Uri 'http://localhost:19000/api/thing' -AuthenticationType 'WebView2' -UserName 'a@example.com' -Credential (New-Object System.Management.Automation.PSCredential('b@example.com', (ConvertTo-SecureString 'x' -AsPlainText -Force))) -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*Cannot combine -UserName with -Credential*'
+        }
+
+        It 'Should refuse -SelectAccount together with -UserName' {
+            # Entra ID takes an account name or an account picker, never both.
+            { Invoke-OmadaRestMethod -Uri 'http://localhost:19000/api/thing' -AuthenticationType 'WebView2' -UserName 'a@example.com' -SelectAccount -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*Cannot combine -SelectAccount with an account name*'
+        }
+
+        It 'Should refuse -SelectAccount together with the user name of a credential' {
+            { Invoke-OmadaRestMethod -Uri 'http://localhost:19000/api/thing' -AuthenticationType 'WebView2' -SelectAccount -Credential (New-Object System.Management.Automation.PSCredential('b@example.com', (ConvertTo-SecureString 'x' -AsPlainText -Force))) -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*Cannot combine -SelectAccount with an account name*'
+        }
+
+        It 'Should refuse an account name for an authentication type that cannot act on it' {
+            # Every type but WebView2 would accept the parameter and quietly do nothing with it.
+            { Invoke-OmadaRestMethod -Uri 'http://localhost:19000/api/thing' -AuthenticationType 'Basic' -UserName 'a@example.com' -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*-UserName only applies to -AuthenticationType WebView2*'
+        }
+
+        It 'Should refuse the account picker for an authentication type that cannot show one' {
+            { Invoke-OmadaRestMethod -Uri 'http://localhost:19000/api/thing' -AuthenticationType 'None' -SelectAccount -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*-SelectAccount only applies to -AuthenticationType WebView2*'
+        }
+    }
+
+    Context 'Resolving the account onto the session' {
+        It 'Should take the account from -UserName' {
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-TestRequestContext -Key 'unit-test-account-username' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    Uri                = 'http://localhost:19000/'
+                    UserName           = '  mark@example.com  '
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.SessionContext.UserName | Should -Be 'mark@example.com'
+                $RequestContext.SessionContext.SelectAccount | Should -BeFalse
+            }
+        }
+
+        It 'Should take the account from the user name of a credential' {
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-TestRequestContext -Key 'unit-test-account-credential' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    Uri                = 'http://localhost:19000/'
+                    Credential         = New-Object System.Management.Automation.PSCredential('mark@example.com', (ConvertTo-SecureString 'x' -AsPlainText -Force))
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.SessionContext.UserName | Should -Be 'mark@example.com'
+            }
+        }
+
+        It 'Should take a credential that carries no password at all' {
+            # The whole point of the passwordless path: the account is named, the password is not,
+            # and the sign-in waits in the open window for whatever Entra asks for.
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-TestRequestContext -Key 'unit-test-account-nopassword' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    Uri                = 'http://localhost:19000/'
+                    Credential         = New-Object System.Management.Automation.PSCredential('mark@example.com', ([System.Security.SecureString]::new()))
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.SessionContext.UserName | Should -Be 'mark@example.com'
+                $RequestContext.SessionContext.Credential.GetNetworkCredential().Password | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Should leave the account unset when nobody named one' {
+            # This is the default, and it has to stay indistinguishable from the behaviour before
+            # these parameters existed: the browser decides.
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-TestRequestContext -Key 'unit-test-account-none' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    Uri                = 'http://localhost:19000/'
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.SessionContext.UserName | Should -BeNullOrEmpty
+                $RequestContext.SessionContext.SelectAccount | Should -BeFalse
+            }
+        }
+
+        It 'Should record that the account picker was asked for' {
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-TestRequestContext -Key 'unit-test-account-picker' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    Uri                = 'http://localhost:19000/'
+                    SelectAccount      = $true
+                }
+
+                Invoke-BrowserAuthentication -RequestContext $RequestContext | Out-Null
+
+                $RequestContext.SessionContext.SelectAccount | Should -BeTrue
+            }
+        }
+    }
+
+    Context 'Keeping the parameters out of the web request' {
+        It 'Should not forward them to the underlying web cmdlet' {
+            InModuleScope 'OmadaWeb.PS' {
+                $RequestContext = New-TestRequestContext -Key 'unit-test-account-not-forwarded' -BoundParams @{
+                    AuthenticationType = 'WebView2'
+                    Headers            = @{}
+                    Uri                = 'http://localhost:19000/'
+                    UserName           = 'mark@example.com'
+                    SelectAccount      = $false
+                }
+
+                $Parameter = Set-RequestParameter -RequestContext $RequestContext
+
+                $Parameter.Keys | Should -Not -Contain 'UserName'
+                $Parameter.Keys | Should -Not -Contain 'SelectAccount'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Second of four. **Stacked on #86** - review that one first; this PR's diff is against it.

## The problem

Which account a browser sign-in uses was never this module's to decide. Omada builds the authorization request, Entra ID answers it, and when the browser already holds a session - or WebView2 hands over the Windows account, which `AllowSingleSignOnUsingOSPrimaryAccount = $true` in `Start-WebView2Login` asks it to do - Entra answers **without drawing a page at all**. By the time credential autofill sees anything, the account has been chosen.

That is why passing `-Credential` never fixed an `AADSTS50178`: the user name in it is typed into a screen that is never shown.

## What this adds

```powershell
# Sign in as a named account. No password needed.
Invoke-OmadaRestMethod -Uri "https://example.omada.cloud/api/..." -UserName "mark@example.com"

# Or be shown the picker, including "use another account".
Invoke-OmadaRestMethod -Uri "https://example.omada.cloud/api/..." -SelectAccount
```

| supplied | result |
|---|---|
| `-UserName "mark@example.com"` | `login_hint=mark%40example.com&prompt=login` |
| `-Credential $Credential` | same, from the credential's user name; the password is filled in when it has one |
| `-SelectAccount` | `prompt=select_account` |
| neither | unchanged - the browser decides |

`login_hint` alone would be a suggestion an existing session can ignore, which is why it travels with `prompt=login`. The two parameters cannot be combined: Microsoft's OIDC documentation states that `login_hint` and `select_account` cannot both be sent, and `-UserName` with `-Credential` is refused for the same reason - two names for one account, and honouring either silently discards the other.

## How

**`New-EntraSignInUri`** (new, pure, fully unit-tested) builds the rewritten request and is deliberately narrow:

- only `login.microsoftonline.com` / `.us` / `.partner.microsoftonline.cn`, and only over HTTPS - what gets appended is an account name, and it is not handed to a host nobody named;
- only an authorization endpoint (v1 or v2). The credential post, `/kmsi`, the token endpoint - all left alone;
- WS-Federation gets `wfresh=0`, which is that protocol's "do not reuse the session"; it cannot name an account;
- never a parameter the application set itself;
- only ever **adds**, so `state`, `nonce` and `redirect_uri` are untouched, the request Entra validates is still the one Omada built, and the correlation cookie the application set for it still matches;
- the account name is escaped, so a name containing `&prompt=none` stays a name.

**A `NavigationStarting` handler** applies it. That is the last point at which the choice can still be influenced, and it fires for redirects - which is how the authorization request arrives. It caps itself at three rewrites per window: a redirect chain may legitimately carry more than one authorization request, but a browser going round the same loop is worse than one that stops trying, and without the rewrite the sign-in still works, it just picks the account itself.

**Windows-account SSO** is turned off for exactly these sign-ins and stays on for every other one, so nothing existing gets slower. A `CoreWebView2Environment` cannot be reconfigured after creation, so a session later asked for a different answer is given a new environment instead of silently keeping the old behaviour.

**The account joins the session key**, so it decides the cookie cache and the WebView2 profile too. Two accounts against the same environment can no longer be signed in as each other, and switching between them needs no signing out in between.

## A password is optional

`-UserName` supplies none, and a `PSCredential` may carry an empty one:

```powershell
$Credential = [System.Management.Automation.PSCredential]::new("mark@example.com", [System.Security.SecureString]::new())
```

`Resolve-EntraSignInScreen` has refused to submit an empty password since it was written - an empty password is one of the attempts an account has before smart lockout - and takes a passwordless method when the page offers one. What changes here is that the autofill driver reads the account from the session rather than from `Credential.UserName`, so it engages for an account named without any credential at all. When Entra insists on a password, the window stays open and waits, with the wording #86 added.

## Tests

- `New-EntraSignInUri`: 20 cases - both parameter shapes, no query, escaping, an application's own `prompt`/`login_hint`, another identity provider, plain HTTP, three non-authorization paths in the chain, WS-Federation, a sovereign cloud, and junk input.
- Session identity: two accounts get two session keys and two cookie files; `-UserName` and the same name on a `-Credential` resolve to one.
- Parameter contract: all five refusals, the account resolved onto the session from either source (including a credential with an empty password), the default left untouched, and neither parameter forwarded to the underlying web cmdlet.

## Not in this PR

The automatic single recovery attempt when a sign-in is refused for the wrong account (#3 of 4), and the canary scenarios that exercise all of this against the real tenant (#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry1rBzPbM1vjfyK9ezEDC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry1rBzPbM1vjfyK9ezEDC6)_