### PR TITLE
Offer the account picker once when a sign-in is refused for the wrong account

### DIFF
--- a/OmadaWeb.PS/Private/Get-DataFromWebView2.ps1
+++ b/OmadaWeb.PS/Private/Get-DataFromWebView2.ps1
@@ -8,6 +8,13 @@ function Get-DataFromWebView2 {
         [switch]$InPrivate
     )
 
+    # Read before anything can throw, because the finally block below puts it back. The recovery
+    # further down turns the account picker on for the session it is repairing, and leaving it on
+    # afterwards would make every later sign-in of that session stop and ask - including the ones
+    # that are working. Assigning it inside the try would mean a failure in the first statement of
+    # that block ended in an unset-variable error from the handler instead of the real one.
+    $SelectAccountBeforeRecovery = $SessionContext.SelectAccount
+
     try {
         "{0} - Invoking data from WebView2" -f $MyInvocation.MyCommand | Write-Verbose
 
@@ -19,6 +26,10 @@ function Get-DataFromWebView2 {
         # stack, so the session driving this login is bridged through this script-scope pointer.
         $Script:CurrentWebView2Session = $SessionContext
         $Script:CurrentWebView2Session.LoginRetryCount = 0
+
+        # One allowance per sign-in, not per PowerShell session: a call made an hour later deserves
+        # the same offer of an account picker as this one.
+        $Script:CurrentWebView2Session.AccountRecoveryAttempted = $false
 
         # A new sign-in gets a fresh attempt at autofill, whatever happened during the previous one.
         # Every window opened from here resets it again - see Initialize-WebView2.
@@ -46,8 +57,39 @@ function Get-DataFromWebView2 {
                 # travel the same redirect chain and land on the same error page, so stop here and
                 # report what that page said.
                 if ($null -ne $Script:LoginAbortReason) {
-                    $Script:CurrentWebView2Session.LoginRetryCount = 0
-                    break
+                    # Unless the refusal was about which account signed in, in which case another
+                    # window is not the same window: it carries prompt=select_account, so Entra ID
+                    # asks instead of choosing, and the person who is already sitting in front of the
+                    # browser can pick the account that does work. Test-SignInAccountRecovery holds
+                    # the whole rule for when that is worth doing.
+                    if (Test-SignInAccountRecovery -Category $Script:LoginAbortReason.Category -UserName $Script:CurrentWebView2Session.UserName -RecoveryAttempted:$Script:CurrentWebView2Session.AccountRecoveryAttempted) {
+                        $Tenant = "this tenant"
+                        if ($null -ne $Script:LoginAbortReason.Detail -and -not [string]::IsNullOrWhiteSpace($Script:LoginAbortReason.Detail.ResourceTenant)) {
+                            $Tenant = "tenant '{0}'" -f $Script:LoginAbortReason.Detail.ResourceTenant
+                        }
+
+                        "The account the browser signed in with is not known in {0}. Opening the sign-in window once more, this time asking which account to use - please choose one that exists in that tenant." -f $Tenant | Write-Warning
+
+                        $Script:CurrentWebView2Session.AccountRecoveryAttempted = $true
+                        $Script:CurrentWebView2Session.SelectAccount = $true
+
+                        # Deliberately not paired with a browsing-data clear. prompt=select_account
+                        # already stops Entra ID answering from the session it holds, and clearing
+                        # cookies underneath a sign-in that is starting is what produced AADSTS50058
+                        # in the canary (see the note in Tests/E2E/EntraSignInCanary.Tests.ps1). The
+                        # cheaper of the two also keeps the user's multi-factor state, so the account
+                        # they pick is not made to prove itself from scratch.
+
+                        # Cleared so the drivers stop reading it as "this sign-in is over", and the
+                        # count is put back to the first attempt so the new window opens at once
+                        # rather than after the two-second pause a timed-out window earns.
+                        $Script:LoginAbortReason = $null
+                        $Script:CurrentWebView2Session.LoginRetryCount = 1
+                    }
+                    else {
+                        $Script:CurrentWebView2Session.LoginRetryCount = 0
+                        break
+                    }
                 }
 
                 if ($Script:CurrentWebView2Session.LoginRetryCount -gt 3) {
@@ -108,6 +150,12 @@ function Get-DataFromWebView2 {
         $PSCmdlet.ThrowTerminatingError($PSItem)
     }
     finally {
+        # The account picker belongs to the recovery, not to the session. Put it back however this
+        # call ended - the caller's own -SelectAccount, if they passed one, survives.
+        if ($null -ne $SessionContext) {
+            $SessionContext.SelectAccount = $SelectAccountBeforeRecovery
+        }
+
         $Script:CurrentWebView2Session = $null
     }
 }

--- a/OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1
+++ b/OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1
@@ -43,6 +43,10 @@ function Get-OmadaSessionContext {
         # supplied it: the WebView2 window runs in a blocking dialog that cannot see the call stack.
         UserName            = $null
         SelectAccount       = $false
+        # Whether this sign-in has already been given its one window with an account picker on it
+        # after being refused for the wrong account. Reset at the start of every sign-in, so the
+        # allowance is per call and not per PowerShell session.
+        AccountRecoveryAttempted = $false
         PreferredMfaMethod  = $null
         LastSessionType     = $null
         WebView2Used        = $false

--- a/OmadaWeb.PS/Private/Test-SignInAccountRecovery.ps1
+++ b/OmadaWeb.PS/Private/Test-SignInAccountRecovery.ps1
@@ -1,0 +1,84 @@
+function Test-SignInAccountRecovery {
+    <#
+    .SYNOPSIS
+        Decides whether a refused sign-in is worth one more window with the account picker on it.
+
+    .DESCRIPTION
+        A sign-in refused because the account is not known in the application's tenant is final for
+        that account and only for that account. Somebody else - the same person's guest identity in
+        that tenant, or a different account entirely - signs in perfectly well, and the browser is
+        still open in front of the user when the refusal arrives. Ending the call there is correct
+        and useless: it tells a person who is sitting at a browser to go and run the command again.
+
+        So the WebView2 driver is allowed exactly one more attempt, with prompt=select_account on the
+        request, and this function is the rule for when that is the right thing to do. It is kept out
+        of the driver so it can be read, tested and argued with on its own.
+
+        Four things all have to hold:
+
+          - The refusal is a WrongAccount one. Every other category answers every account the same
+            way, so another window is another way of spending somebody's time.
+          - No account was named by the caller. -UserName and -Credential are answers to exactly the
+            question the picker asks, and re-asking it would override what the caller already said -
+            when the account they named is the one the tenant rejected, the picker cannot help.
+          - Nothing has been tried yet for this call. One recovery, never two: a second refusal is
+            the tenant saying the same thing again, and a browser window that keeps reappearing is
+            worse than an error message.
+          - Somebody is there to answer. An account picker in a session with no interactive desktop
+            is a window nobody will ever click, and the call would hang where it used to fail with a
+            message. The check is Environment.UserInteractive, which is false exactly where that is
+            true - a service, a session-0 scheduled task.
+
+    .PARAMETER Category
+        The refusal category recorded by Stop-OmadaLogin.
+
+    .PARAMETER UserName
+        The account the caller named, if any.
+
+    .PARAMETER RecoveryAttempted
+        Whether this sign-in has already had its one attempt.
+
+    .PARAMETER UserInteractive
+        Whether there is a desktop session to show a picker in. Defaults to the process's own answer;
+        it is a parameter so the rule can be tested without one.
+
+    .OUTPUTS
+        System.Boolean.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Category,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$UserName,
+
+        [switch]$RecoveryAttempted,
+
+        [bool]$UserInteractive = [System.Environment]::UserInteractive
+    )
+
+    if ($Category -ne "WrongAccount") {
+        return $false
+    }
+
+    if ($RecoveryAttempted) {
+        "{0} - The sign-in has already been offered an account picker once, so the refusal stands." -f $MyInvocation.MyCommand | Write-Verbose
+        return $false
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($UserName)) {
+        "{0} - The account was named by the caller, so the refusal is about that account and an account picker cannot answer it." -f $MyInvocation.MyCommand | Write-Verbose
+        return $false
+    }
+
+    if (-not $UserInteractive) {
+        "{0} - There is no interactive desktop to show an account picker in, so the refusal stands." -f $MyInvocation.MyCommand | Write-Verbose
+        return $false
+    }
+
+    return $true
+}

--- a/OmadaWeb.PS/Private/Test-SignInAccountRecovery.ps1
+++ b/OmadaWeb.PS/Private/Test-SignInAccountRecovery.ps1
@@ -25,9 +25,9 @@ function Test-SignInAccountRecovery {
             the tenant saying the same thing again, and a browser window that keeps reappearing is
             worse than an error message.
           - Somebody is there to answer. An account picker in a session with no interactive desktop
-            is a window nobody will ever click, and the call would hang where it used to fail with a
-            message. The check is Environment.UserInteractive, which is false exactly where that is
-            true - a service, a session-0 scheduled task.
+            is a window nobody will ever click, and the call would hang there where it used to fail
+            with a message that says what is wrong. The check is Environment.UserInteractive, which
+            is false in exactly those places - a Windows service, a session-0 scheduled task.
 
     .PARAMETER Category
         The refusal category recorded by Stop-OmadaLogin.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,16 @@ This account cannot be used for this application however often the sign-in is re
 Entra ID withholds the account name from this message because it identifies an end user. Look the attempt up by its correlation ID in the sign-in logs of the tenant that refused it to see which account was used.
 ```
 
+**A refusal about the account gets one more window, with the picker on it.** When the sign-in was refused because the account the browser chose is not known in the application's tenant - and only then - the module says so and opens the sign-in window once more with `prompt=select_account`, so you can pick an account that does exist there:
+
+```text
+WARNING: The account the browser signed in with is not known in tenant 'Example productie'. Opening the
+sign-in window once more, this time asking which account to use - please choose one that exists in that
+tenant.
+```
+
+Once, never twice: a second refusal is the tenant repeating itself. It is also skipped entirely when you named the account yourself with `-UserName` or `-Credential` - the picker asks exactly the question you already answered - and when there is no interactive desktop, where a picker would be a window nobody will ever click and the command would hang instead of failing with a message.
+
 The request then fails with that same message rather than with a bare "could not authenticate", so what to do next is in the error itself. Add `-ForceAuthentication` to the retry so the sign-in starts from a clean browser session.
 
 Everything under `Meaning` is lifted out of the message Entra wrote, because all of it is something you have to paste into a portal to get any further and none of it was anywhere you could see it. One thing is deliberately missing: the account name. Entra replaces it with `{EUII Hidden}` in a message it hands to an application, so the sign-in logs of the tenant that refused the sign-in - searched by the correlation ID above - are the only place the account can be identified.

--- a/Tests/Unit/Get-DataFromWebView2.Recovery.Tests.ps1
+++ b/Tests/Unit/Get-DataFromWebView2.Recovery.Tests.ps1
@@ -1,0 +1,157 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Recovering a sign-in that was refused for the wrong account' -Tag 'Unit' {
+
+    BeforeAll {
+        InModuleScope 'OmadaWeb.PS' {
+            # A refusal shaped exactly as Stop-OmadaLogin records one, without a browser having to
+            # produce it.
+            function Script:New-TestAbortReason {
+                param([string]$Category = 'WrongAccount')
+
+                return [PSCustomObject]@{
+                    Message  = "AADSTS50178: User account does not exist in tenant 'Example productie'."
+                    Code     = 'AADSTS50178'
+                    Reason   = 'The account that signed in is not known in the tenant the Omada application is registered in.'
+                    Url      = 'https://example.omada.cloud/logon.aspx'
+                    Engine   = 'WebView2'
+                    Category = $Category
+                    Detail   = [PSCustomObject]@{ HasDetail = $true; ResourceTenant = 'Example productie' }
+                }
+            }
+        }
+    }
+
+    BeforeEach {
+        InModuleScope 'OmadaWeb.PS' {
+            # The window itself is the one thing these tests do not exercise: the driver's decisions
+            # are what is under test, and they are all taken between windows.
+            Mock Install-WebView2 { $true }
+            Mock Add-ReflectionAssembly {}
+            Mock Reset-LoginAutomationState {}
+
+            $Script:TestWindowCount = 0
+            $Script:TestSelectAccountPerWindow = @()
+        }
+    }
+
+    It 'Opens one more window with the account picker, and signs in with what the user chooses' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Test-SignInAccountRecovery { $true }
+            Mock Start-WebView2Login {
+                $Script:TestWindowCount++
+                $Script:TestSelectAccountPerWindow += $Script:CurrentWebView2Session.SelectAccount
+
+                if ($Script:TestWindowCount -eq 1) {
+                    # The first window comes back refused, exactly as a real one does.
+                    $Script:LoginAbortReason = New-TestAbortReason
+                    return
+                }
+
+                $Script:CurrentWebView2Session.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' }
+            }
+
+            $SessionContext = Get-OmadaSessionContext -Key 'unit-test-recovery-succeeds'
+            $SessionContext.BaseUrl = 'http://localhost:19000/'
+            $SessionContext.AuthCookie = $null
+
+            Get-DataFromWebView2 -SessionContext $SessionContext -WarningAction SilentlyContinue
+
+            $Script:TestWindowCount | Should -Be 2
+            $SessionContext.AuthCookie.Value | Should -Be 'cookie-value'
+
+            # The first window let the browser choose, the second asked. That is the entire repair.
+            $Script:TestSelectAccountPerWindow[0] | Should -BeFalse
+            $Script:TestSelectAccountPerWindow[1] | Should -BeTrue
+        }
+    }
+
+    It 'Leaves the account picker off the session once the call is over' {
+        # It belongs to the recovery, not to the session: every later sign-in would otherwise stop
+        # and ask, including the ones that were working all along.
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Test-SignInAccountRecovery { $true }
+            Mock Start-WebView2Login {
+                $Script:TestWindowCount++
+                if ($Script:TestWindowCount -eq 1) {
+                    $Script:LoginAbortReason = New-TestAbortReason
+                    return
+                }
+                $Script:CurrentWebView2Session.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' }
+            }
+
+            $SessionContext = Get-OmadaSessionContext -Key 'unit-test-recovery-restores'
+            $SessionContext.BaseUrl = 'http://localhost:19000/'
+            $SessionContext.AuthCookie = $null
+
+            Get-DataFromWebView2 -SessionContext $SessionContext -WarningAction SilentlyContinue
+
+            $SessionContext.SelectAccount | Should -BeFalse
+        }
+    }
+
+    It 'Keeps a picker the caller asked for' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Test-SignInAccountRecovery { $true }
+            Mock Start-WebView2Login {
+                $Script:TestWindowCount++
+                $Script:CurrentWebView2Session.AuthCookie = [PSCustomObject]@{ Name = 'oisauthtoken'; Value = 'cookie-value'; domain = 'localhost' }
+            }
+
+            $SessionContext = Get-OmadaSessionContext -Key 'unit-test-recovery-keeps-caller-choice'
+            $SessionContext.BaseUrl = 'http://localhost:19000/'
+            $SessionContext.AuthCookie = $null
+            $SessionContext.SelectAccount = $true
+
+            Get-DataFromWebView2 -SessionContext $SessionContext -WarningAction SilentlyContinue
+
+            $SessionContext.SelectAccount | Should -BeTrue
+        }
+    }
+
+    It 'Stops after the second refusal instead of opening a third window' {
+        InModuleScope 'OmadaWeb.PS' {
+            # The real rule refuses a second attempt itself; this mock answers by whether one has
+            # been recorded, so the driver's own bookkeeping is what decides the outcome.
+            Mock Test-SignInAccountRecovery { -not $RecoveryAttempted }
+            Mock Start-WebView2Login {
+                $Script:TestWindowCount++
+                $Script:LoginAbortReason = New-TestAbortReason
+            }
+
+            $SessionContext = Get-OmadaSessionContext -Key 'unit-test-recovery-gives-up'
+            $SessionContext.BaseUrl = 'http://localhost:19000/'
+            $SessionContext.AuthCookie = $null
+
+            { Get-DataFromWebView2 -SessionContext $SessionContext -WarningAction SilentlyContinue -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*does not exist in tenant*'
+
+            $Script:TestWindowCount | Should -Be 2
+        }
+    }
+
+    It 'Does not open a second window for a refusal another account cannot answer' {
+        InModuleScope 'OmadaWeb.PS' {
+            Mock Test-SignInAccountRecovery { $false }
+            Mock Start-WebView2Login {
+                $Script:TestWindowCount++
+                $Script:LoginAbortReason = New-TestAbortReason -Category 'AppRegistration'
+            }
+
+            $SessionContext = Get-OmadaSessionContext -Key 'unit-test-recovery-not-offered'
+            $SessionContext.BaseUrl = 'http://localhost:19000/'
+            $SessionContext.AuthCookie = $null
+
+            { Get-DataFromWebView2 -SessionContext $SessionContext -WarningAction SilentlyContinue -ErrorAction Stop } | Should -Throw
+
+            $Script:TestWindowCount | Should -Be 1
+        }
+    }
+}

--- a/Tests/Unit/Test-SignInAccountRecovery.Tests.ps1
+++ b/Tests/Unit/Test-SignInAccountRecovery.Tests.ps1
@@ -1,0 +1,58 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+}
+
+Describe 'Test-SignInAccountRecovery' -Tag 'Unit' {
+
+    Context 'The one case worth another window' {
+        It 'Offers the account picker when the tenant did not know the account the browser chose' {
+            InModuleScope 'OmadaWeb.PS' {
+                Test-SignInAccountRecovery -Category 'WrongAccount' -UserInteractive $true | Should -BeTrue
+            }
+        }
+    }
+
+    Context 'Refusals another account cannot answer' {
+        It 'Does not offer it for any other category' {
+            InModuleScope 'OmadaWeb.PS' {
+                foreach ($Category in @('Authorization', 'AppRegistration', 'IdentityProvider', 'Unknown', 'None', '')) {
+                    Test-SignInAccountRecovery -Category $Category -UserInteractive $true |
+                        Should -BeFalse -Because "'$Category' answers every account the same way"
+                }
+            }
+        }
+    }
+
+    Context 'Refusals the user already answered' {
+        It 'Does not overrule an account the caller named' {
+            # The picker asks exactly the question -UserName already answered, and the account it
+            # named is the one the tenant rejected.
+            InModuleScope 'OmadaWeb.PS' {
+                Test-SignInAccountRecovery -Category 'WrongAccount' -UserName 'mark@example.com' -UserInteractive $true | Should -BeFalse
+            }
+        }
+
+        It 'Offers it once and never twice' {
+            # A second refusal is the tenant repeating itself, and a window that keeps reappearing is
+            # worse than an error message.
+            InModuleScope 'OmadaWeb.PS' {
+                Test-SignInAccountRecovery -Category 'WrongAccount' -RecoveryAttempted -UserInteractive $true | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'Nobody at the keyboard' {
+        It 'Does not open a picker in a session with no interactive desktop' {
+            # A scheduled task would hang on a window nobody will ever click, where it used to fail
+            # with a message that says what is wrong.
+            InModuleScope 'OmadaWeb.PS' {
+                Test-SignInAccountRecovery -Category 'WrongAccount' -UserInteractive $false | Should -BeFalse
+            }
+        }
+    }
+}


### PR DESCRIPTION
Third of four. **Stacked on #87**, which is stacked on #86 - review those first; this PR's diff is against #87.

## Why

A sign-in refused because the account is not known in the application's tenant is final for *that account* and only for that account. Somebody else - the same person's guest identity in that tenant, a different account entirely - signs in perfectly well, and the browser window is still open in front of the user when the refusal arrives.

Ending the call there is correct and useless: it tells a person who is sitting at a browser to go and run the command again.

## What happens now

```text
WARNING: The account the browser signed in with is not known in tenant 'Example productie'. Opening the
sign-in window once more, this time asking which account to use - please choose one that exists in that
tenant.
```

One more window, with `prompt=select_account` on the request (the mechanism from #87), so Entra ID asks instead of choosing.

## When

The rule lives in `Test-SignInAccountRecovery`, not in the driver, so it can be read and argued with on its own. Four conditions, all of which have to hold:

| Condition | Why |
|---|---|
| category is `WrongAccount` | every other category answers every account the same way, so another window is another way of spending somebody's time |
| the caller named no account | `-UserName` / `-Credential` answer exactly the question the picker asks - and when the account they named is the one the tenant rejected, the picker cannot help |
| nothing tried yet, this call | a second refusal is the tenant repeating itself; a window that keeps reappearing is worse than an error message |
| `Environment.UserInteractive` | a picker in a session with no desktop is a window nobody will ever click, and the call would **hang** where it used to fail with a message that says what is wrong |

The allowance is per sign-in, not per PowerShell session. The account picker is taken back off the session when the call ends - it belongs to the recovery, and leaving it on would make every later sign-in of that session stop and ask, including the ones that were working. A `-SelectAccount` the caller passed themselves survives.

## Deliberately not a browsing-data clear

`prompt=select_account` already stops Entra answering from the session it holds. Clearing cookies underneath a sign-in that is starting is what produced `AADSTS50058` in the canary (there is a standing note about it in `Tests/E2E/EntraSignInCanary.Tests.ps1`), and the cheaper of the two also keeps the user's multi-factor state - so the account they pick is not made to prove itself from scratch.

## Not changed: AADSTS16003 on Entra's own page

The same condition seen from the other side - silent SSO offering an account the tenant does not know - is `AADSTS16003`, which `Get-EntraErrorVerdict` already answers with `Manual`: autofill steps aside and the user picks an account in the window that is **already open**. That is the same outcome this PR arranges for the Omada-banner path, so turning it into a terminal error first, to then recover from it, would only add a window. Left as it is.

## Tests

- `Test-SignInAccountRecovery`: the one case that qualifies, all six categories that do not, an account the caller named, a second attempt, and a session with no interactive desktop.
- The driver loop, with the window mocked out: the second window carries the picker while the first does not, the cookie from it completes the call, the picker is off the session afterwards, a caller's own `-SelectAccount` survives, a second refusal ends the call after exactly two windows, and a category that does not qualify never opens a second one.

## Not in this PR

The canary scenarios that exercise all three PRs against the real tenant (#4 of 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry1rBzPbM1vjfyK9ezEDC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry1rBzPbM1vjfyK9ezEDC6)_