### PR TITLE
Watch the passwordless and no-account sign-ins against the real tenant

### DIFF
--- a/.github/workflows/entra-canary.yml
+++ b/.github/workflows/entra-canary.yml
@@ -43,7 +43,10 @@ jobs:
   canary:
     name: Entra ID sign-in
     runs-on: windows-latest
-    timeout-minutes: 30
+    # Three scenarios, each of which may be retried once for a flake. Two of them are watched for a
+    # fixed period rather than run to completion, because they are sign-ins that deliberately do not
+    # complete - see Tests/E2E/EntraSignInCanary.Tests.ps1.
+    timeout-minutes: 45
 
     # Holds the four canary secrets. An environment rather than repository secrets, so that no
     # pull-request workflow can reach them.
@@ -132,16 +135,27 @@ jobs:
           # failure - and that is the difference between a canary and a job that sometimes times out.
           # Generous for a real sign-in (no MFA on this account, so it is seconds) and short enough
           # that two attempts plus the flake pause fit inside the job timeout with room to report.
-          $attemptTimeoutSeconds = 300
+          # The sign-in that completes is quick - no MFA on this account, so it is seconds - while
+          # the two that deliberately do not complete are watched for a fixed 135 seconds and then
+          # stopped from inside the test. Both numbers leave room for a slow runner and are short
+          # enough that every scenario plus its flake retry fits inside the job timeout.
+          $attemptTimeoutSeconds = @{
+            PasswordAutofill = 300
+            UserNameOnly     = 330
+            NoUserName       = 330
+          }
 
           function Invoke-CanaryAttempt {
-            param([int]$Attempt)
+            param([string]$Scenario, [int]$Attempt)
 
-            $diagnosticPath = Join-Path $env:RUNNER_TEMP ("canary-diagnostic-{0}.txt" -f $Attempt)
+            $label = "{0}-{1}" -f $Scenario, $Attempt
+            $timeout = $attemptTimeoutSeconds[$Scenario]
+
+            $diagnosticPath = Join-Path $env:RUNNER_TEMP ("canary-diagnostic-{0}.txt" -f $label)
             Remove-Item -LiteralPath $diagnosticPath -Force -ErrorAction SilentlyContinue
 
-            $resultPath = Join-Path $env:GITHUB_WORKSPACE ("buildoutput/CanaryResults-{0}.xml" -f $Attempt)
-            $summaryPath = Join-Path $env:RUNNER_TEMP ("canary-summary-{0}.json" -f $Attempt)
+            $resultPath = Join-Path $env:GITHUB_WORKSPACE ("buildoutput/CanaryResults-{0}.xml" -f $label)
+            $summaryPath = Join-Path $env:RUNNER_TEMP ("canary-summary-{0}.json" -f $label)
             Remove-Item -LiteralPath $resultPath, $summaryPath -Force -ErrorAction SilentlyContinue
 
             $arguments = @(
@@ -150,28 +164,29 @@ jobs:
               "-ModulePath", ('"{0}"' -f $modulePath),
               "-ResultPath", ('"{0}"' -f $resultPath),
               "-SummaryPath", ('"{0}"' -f $summaryPath),
-              "-DiagnosticPath", ('"{0}"' -f $diagnosticPath)
+              "-DiagnosticPath", ('"{0}"' -f $diagnosticPath),
+              "-Scenario", $Scenario
             )
 
             # Captured to a file rather than streamed, so that a killed attempt still has a trace to
             # read. It is echoed into the job log below either way; a timed-out attempt whose output
             # went nowhere is what made the first stalled run unexplainable.
-            $childLog = Join-Path $env:RUNNER_TEMP ("canary-output-{0}.log" -f $Attempt)
-            $childErrorLog = Join-Path $env:RUNNER_TEMP ("canary-error-{0}.log" -f $Attempt)
+            $childLog = Join-Path $env:RUNNER_TEMP ("canary-output-{0}.log" -f $label)
+            $childErrorLog = Join-Path $env:RUNNER_TEMP ("canary-error-{0}.log" -f $label)
 
             $process = Start-Process -FilePath (Get-Command pwsh.exe).Source -ArgumentList $arguments -NoNewWindow -PassThru `
               -RedirectStandardOutput $childLog -RedirectStandardError $childErrorLog
-            $timedOut = -not $process.WaitForExit($attemptTimeoutSeconds * 1000)
+            $timedOut = -not $process.WaitForExit($timeout * 1000)
 
             if ($timedOut) {
-              Write-Host ("::warning title=Canary attempt timed out::Attempt {0} was still running after {1} seconds and was stopped." -f $Attempt, $attemptTimeoutSeconds)
+              Write-Host ("::warning title=Canary attempt timed out::{0} attempt {1} was still running after {2} seconds and was stopped." -f $Scenario, $Attempt, $timeout)
               try { $process.Kill($true) } catch { Write-Host "Could not stop the attempt cleanly: $($_.Exception.Message)" }
               # Every browser process the sign-in started outlives the runspace that opened it, and
               # the next attempt must not inherit one.
               Get-Process -Name msedgewebview2 -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
             }
 
-            Write-Host ("::group::Attempt {0} output" -f $Attempt)
+            Write-Host ("::group::{0} attempt {1} output" -f $Scenario, $Attempt)
             Get-Content -LiteralPath $childLog -ErrorAction SilentlyContinue | Write-Host
             Get-Content -LiteralPath $childErrorLog -ErrorAction SilentlyContinue | Write-Host
             Write-Host "::endgroup::"
@@ -189,12 +204,12 @@ jobs:
               $lastScreen = @(Select-String -LiteralPath $childLog -Pattern "Screen '.*', action '.*'" -ErrorAction SilentlyContinue |
                 Select-Object -Last 1 | ForEach-Object { $_.Line.Trim() })
 
-              $failure = @("- The sign-in did not finish within $attemptTimeoutSeconds seconds and was stopped. Nobody is at this browser, so a sign-in that waits for a user waits forever.")
+              $failure = @("- [$Scenario] The attempt did not finish within $timeout seconds and was stopped. Nobody is at this browser, so a sign-in that waits for a user waits forever - the scenarios that expect that stop themselves from the inside, so reaching this means one of them did not.")
               if ($lastScreen.Count -gt 0) {
-                $failure += "- The last page the automation named was: $($lastScreen[0])"
+                $failure += "- [$Scenario] The last page the automation named was: $($lastScreen[0])"
               }
               else {
-                $failure += "- The automation never named a page, so it did not get as far as reading one. Look at the trace above."
+                $failure += "- [$Scenario] The automation never named a page, so it did not get as far as reading one. Look at the trace above."
               }
 
               return [pscustomobject]@{
@@ -212,7 +227,7 @@ jobs:
                 Passed     = 0
                 Skipped    = 0
                 Diagnostic = $diagnostic
-                Failure    = @("- The attempt exited with code $($process.ExitCode) without reporting a result. See the output above.")
+                Failure    = @("- [$Scenario] The attempt exited with code $($process.ExitCode) without reporting a result. See the output above.")
               }
             }
 
@@ -223,50 +238,76 @@ jobs:
               Passed     = [int]$summary.Passed
               Skipped    = [int]$summary.Skipped
               Diagnostic = $diagnostic
-              Failure    = @($summary.Failure)
+              Failure    = @($summary.Failure | ForEach-Object { $_ -replace '^- ', ("- [{0}] " -f $Scenario) })
             }
           }
 
-          $first = Invoke-CanaryAttempt -Attempt 1
-          $final = $first
+          # Three sign-ins, one after the other. They cannot share a run: each needs its own browser
+          # window, and two of them are watched for a fixed period rather than run to completion.
+          #
+          #   PasswordAutofill - a user name and a password. Completes, and is the original canary:
+          #                      it watches whether Microsoft's screens are still recognized.
+          #   UserNameOnly     - a user name and no password. Must reach Entra as part of the request
+          #                      (login_hint), must arrive at the password page, must not submit an
+          #                      empty password, and must hand the window back saying it is waiting.
+          #   NoUserName       - neither. Must add nothing to the request and drive nothing at all.
+          $scenarios = @('PasswordAutofill', 'UserNameOnly', 'NoUserName')
+
+          $lines = [System.Collections.Generic.List[string]]::new()
+          $failures = [System.Collections.Generic.List[string]]::new()
+          $diagnostics = [System.Collections.Generic.List[string]]::new()
+          $totalFailed = 0
+          $totalSkipped = 0
+          $totalPassed = 0
+
+          foreach ($scenario in $scenarios) {
+            $first = Invoke-CanaryAttempt -Scenario $scenario -Attempt 1
+            $final = $first
+
+            if ($first.Failed -gt 0) {
+              # The flake policy. Microsoft's sign-in service has transient bad minutes, and a canary
+              # that alerts on one of them gets muted by its audience, which is the only failure mode
+              # worse than not having a canary. One automatic retry per scenario, and a warning
+              # either way so a run that needed the retry is still visible.
+              Write-Host ("::warning title=Canary retry::The {0} attempt failed. Retrying once in 120 seconds before alerting." -f $scenario)
+              Start-Sleep -Seconds 120
+              $final = Invoke-CanaryAttempt -Scenario $scenario -Attempt 2
+            }
+
+            $lines.Add(("{0}: {1} passed, {2} failed{3}." -f $scenario, $final.Passed, $final.Failed, $(if ($first.Failed -gt 0) { " (after the flake retry)" } else { "" })))
+
+            $totalFailed += $final.Failed
+            $totalPassed += $final.Passed
+            $totalSkipped += $final.Skipped
+
+            $final.Failure | ForEach-Object { $failures.Add($_) }
+
+            if (-not [string]::IsNullOrWhiteSpace($final.Diagnostic)) {
+              $diagnostics.Add(("{0}:`n{1}" -f $scenario, $final.Diagnostic.Trim()))
+            }
+          }
 
           # The tests decided for themselves that they are not configured. Reported rather than
           # passed off as a success, so a canary that has silently stopped running is visible.
-          if ($first.Skipped -gt 0 -and $first.Passed -eq 0 -and $first.Failed -eq 0) {
+          if ($totalSkipped -gt 0 -and $totalPassed -eq 0 -and $totalFailed -eq 0) {
             Write-Host "::notice title=Canary skipped::The canary tests reported themselves as not configured."
             "outcome=skipped" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
             "report=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
             exit 0
           }
 
-          if ($first.Failed -gt 0) {
-            # The flake policy. Microsoft's sign-in service has transient bad minutes, and a canary
-            # that alerts on one of them gets muted by its audience, which is the only failure mode
-            # worse than not having a canary. One automatic retry, and a warning either way so a run
-            # that needed the retry is still visible.
-            Write-Host "::warning title=Canary retry::The first attempt failed. Retrying once in 120 seconds before alerting."
-            Start-Sleep -Seconds 120
-            $final = Invoke-CanaryAttempt -Attempt 2
-          }
-
-          $lines = [System.Collections.Generic.List[string]]::new()
-          $lines.Add(("Attempt 1: {0} passed, {1} failed." -f $first.Passed, $first.Failed))
-          if ($first.Failed -gt 0) {
-            $lines.Add(("Attempt 2 (after the flake retry): {0} passed, {1} failed." -f $final.Passed, $final.Failed))
-          }
-
-          if ($final.Failure.Count -gt 0) {
+          if ($failures.Count -gt 0) {
             $lines.Add("")
             $lines.Add("Failed assertions:")
-            $final.Failure | ForEach-Object { $lines.Add($_) }
+            $failures | ForEach-Object { $lines.Add($_) }
           }
 
-          if (-not [string]::IsNullOrWhiteSpace($final.Diagnostic)) {
+          if ($diagnostics.Count -gt 0) {
             $lines.Add("")
             $lines.Add("Diagnostic reported by Switch-ToManualLogin:")
             $lines.Add("")
             $lines.Add('```')
-            $lines.Add($final.Diagnostic.Trim())
+            $diagnostics | ForEach-Object { $lines.Add($_) }
             $lines.Add('```')
           }
 
@@ -282,7 +323,7 @@ jobs:
             }
           }
 
-          $outcome = if ($final.Failed -gt 0) { 'failure' } else { 'success' }
+          $outcome = if ($totalFailed -gt 0) { 'failure' } else { 'success' }
           "outcome=$outcome" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
           $delimiter = "REPORT-" + [guid]::NewGuid().ToString('N')
@@ -292,7 +333,7 @@ jobs:
 
           $report | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
-          if ($final.Failed -gt 0) {
+          if ($totalFailed -gt 0) {
             throw "The Entra sign-in canary failed twice. See the report above."
           }
 

--- a/.github/workflows/entra-canary.yml
+++ b/.github/workflows/entra-canary.yml
@@ -334,7 +334,7 @@ jobs:
           $report | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
           if ($totalFailed -gt 0) {
-            throw "The Entra sign-in canary failed twice. See the report above."
+            throw "One or more Entra sign-in canary scenarios failed twice. See the report above."
           }
 
       - name: Upload the canary test results
@@ -411,7 +411,7 @@ jobs:
                 ];
 
             const body = [
-              `The scheduled Entra ID sign-in canary failed twice in a row, so this is not a transient Microsoft hiccup.`,
+              `A scheduled Entra ID sign-in canary scenario failed twice in a row, so this is not a transient Microsoft hiccup. The report below names the scenario.`,
               ``,
               ...diagnosis,
               ``,

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -1,7 +1,13 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ModulePath', Justification = 'Used by Import-Module inside the Describe BeforeAll, which the analyzer does not follow into.')]
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'The canary password arrives from a GitHub environment secret as an environment variable, which is a plain string by the time this process can see it. Building the PSCredential the module takes is the only thing done with it.')]
 param(
-    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1'),
+
+    # Which of the three sign-ins to drive. They are separate runs rather than separate assertions in
+    # one, because each needs its own browser window and two of them never finish - see the second
+    # Describe below.
+    [ValidateSet('PasswordAutofill', 'UserNameOnly', 'NoUserName')]
+    [string]$Scenario = 'PasswordAutofill'
 )
 
 # The scheduled login-flow canary (roadmap E5, issue #33).
@@ -48,9 +54,14 @@ BeforeDiscovery {
         [string]::IsNullOrWhiteSpace($Script:CanaryUserName) -or
         [string]::IsNullOrWhiteSpace($Script:CanaryPassword)
     )
+
+    # Read at discovery for the same reason as the configuration above: which Describe runs is a
+    # property of the run, not something to decide inside one.
+    $Script:RunPasswordScenario = $Script:CanaryConfigured -and $Scenario -eq 'PasswordAutofill'
+    $Script:RunWaitingScenario = $Script:CanaryConfigured -and $Scenario -in @('UserNameOnly', 'NoUserName')
 }
 
-Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigured) {
+Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:RunPasswordScenario) {
 
     BeforeAll {
         . (Join-Path $PSScriptRoot 'Start-CanaryRelyingParty.ps1')
@@ -209,6 +220,163 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:CanaryConfigur
         # Reads the runspace's error stream as well as the loop's own record, so a listener that died
         # before it ever served a request cannot be reported as healthy while the sign-in failure is
         # blamed on Microsoft.
+        (Get-CanaryRelyingPartyError -RelyingParty $Script:RelyingParty) -join [System.Environment]::NewLine | Should -BeNullOrEmpty
+    }
+}
+
+# The two sign-ins that are not meant to finish.
+#
+# A password that was never supplied and an account that was never named both end the same way: the
+# module fills in what it was given, refuses to invent the rest, and leaves the window open for the
+# person it is waiting for. On a runner that person does not exist, so there is nothing to wait for
+# and nothing to assert afterwards - which is exactly why these are worth watching against the real
+# Entra ID. It is the one arrangement where "the sign-in did not complete" is the correct outcome,
+# and where a module that quietly submitted an empty password instead would look like a success.
+#
+# So the sign-in runs in a background job and is watched rather than awaited. The job is a separate
+# process, which is what makes it stoppable: the WinForms dialog blocks the thread it is shown on, so
+# nothing inside that process can be interrupted once the window is up. The observation window is
+# fixed rather than cut short at the first marker, because the last thing these check - the handover
+# that says the sign-in is waiting for you - only happens after the module has seen no progress for
+# $Script:LoginAutomationFallbackTimeout seconds.
+Describe 'Entra ID sign-in canary - a sign-in that waits for the user' -Tag 'E2E' -Skip:(-not $Script:RunWaitingScenario) {
+
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'Start-CanaryRelyingParty.ps1')
+
+        $Port = if ([string]::IsNullOrWhiteSpace($Env:OMADAWEBPS_CANARY_PORT)) { 8400 } else { [int]$Env:OMADAWEBPS_CANARY_PORT }
+
+        # Both scenarios get an authorization request that carries no prompt and no login hint. For
+        # UserNameOnly that is the point - what reaches Entra has to have been put there by the
+        # module - and for NoUserName it is what makes "the module added nothing" mean something.
+        $Script:RelyingParty = Start-CanaryRelyingParty -TenantId $Env:OMADAWEBPS_CANARY_TENANT_ID -ClientId $Env:OMADAWEBPS_CANARY_CLIENT_ID -LoginHint '' -Prompt '' -Port $Port
+
+        # Long enough for the redirect chain, the sign-in page, and the 60 seconds of no progress
+        # that ends in the handover ($Script:LoginAutomationFallbackTimeout), with room for a slow
+        # runner. The workflow allows more than this per attempt, so a window that overruns is
+        # reported by these assertions rather than by a killed step.
+        $ObservationSeconds = 135
+
+        $UserNameForScenario = if ($Scenario -eq 'UserNameOnly') { $Env:OMADAWEBPS_CANARY_USERNAME } else { '' }
+
+        $SignIn = Start-Job -ScriptBlock {
+            param($ModulePath, $ResourceUrl, $UserName)
+
+            $VerbosePreference = 'Continue'
+            Import-Module $ModulePath -Force -ErrorAction Stop
+
+            $Parameter = @{
+                Uri                = $ResourceUrl
+                AuthenticationType = 'WebView2'
+                SkipCookieCache    = $true
+            }
+
+            # PowerShell 7 refuses to send a credential over an unencrypted connection without being
+            # told to, and the stand-in serves plain HTTP on loopback. Guarded by version because the
+            # parameter does not exist on Windows PowerShell 5.1.
+            if ($PSVersionTable.PSVersion.Major -ge 6) {
+                $Parameter['AllowUnencryptedAuthentication'] = $true
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($UserName)) {
+                $Parameter['UserName'] = $UserName
+            }
+
+            # Every stream, as strings, as they are produced. The verbose trace is the product here:
+            # what is being asserted is which decisions the module took on a page it could read
+            # perfectly well, and those are only ever reported there.
+            Invoke-OmadaWebRequest @Parameter -Verbose *>&1 | ForEach-Object { $_.ToString() }
+        } -ArgumentList $ModulePath, $Script:RelyingParty.ResourceUrl, $UserNameForScenario
+
+        $Deadline = [DateTime]::Now.AddSeconds($ObservationSeconds)
+        $Captured = [System.Collections.Generic.List[string]]::new()
+
+        while ([DateTime]::Now -lt $Deadline -and $SignIn.State -eq 'Running') {
+            foreach ($Record in @(Receive-Job -Job $SignIn -ErrorAction SilentlyContinue)) {
+                $Captured.Add([string]$Record)
+            }
+            Start-Sleep -Milliseconds 500
+        }
+
+        # Stopped, then drained: a job that buffered rather than streamed still hands over everything
+        # it wrote, so the assertions below never depend on how promptly a record crossed the process
+        # boundary.
+        Stop-Job -Job $SignIn -ErrorAction SilentlyContinue
+        foreach ($Record in @(Receive-Job -Job $SignIn -ErrorAction SilentlyContinue)) {
+            $Captured.Add([string]$Record)
+        }
+        Remove-Job -Job $SignIn -Force -ErrorAction SilentlyContinue
+
+        # The browser belongs to a process that has just been killed, and the next attempt must not
+        # inherit one that is still holding the profile.
+        Get-Process -Name msedgewebview2 -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+        $Script:Trace = $Captured -join [System.Environment]::NewLine
+
+        "::group::Entra sign-in canary trace ($Scenario)" | Write-Host
+        $Captured | ForEach-Object { $_ | Write-Host }
+        "::endgroup::" | Write-Host
+
+        if (-not [string]::IsNullOrWhiteSpace($Env:OMADAWEBPS_CANARY_DIAGNOSTIC_PATH)) {
+            @($Captured | Where-Object { $_ -match 'Automated Microsoft sign-in' }) -join [System.Environment]::NewLine |
+                Set-Content -LiteralPath $Env:OMADAWEBPS_CANARY_DIAGNOSTIC_PATH -Encoding UTF8
+        }
+    }
+
+    AfterAll {
+        Stop-CanaryRelyingParty -RelyingParty $Script:RelyingParty
+    }
+
+    It 'Put the account into the sign-in request' -Skip:($Scenario -ne 'UserNameOnly') {
+        # An account named on the command line has to reach Entra as part of the request, because by
+        # the time a page is drawn the account has already been chosen.
+        #
+        # This is also the scenario's proof that the browser got to Microsoft at all: the rewrite only
+        # ever happens on an authorization request on a Microsoft sign-in host, so the line cannot be
+        # in the trace unless the browser was there. Everything below depends on that, which is why
+        # this assertion comes first.
+        $Script:Trace | Should -Match 'Asking Entra ID for the account this call named' -Because "either the browser never reached the sign-in page, or -UserName did not reach the authorization request and Entra chose the account itself"
+    }
+
+    It 'Left the request alone when no account was named' -Skip:($Scenario -ne 'NoUserName') {
+        # The default has to stay indistinguishable from the module not being involved in the choice.
+        # The second assertion doubles as this scenario's proof that Microsoft was reached: the line
+        # is written from the autofill driver, which runs only while the browser is on the sign-in
+        # host.
+        $Script:Trace | Should -Not -Match 'Asking Entra ID for the account this call named'
+        $Script:Trace | Should -Match 'No account was named for this sign-in' -Because "either the browser never reached the sign-in page, or the module drove it when nobody had named an account"
+    }
+
+    It 'Reached the page that asks for a password' -Skip:($Scenario -ne 'UserNameOnly') {
+        # Proves the account name was filled in and accepted: Entra only asks for a password once it
+        # knows whose password it is asking for.
+        $Script:Trace | Should -Match "Screen 'PasswordRequired'" -Because "the sign-in never got as far as being asked for a password, so what happens when it is asked was not tested"
+    }
+
+    It 'Did not submit a password it was never given' -Skip:($Scenario -ne 'UserNameOnly') {
+        # An empty password is one of the attempts an account has before Entra ID locks it out, which
+        # is why the resolver refuses to send one. This is the assertion that would catch it doing so.
+        $Script:Trace | Should -Not -Match "Screen 'PasswordEntry', action 'SetValueAndClick'"
+        $Script:Trace | Should -Match "action 'Wait'"
+    }
+
+    It 'Handed the window back saying it is waiting, not that the page is broken' -Skip:($Scenario -ne 'UserNameOnly') {
+        # The failure this scenario exists for. Before, a password prompt ran into the stall detector
+        # and was reported as "the sign-in page no longer matches what this module knows about it,
+        # Microsoft probably changed it, please report this" - three false statements and a request
+        # to file a bug for having to type your own password.
+        $Script:Trace | Should -Match 'Automated Microsoft sign-in is waiting for you' -Because "a page the module read perfectly well was reported as a page it could not read"
+        $Script:Trace | Should -Not -Match 'no longer matches what this module knows about it'
+    }
+
+    It 'Drove nothing, and so reported nothing to fix' -Skip:($Scenario -ne 'NoUserName') {
+        # With no account named there is nothing to fill in, so the automation never engages - and a
+        # handover diagnostic here would mean it had engaged and then given up, which is a different
+        # thing entirely and would be reported as a broken sign-in page.
+        $Script:Trace | Should -Not -Match 'Automated Microsoft sign-in'
+    }
+
+    It 'Kept the loopback stand-in healthy throughout' {
         (Get-CanaryRelyingPartyError -RelyingParty $Script:RelyingParty) -join [System.Environment]::NewLine | Should -BeNullOrEmpty
     }
 }

--- a/Tests/E2E/Invoke-CanaryAttempt.ps1
+++ b/Tests/E2E/Invoke-CanaryAttempt.ps1
@@ -32,6 +32,11 @@
 .PARAMETER DiagnosticPath
     Passed to the test as OMADAWEBPS_CANARY_DIAGNOSTIC_PATH, where Switch-ToManualLogin's diagnostic
     is written when there is one.
+.PARAMETER Scenario
+    Which sign-in to drive. 'PasswordAutofill' is the sign-in that completes - the original canary.
+    'UserNameOnly' and 'NoUserName' are the two that are not meant to complete: they watch what the
+    module does when it is given an account but no password, and when it is given neither. Each needs
+    its own browser window, so each is its own attempt.
 .EXAMPLE
     ./Tests/E2E/Invoke-CanaryAttempt.ps1 -ModulePath ./buildoutput/OmadaWeb.PS/OmadaWeb.PS.psm1 `
         -ResultPath ./buildoutput/CanaryResults-1.xml -SummaryPath $env:RUNNER_TEMP/summary-1.json `
@@ -49,7 +54,10 @@ param(
     [string]$SummaryPath,
 
     [Parameter(Mandatory)]
-    [string]$DiagnosticPath
+    [string]$DiagnosticPath,
+
+    [ValidateSet('PasswordAutofill', 'UserNameOnly', 'NoUserName')]
+    [string]$Scenario = 'PasswordAutofill'
 )
 
 $ErrorActionPreference = "Stop"
@@ -57,7 +65,7 @@ $VerbosePreference = "Continue"
 
 $Env:OMADAWEBPS_CANARY_DIAGNOSTIC_PATH = $DiagnosticPath
 
-$Container = New-PesterContainer -Path (Join-Path $PSScriptRoot "EntraSignInCanary.Tests.ps1") -Data @{ ModulePath = $ModulePath }
+$Container = New-PesterContainer -Path (Join-Path $PSScriptRoot "EntraSignInCanary.Tests.ps1") -Data @{ ModulePath = $ModulePath; Scenario = $Scenario }
 
 $Configuration = New-PesterConfiguration
 $Configuration.Run.Container = $Container
@@ -71,6 +79,7 @@ $Configuration.TestResult.OutputPath = $ResultPath
 $Result = Invoke-Pester -Configuration $Configuration
 
 $Summary = [ordered]@{
+    Scenario = $Scenario
     Failed  = [int]$Result.FailedCount
     Passed  = [int]$Result.PassedCount
     Skipped = [int]$Result.SkippedCount

--- a/Tests/E2E/Start-CanaryRelyingParty.ps1
+++ b/Tests/E2E/Start-CanaryRelyingParty.ps1
@@ -105,6 +105,11 @@ function New-CanaryAuthorizeUri {
         only thing under test - would never be rendered. The canary would then pass by not testing
         anything, which is worse than failing.
 
+        It is a parameter rather than a constant because one thing under test is the module's own
+        ability to put that parameter there. A scenario that checks whether -UserName reaches Entra
+        as login_hint and prompt=login has to be given an authorization request that carries neither,
+        or it would be watching this stand-in do the work and calling it a pass.
+
         The login hint is sent so that Entra can serve the account's own sign-in experience. It does
         not skip the username screen: the automation still fills it in, which is what the canary is
         there to watch.
@@ -125,7 +130,12 @@ function New-CanaryAuthorizeUri {
         The opaque state value echoed back on the redirect, which the listener checks.
 
     .PARAMETER LoginHint
-        The canary account's user principal name.
+        The canary account's user principal name. Left out when the scenario is about the module
+        supplying it.
+
+    .PARAMETER Prompt
+        The OpenID Connect prompt to send. Defaults to 'login'; an empty value sends none, which is
+        what a scenario testing the module's own prompt needs.
 
     .OUTPUTS
         System.String. The absolute authorization request URI.
@@ -155,7 +165,11 @@ function New-CanaryAuthorizeUri {
 
         [AllowNull()]
         [AllowEmptyString()]
-        [string]$LoginHint
+        [string]$LoginHint,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Prompt = "login"
     )
 
     $QueryParameter = [ordered]@{
@@ -167,7 +181,10 @@ function New-CanaryAuthorizeUri {
         state                 = $State
         code_challenge        = $CodeChallenge
         code_challenge_method = "S256"
-        prompt                = "login"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Prompt)) {
+        $QueryParameter["prompt"] = $Prompt
     }
 
     if (-not [string]::IsNullOrWhiteSpace($LoginHint)) {
@@ -254,7 +271,12 @@ function Start-CanaryRelyingParty {
         The application (client) ID of the canary app registration.
 
     .PARAMETER LoginHint
-        The canary account's user principal name.
+        The canary account's user principal name. Left out when the scenario is about the module
+        supplying it.
+
+    .PARAMETER Prompt
+        The OpenID Connect prompt the authorization request carries. Defaults to 'login'; an empty
+        value sends none.
 
     .PARAMETER Port
         The loopback port to listen on. Must be covered by a registered redirect URI; Entra ignores
@@ -279,6 +301,10 @@ function Start-CanaryRelyingParty {
         [AllowEmptyString()]
         [string]$LoginHint,
 
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Prompt = "login",
+
         [ValidateRange(1024, 65535)]
         [int]$Port = 8400
     )
@@ -288,7 +314,7 @@ function Start-CanaryRelyingParty {
     $Pkce = New-CanaryPkcePair
     $StateValue = [guid]::NewGuid().ToString("N")
 
-    $AuthorizeUri = New-CanaryAuthorizeUri -TenantId $TenantId -ClientId $ClientId -RedirectUri $RedirectUri -CodeChallenge $Pkce.Challenge -State $StateValue -LoginHint $LoginHint
+    $AuthorizeUri = New-CanaryAuthorizeUri -TenantId $TenantId -ClientId $ClientId -RedirectUri $RedirectUri -CodeChallenge $Pkce.Challenge -State $StateValue -LoginHint $LoginHint -Prompt $Prompt
 
     $CookieName = "oisauthtoken"
     $CookieValue = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("canary-cookie-value"))

--- a/Tests/Unit/CanaryRelyingParty.Tests.ps1
+++ b/Tests/Unit/CanaryRelyingParty.Tests.ps1
@@ -193,9 +193,11 @@ Describe 'New-CanaryAuthorizeUri' -Tag 'Unit' {
         $Parameter = $Script:AuthorizeParameter.Clone()
         $Parameter.Prompt = ""
 
-        $Uri = New-CanaryAuthorizeUri @Parameter
+        $Query = Get-CanaryQueryParameter -Uri (New-CanaryAuthorizeUri @Parameter)
 
-        $Uri | Should -Not -Match 'prompt='
+        # Asked of the parsed query rather than of the raw string: 'prompt=' would also be satisfied
+        # by a parameter that merely ends in it, and absence is the thing being asserted.
+        $Query.ContainsKey("prompt") | Should -BeFalse
     }
 
     It 'Omits the login hint when none was supplied' {

--- a/Tests/Unit/CanaryRelyingParty.Tests.ps1
+++ b/Tests/Unit/CanaryRelyingParty.Tests.ps1
@@ -187,6 +187,17 @@ Describe 'New-CanaryAuthorizeUri' -Tag 'Unit' {
         (Get-CanaryQueryParameter -Uri $Uri)["login_hint"] | Should -Be "canary+test@example.onmicrosoft.com"
     }
 
+    It 'Omits the prompt when the scenario asks for a bare authorization request' {
+        # A scenario that tests whether the module puts prompt and login_hint on the request has to
+        # be given one that carries neither, or it would be watching the stand-in do the work.
+        $Parameter = $Script:AuthorizeParameter.Clone()
+        $Parameter.Prompt = ""
+
+        $Uri = New-CanaryAuthorizeUri @Parameter
+
+        $Uri | Should -Not -Match 'prompt='
+    }
+
     It 'Omits the login hint when none was supplied' {
         $Parameter = $Script:AuthorizeParameter.Clone()
         $Parameter.LoginHint = ""

--- a/docs/entra-canary.md
+++ b/docs/entra-canary.md
@@ -19,11 +19,34 @@ own schedule, and until now the detection mechanism was a user bug report.
 `Build/psakeBuild.ps1` has excluded the `E2E` tag from every build since long before this workflow
 existed, with a comment promising a separate scheduled pipeline. This is that pipeline.
 
+## The three scenarios
+
+Each run drives three sign-ins, one after the other. They cannot share a run: each needs its own
+browser window, and two of them are sign-ins that deliberately never finish.
+
+| Scenario | Given | Green when |
+|---|---|---|
+| `PasswordAutofill` | a user name and a password | the sign-in completes and the resource comes back — the original canary |
+| `UserNameOnly` | a user name, no password | the account reaches Entra **inside the authorization request** (`login_hint`), the password page is reached, no empty password is submitted, and the window is handed back saying it is waiting for you |
+| `NoUserName` | neither | nothing is added to the request and nothing is driven at all — the default has to stay indistinguishable from the module not being involved in the choice |
+
+The last two never complete, so they are watched rather than awaited: the sign-in runs in a
+background job for a fixed 135 seconds — long enough for the redirect chain, the sign-in page, and
+the 60 seconds of no progress that ends in the handover — and is then stopped from inside the test,
+which asserts against everything the module traced. A separate process is what makes that possible at
+all: the WinForms dialog blocks the thread it is shown on, so nothing inside that process can be
+interrupted once the window is up.
+
+`UserNameOnly` and `NoUserName` are given an authorization request carrying **no** `prompt` and **no**
+`login_hint`. For the first that is the point — whatever reaches Entra must have been put there by
+the module — and for the second it is what makes "the module added nothing" mean something.
+
 ## What it covers, and what it deliberately does not
 
 | | |
 |---|---|
 | **Covers** | The username screen, the password screen and "Stay signed in?" — the screens a password sign-in actually renders — driven by the shipping code path: `Invoke-WebView2MicrosoftLogin` over what `Get-EntraSignInProbeScript` reads and `Resolve-EntraSignInScreen` judges. |
+| **Covers** | That an account named with `-UserName` reaches Entra as part of the request, that a missing password is waited for rather than invented, and that naming no account leaves the request alone. |
 | **Does not cover** | Multi-factor authentication. An interactive approval cannot be automated, so the canary account is exempt by policy. The MFA screens in `Resolve-EntraSignInScreen` are covered by unit tests against recorded page snapshots instead. |
 | **Does not cover** | Interactive sign-in in general. That is IdP-agnostic — a tenant on Ping, Okta or ADFS reaches none of this code — so there is nothing here for the canary to watch. |
 | **Does not cover** | Omada itself. The canary needs no Omada environment; see below. |
@@ -178,10 +201,10 @@ also runs standalone:
 ### Flake policy
 
 Microsoft's sign-in service has transient bad minutes, and a canary that alerts on one of them gets
-muted by its audience — the only failure mode worse than having no canary. So the job runs the test,
-and on failure waits 120 seconds and runs it **once** more. The job fails only if both attempts fail.
-A first attempt that the retry cleared is still reported as a warning annotation, so flakes stay
-visible.
+muted by its audience — the only failure mode worse than having no canary. So each scenario runs, and on
+failure waits 120 seconds and runs **once** more. The job fails only if a scenario fails twice. A
+first attempt that the retry cleared is still reported as a warning annotation, so flakes stay
+visible. Every failed assertion in the report is prefixed with the scenario it came from.
 
 ### Notification
 
@@ -242,6 +265,21 @@ $env:OMADAWEBPS_CANARY_PASSWORD  = '<password>'
 
 Invoke-Pester -Path ./Tests/E2E -TagFilter E2E -Output Detailed
 ```
+
+That runs the `PasswordAutofill` scenario, which is the default. For one of the others, pass it
+through the container the way the workflow does:
+
+```powershell
+$Container = New-PesterContainer -Path ./Tests/E2E/EntraSignInCanary.Tests.ps1 -Data @{
+    ModulePath = './buildoutput/OmadaWeb.PS/OmadaWeb.PS.psm1'
+    Scenario   = 'UserNameOnly'
+}
+Invoke-Pester -Container $Container -TagFilter E2E -Output Detailed
+```
+
+A local run of `UserNameOnly` or `NoUserName` is worth watching rather than only reading: the browser
+window opens, stops where a person would take over, and stays there until the observation window ends
+— which is the behaviour being asserted.
 
 Without those variables the tests report **skipped**, which is also what keeps them out of a normal
 build. The build additionally excludes the `E2E` tag outright, so `./Build/build.ps1` never opens a


### PR DESCRIPTION
Fourth of four. **Stacked on #88 → #87 → #86** - review those first; this PR's diff is against #88.

## Why

The canary drove one sign-in: a user name and a password, which completes. The two paths #87 adds are the ones where the module deliberately does *nothing more* - it fills in what it was given, refuses to invent the rest, and leaves the window open for the person it is waiting for.

No unit test can say whether Entra ID still behaves that way, and a runner has nobody to type the password, so those sign-ins never end. **That is exactly why they are worth watching against the real tenant**: "the sign-in did not complete" is the correct outcome here, and a module that quietly submitted an empty password instead would look like a success.

## Three scenarios

| Scenario | Given | Green when |
|---|---|---|
| `PasswordAutofill` | user name + password | unchanged - the sign-in completes and the resource comes back |
| `UserNameOnly` | user name, **no password** | the account reaches Entra inside the authorization request (`login_hint`), the password page is reached, **no empty password is submitted**, and the window is handed back saying it is waiting for you |
| `NoUserName` | neither | nothing is added to the request and nothing is driven at all |

Each is its own attempt, because each needs its own browser window.

## How the two that never finish are tested

They are **watched, not awaited**. The sign-in runs in a background job for a fixed 135 seconds - the redirect chain, the sign-in page, and the 60 seconds of no progress that ends in the handover - and is then stopped from inside the test, which asserts against everything the module traced.

A separate process is what makes that possible at all: the WinForms dialog blocks the thread it is shown on, so nothing inside that process can be interrupted once the window is up. The job is stopped *and then* drained, so the assertions never depend on how promptly a record crossed the process boundary.

Both are given an authorization request carrying **no** `prompt` and **no** `login_hint`, which `Start-CanaryRelyingParty` can now build (`-Prompt ''`). For `UserNameOnly` that is the point - what reaches Entra must have been put there by the module, not by the stand-in - and for `NoUserName` it is what makes "the module added nothing" mean something.

Each scenario carries its own proof that the browser reached Microsoft at all, rather than a shared assertion that could pass for the wrong reason: the rewrite line only ever appears for an authorization request on a Microsoft sign-in host, and the "no account was named" line is only written while the browser is on that host.

## Workflow

Each scenario keeps its own flake retry, every failed assertion in the report names the scenario it came from, and the artifact glob is unchanged. The job timeout goes from 30 to 45 minutes to fit three scenarios and their retries with room to report - worst case is about 38 minutes.

## What a red run means now

Unchanged for `PasswordAutofill`: a selector break, with the diagnostic in the alert. For the other two it means the passwordless path stopped behaving - either the account no longer reaches Entra in the request, or a page the module reads perfectly well is being reported as one it cannot.

## Tests

`New-CanaryAuthorizeUri` gains a case for the bare authorization request, since a scenario that tests whether the *module* sets `prompt` and `login_hint` must not be handed a request that already carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry1rBzPbM1vjfyK9ezEDC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry1rBzPbM1vjfyK9ezEDC6)_