### PR TITLE
Stop the 401 retry recursing without end, and cover it and the cookie cache with tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to OmadaWeb.PS
+
+Thanks for helping improve the module. This page covers the few things that are specific to this
+repository: the one rule we ask every change to follow, where the tests live, and how a pull
+request gets validated.
+
+## Every bug fix ships with its regression test
+
+**A pull request that fixes a bug must also add the test that would have caught it.**
+
+Not a test that exercises the area in general — the test that fails on the code as it was, and
+passes on the code as it is. Write it first if you can; if you write it afterwards, revert your
+fix once and watch the test go red, so you know it is actually testing the fix.
+
+Why this rule and not a coverage target: the bugs this module has shipped were not in the
+untested-on-paper corners, they were in seams that looked obvious — a cookie written under one
+filename and read under another, a `ConvertTo-Json` without `-Depth` silently truncating a request
+body, a manifest field mangled on its way through a hashtable, a version cast that threw on a
+prerelease tag. Each of those was a small function nobody thought needed a test. A regression test
+is the cheapest way to make a fix permanent, and far cheaper to write while the failure is still
+reproducible in front of you than six months later.
+
+The same applies, in spirit, to a feature: land it with tests for the behaviour you are promising.
+
+If a fix genuinely cannot be tested — it only reproduces against a live tenant, or inside a real
+browser window — say so in the pull request and explain why, rather than leaving the reviewer to
+wonder. Often the answer is a seam: `Invoke-OmadaRequest`'s 401 retry is testable precisely because
+the browser is one mockable call (`Get-DataFromWebView2`) rather than something woven through the
+request path.
+
+## Where the tests live
+
+| Location | What it holds | When to add here |
+|---|---|---|
+| `Tests/Unit/*.Tests.ps1` | Pester unit tests for a single function, usually via `InModuleScope 'OmadaWeb.PS'`. | Anything that is logic. Most tests belong here. |
+| `Tests/Integration/*.Tests.ps1` | Tests that drive the real request path against a local `HttpListener`. | Behaviour that only appears once a real HTTP response comes back — status handling, retries, session state. |
+| Tests tagged `E2E` | Sign-in against a real tenant in a real browser. | Only for the sign-in flow itself. Excluded from the build; they run on the scheduled Entra canary (`docs/entra-canary.md`). |
+
+Three things worth knowing before you write one:
+
+- **Tests run against the built module**, not the source tree: the build passes `-ModulePath` to
+  each file pointing at `buildoutput`. Keep the `param([string]$ModulePath = ...)` header the
+  existing files use, so the file works both ways.
+- **Every test run enables `Set-StrictMode -Version Latest`** inside the module, and that reaches
+  into `InModuleScope` blocks. Reading a variable or property that does not exist is an error, not
+  `$null`.
+- **Nothing may reach the network or a real tenant.** An integration test brings its own
+  `HttpListener`; a unit test mocks the browser call.
+
+## Running the tests
+
+```powershell
+# Analyzer + build + help check + tests. This is what CI runs on a pull request.
+./Build/build.ps1 -Task TestBuildOnly -BuildVersion '0.0.0'
+
+# A single file, against the source module
+Invoke-Pester -Path ./Tests/Unit/OmadaCookieCache.Tests.ps1 -Output Detailed
+```
+
+PSScriptAnalyzer gates the build. The repository's PowerShell conventions are Stroustrup braces,
+no aliases, full cmdlet names in correct casing, spaces around operators, and aligned hashtable
+values.
+
+If you change comment-based help or a `-HelpMessage` in `Set-DynamicParameter.ps1`, run
+`Build/Update-ReadmeHelp.ps1` before committing — the README's command sections are generated, and
+`Build/Test-CommentBasedHelp.ps1` fails the build when an exported command is missing help.
+
+## Branches
+
+| Kind | Format |
+|---|---|
+| Feature | `feature/<description>` |
+| Bug fix | `bugfix/<description>` |
+| Hotfix | `hotfix/<description>` |
+| Docs | `docs/<description>` |
+| Release | `release/v<major>.<minor>.<patch>.<build>[-nightly]` |
+
+`<description>` is lowercase, words separated by hyphens or underscores. Branch from `main`.
+
+## Pull requests
+
+1. Open the pull request against `main`. Describe what broke or was missing, what changed, and how
+   you verified it — including the judgement calls a reviewer could reasonably have made
+   differently.
+2. **Validation does not start on its own.** Comment `/validate` on the pull request. Post it as
+   the most recent comment; a newer `/validate` supersedes an earlier run rather than racing it.
+3. Resolve every review thread, automated ones included, before asking for a merge.
+
+Please do not add AI-attribution trailers (`Co-Authored-By: Claude` and similar) to commits or
+pull request descriptions.

--- a/OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1
+++ b/OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1
@@ -55,6 +55,11 @@ function Get-OmadaSessionContext {
         CookieCacheFilePath = $null
         LoginRetryCount     = 0
         LoginCount          = 0
+        # How many times Invoke-OmadaRequest has re-authenticated this session and retried without
+        # the server accepting the result yet. Distinct from LoginRetryCount, which counts sign-in
+        # windows inside a single Get-DataFromWebView2/Get-DataFromWebDriver call and is reset every
+        # time one starts - which is why it cannot bound the retry recursion across calls.
+        ReAuthenticationCount = 0
         WebView2ProfilePath = (Join-Path $Script:WebView2UserProfileBasePath ("OmadaWebView2Profile_{0}" -f $KeyHash.Substring(0, 16)))
         WebViewEnv          = $null
         # Which way single sign-on with the Windows account was configured when WebViewEnv was

--- a/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
+++ b/OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1
@@ -366,6 +366,9 @@ function Invoke-OmadaRequest {
                             }
                         }
                         $SessionContext.LoginCount++
+                        # This session is answering again, so the re-authentication budget spent
+                        # getting here is returned - the next expiry gets a full one.
+                        $SessionContext.ReAuthenticationCount = 0
                         return $Return
                     }
                     "Invoke-WebRequest" {
@@ -385,6 +388,8 @@ function Invoke-OmadaRequest {
                             throw $CustomErrorTrigger
                         }
                         $SessionContext.LoginCount++
+                        # See the matching reset in the Invoke-RestMethod branch above.
+                        $SessionContext.ReAuthenticationCount = 0
                         return $Return
                     }
                     default {
@@ -427,6 +432,24 @@ function Invoke-OmadaRequest {
                         # The original 401 is carried as the inner exception: it holds the response
                         # this verdict was reached from, which is the only place the server's own
                         # explanation survives.
+                        throw (New-OmadaSessionExpiredError -Message $Message -BaseUrl $SessionContext.BaseUrl -InnerException $PSItem.Exception)
+                    }
+
+                    # Nothing else bounds the recursion at the end of this branch.
+                    # Get-DataFromWebView2 and Get-DataFromWebDriver each cap the number of sign-in
+                    # windows they open, but both reset that count on entry, so every recursion
+                    # starts their counter over. A server that answers 401 to a cookie the browser
+                    # keeps handing back therefore recursed without end - each turn opening another
+                    # sign-in window - until the call stack ran out.
+                    # The count lives on the session context and is cleared on the first successful
+                    # response (next to LoginCount++), so a long-lived session is never eventually
+                    # refused a re-authentication it legitimately needs.
+                    $SessionContext.ReAuthenticationCount++
+                    if ($SessionContext.ReAuthenticationCount -gt $Script:MaxLoginRetries) {
+                        $Message = "Re-authentication for '{0}' was attempted {1} time(s) and the server still answered HTTP 401. Giving up instead of signing in again." -f $SessionContext.BaseUrl, ($SessionContext.ReAuthenticationCount - 1)
+                        $SessionContext.ReAuthenticationCount = 0
+                        # The last 401 is carried as the inner exception: it holds the response the
+                        # verdict was reached from, which is where the server's own explanation is.
                         throw (New-OmadaSessionExpiredError -Message $Message -BaseUrl $SessionContext.BaseUrl -InnerException $PSItem.Exception)
                     }
 

--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,8 @@ Every release has a CycloneDX Software Bill of Materials (`OmadaWeb.PS-<version>
 
 Contributions are welcome! If you have ideas for improvements or bug fixes, feel free to open a pull request on [GitHub](https://github.com/Fortigi/OmadaWeb.PS).
 
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) first — it covers where the tests live, how to run them, how a pull request gets validated, and the one rule we ask every change to follow: **every bug fix ships with the test that would have caught it**.
+
 The COMMANDS, SYNTAX, EXAMPLES and PARAMETERS sections of this README are generated from the module, so help is written once:
 
 - Comment-based help in `OmadaWeb.PS/Public/*.ps1` is the source of every synopsis, description and example, and of the parameter descriptions of commands that declare their parameters normally. It is the same help `Get-Help` shows.

--- a/Tests/Integration/Invoke-OmadaRequest.ReAuth.Tests.ps1
+++ b/Tests/Integration/Invoke-OmadaRequest.ReAuth.Tests.ps1
@@ -1,0 +1,358 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    # A listener of this file's own rather than Tests/Integration/Start-WebServer.ps1, which always
+    # answers 200 and so cannot express the thing under test. It runs in-process on its own
+    # runspace and is steered through a synchronized hashtable, so a test can say "refuse the next
+    # request" or "refuse every request" and then read back how many requests actually arrived.
+    $Script:ServerState = [hashtable]::Synchronized(@{
+            UnauthorizedRemaining = 0      # 401 this many more times, then 200. -1 means always.
+            StatusOverride        = $null  # answer with this status instead, for the 502 case
+            Requests              = 0
+            Stop                  = $false
+        })
+
+    $Script:ServerPort = Get-Random -Minimum 21000 -Maximum 22000
+    $Script:ServerUri = "http://localhost:{0}/" -f $Script:ServerPort
+
+    $Script:ServerRunspace = [runspacefactory]::CreateRunspace()
+    $Script:ServerRunspace.Open()
+    $Script:ServerRunspace.SessionStateProxy.SetVariable("Prefix", $Script:ServerUri)
+    $Script:ServerRunspace.SessionStateProxy.SetVariable("State", $Script:ServerState)
+    $Script:ServerShell = [powershell]::Create()
+    $Script:ServerShell.Runspace = $Script:ServerRunspace
+    $Script:ServerShell.AddScript({
+            $Listener = [System.Net.HttpListener]::new()
+            $Listener.Prefixes.Add($Prefix)
+            $Listener.Start()
+            while (-not $State.Stop) {
+                try {
+                    $Context = $Listener.GetContext()
+                    if ($State.Stop) { $Context.Response.Close(); break }
+
+                    $State.Requests++
+
+                    if ($null -ne $State.StatusOverride) {
+                        $Status = [int]$State.StatusOverride
+                    }
+                    elseif ($State.UnauthorizedRemaining -ne 0) {
+                        $Status = 401
+                        if ($State.UnauthorizedRemaining -gt 0) { $State.UnauthorizedRemaining-- }
+                    }
+                    else {
+                        $Status = 200
+                    }
+
+                    $Body = if ($Status -eq 200) { '{"value":"ok"}' } else { "denied" }
+                    $Bytes = [Text.Encoding]::UTF8.GetBytes($Body)
+                    $Context.Response.StatusCode = $Status
+                    $Context.Response.ContentType = "application/json"
+                    $Context.Response.OutputStream.Write($Bytes, 0, $Bytes.Length)
+                    $Context.Response.Close()
+                }
+                catch {
+                    if (-not $Listener.IsListening) { break }
+                }
+            }
+            try { $Listener.Stop() } catch { }
+        }) | Out-Null
+    $Script:ServerShell.BeginInvoke() | Out-Null
+
+    # Readiness: poll rather than sleep a fixed amount. Deliberately not the shared harness's probe,
+    # which counted a request of its own against the very counters these tests assert on.
+    $Ready = $false
+    $Deadline = [System.Diagnostics.Stopwatch]::StartNew()
+    while (-not $Ready -and $Deadline.Elapsed.TotalSeconds -lt 30) {
+        try {
+            Invoke-WebRequest -Uri $Script:ServerUri -TimeoutSec 2 -SkipHttpErrorCheck | Out-Null
+            $Ready = $true
+        }
+        catch { Start-Sleep -Milliseconds 250 }
+    }
+    if (-not $Ready) { throw "The test listener did not start on $Script:ServerUri" }
+    $Script:ServerState.Requests = 0
+
+    function Reset-ServerState {
+        param(
+            [int]$Unauthorized = 0,
+            $StatusOverride = $null
+        )
+        $Script:ServerState.UnauthorizedRemaining = $Unauthorized
+        $Script:ServerState.StatusOverride = $StatusOverride
+        $Script:ServerState.Requests = 0
+    }
+
+    # Every test starts from a session store with nothing in it, so one test's cookie or
+    # re-authentication count cannot be read by the next.
+    function Reset-SessionState {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:OmadaSessions = @{}
+            $Script:OmadaWebAuthCookie = $null
+            $Script:RecheckEnvironmentSuspended = $false
+        }
+    }
+
+    function Get-OnlySessionContext {
+        InModuleScope 'OmadaWeb.PS' {
+            $Script:OmadaSessions.Values | Select-Object -First 1
+        }
+    }
+
+    $Script:FakeCookie = [pscustomobject]@{
+        name     = "oisauthtoken"
+        value    = "test-cookie-value"
+        domain   = "localhost"
+        path     = "/"
+        expires  = $null
+        httpOnly = $true
+        secure   = $false
+        sameSite = "Lax"
+    }
+}
+
+AfterAll {
+    if ($null -ne $Script:ServerState) { $Script:ServerState.Stop = $true }
+    try { Invoke-WebRequest -Uri $Script:ServerUri -TimeoutSec 2 -SkipHttpErrorCheck | Out-Null } catch { }
+    try { $Script:ServerShell.Stop() } catch { }
+    try { $Script:ServerRunspace.Dispose() } catch { }
+}
+
+Describe 'Invoke-OmadaRequest 401 re-authentication' -Tag 'Integration' {
+
+    BeforeEach {
+        Reset-SessionState
+        # The browser is the one thing that cannot run here, so it is the one thing mocked: it
+        # hands back a cookie exactly as a completed sign-in would. Everything else - the request,
+        # the 401, the catch, the recursion - is the real code path.
+        Mock -ModuleName OmadaWeb.PS Get-DataFromWebView2 {
+            $SessionContext.AuthCookie = [pscustomobject]@{
+                name     = "oisauthtoken"
+                value    = "test-cookie-value"
+                domain   = "localhost"
+                path     = "/"
+                expires  = $null
+                httpOnly = $true
+                secure   = $false
+                sameSite = "Lax"
+            }
+        }
+    }
+
+    Context 'The server rejects once and then accepts' {
+        It 'should return the successful response to the caller' {
+            Reset-ServerState -Unauthorized 1
+
+            $Result = Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache
+            $Result.value | Should -Be "ok"
+        }
+
+        It 'should sign in once more and retry exactly once' {
+            Reset-ServerState -Unauthorized 1
+
+            Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache | Out-Null
+
+            # Two requests: the rejected one and the retry. Two sign-ins: the initial one (no
+            # cookie yet) and the one the 401 forced.
+            $Script:ServerState.Requests | Should -Be 2
+            Should -Invoke -ModuleName OmadaWeb.PS Get-DataFromWebView2 -Times 2 -Exactly
+        }
+
+        It 'should discard the rejected cookie before signing in again' {
+            Reset-ServerState -Unauthorized 1
+            $Observed = [System.Collections.Generic.List[object]]::new()
+            Mock -ModuleName OmadaWeb.PS Get-DataFromWebView2 -MockWith {
+                # What the cookie was at the moment the re-authentication started. A cookie still
+                # sitting here would mean the rejected one was never cleared.
+                $Observed.Add($SessionContext.AuthCookie)
+                $SessionContext.AuthCookie = [pscustomobject]@{
+                    name = "oisauthtoken"; value = "test-cookie-value"; domain = "localhost"
+                    path = "/"; expires = $null; httpOnly = $true; secure = $false; sameSite = "Lax"
+                }
+            }
+
+            Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache | Out-Null
+
+            $Observed.Count | Should -Be 2
+            $Observed[1] | Should -BeNullOrEmpty
+        }
+
+        It 'should leave the re-authentication budget spent, then restored, so the next expiry gets a full one' {
+            Reset-ServerState -Unauthorized 1
+            Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache | Out-Null
+
+            (Get-OnlySessionContext).ReAuthenticationCount | Should -Be 0
+        }
+    }
+
+    Context 'The server rejects every time' {
+        It 'should stop instead of recursing without end' {
+            # This is the case that used to recurse until the call stack ran out: each turn reset
+            # the sign-in window counter, so nothing accumulated across the recursion.
+            Reset-ServerState -Unauthorized -1
+
+            { Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache -ErrorAction Stop } |
+                Should -Throw "*still answered HTTP 401*"
+        }
+
+        It 'should give up after the configured number of attempts, not before and not after' {
+            Reset-ServerState -Unauthorized -1
+            $MaxRetries = InModuleScope 'OmadaWeb.PS' { $Script:MaxLoginRetries }
+
+            try { Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache -ErrorAction Stop | Out-Null } catch { }
+
+            # The first request happens after the initial sign-in; each of the MaxLoginRetries
+            # re-authentications adds one more. The attempt that would exceed the budget is refused
+            # before another sign-in window is opened.
+            $Script:ServerState.Requests | Should -Be ($MaxRetries + 1)
+            Should -Invoke -ModuleName OmadaWeb.PS Get-DataFromWebView2 -Times ($MaxRetries + 1) -Exactly
+        }
+
+        It 'should say how many attempts were made and which tenant refused them' {
+            Reset-ServerState -Unauthorized -1
+            $MaxRetries = InModuleScope 'OmadaWeb.PS' { $Script:MaxLoginRetries }
+
+            $Message = $null
+            try { Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache -ErrorAction Stop | Out-Null }
+            catch { $Message = $_.Exception.Message }
+
+            $Message | Should -Match ([regex]::Escape("attempted {0} time(s)" -f $MaxRetries))
+            $Message | Should -Match "localhost"
+        }
+
+        It 'should reset the budget once it has given up, so a later call is not refused outright' {
+            Reset-ServerState -Unauthorized -1
+            try { Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache -ErrorAction Stop | Out-Null } catch { }
+
+            (Get-OnlySessionContext).ReAuthenticationCount | Should -Be 0
+
+            # And proves it: the same session succeeds the moment the server accepts again.
+            Reset-ServerState -Unauthorized 0
+            (Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache).value | Should -Be "ok"
+        }
+    }
+
+    Context 'A 401 with -CookiePath' {
+        It 'should write the fresh cookie to disk before retrying, so the retry cannot reload the rejected one' {
+            $CookieFolder = Join-Path ([System.IO.Path]::GetTempPath()) ("omadaCookie_{0}" -f ([guid]::NewGuid().ToString("N")))
+            New-Item -Path $CookieFolder -ItemType Directory -Force | Out-Null
+            try {
+                $CookieFileName = InModuleScope 'OmadaWeb.PS' -Parameters @{ UriA = $Script:ServerUri } {
+                    Get-OmadaCookieFileName -Uri ([System.Uri]::new($UriA))
+                }
+                $CookieFile = Join-Path $CookieFolder -ChildPath $CookieFileName
+
+                # A stale cookie already on disk: exactly the one that causes the 401, and the one
+                # an unfixed retry would reload on its way round the loop. Written and read through
+                # the module's own helpers, so the file is in whatever shape the module expects
+                # (protected at rest since issue #21) rather than a bare Clixml this test invented.
+                InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $CookieFile } {
+                    Export-OmadaCookieFile -Path $PathA -AuthCookie ([pscustomobject]@{
+                            name = "oisauthtoken"; value = "stale-cookie"; domain = "localhost"
+                            path = "/"; expires = $null; httpOnly = $true; secure = $false; sameSite = "Lax"
+                        }) | Out-Null
+                }
+
+                Reset-ServerState -Unauthorized 1
+                Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -CookiePath $CookieFolder | Out-Null
+
+                $OnDisk = InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $CookieFile } {
+                    Import-OmadaCookieFile -Path $PathA
+                }
+                $OnDisk.value | Should -Be "test-cookie-value"
+                $Script:ServerState.Requests | Should -Be 2
+            }
+            finally {
+                Remove-Item -Path $CookieFolder -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'A 401 with the encrypted cookie cache in play' {
+        It 'should delete the cached cookie the server has just rejected' {
+            Reset-ServerState -Unauthorized 1
+
+            $CachePath = $null
+            # Observed while each re-authentication runs: by the time the call returns the cache
+            # has been written again, so asserting afterwards would prove nothing. A list in the
+            # test's own scope, not a $Script: variable - inside a mock body that would land in
+            # this file's scope, not the module's, and read back as $null.
+            $CacheExistedAtSignIn = [System.Collections.Generic.List[bool]]::new()
+            Mock -ModuleName OmadaWeb.PS Get-DataFromWebView2 -MockWith {
+                $CacheExistedAtSignIn.Add(
+                    (![string]::IsNullOrWhiteSpace($SessionContext.CookieCacheFilePath)) -and (Test-Path $SessionContext.CookieCacheFilePath -PathType Leaf)
+                )
+                $SessionContext.AuthCookie = [pscustomobject]@{
+                    name = "oisauthtoken"; value = "test-cookie-value"; domain = "localhost"
+                    path = "/"; expires = $null; httpOnly = $true; secure = $false; sameSite = "Lax"
+                }
+            }
+
+            try {
+                Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 | Out-Null
+                # Two sign-ins: the initial one and the one the 401 forced. The cache must have
+                # been gone by the time the second started - that is the rejected cookie being
+                # thrown away rather than handed straight back to the retry.
+                $CacheExistedAtSignIn.Count | Should -Be 2
+                $CacheExistedAtSignIn[1] | Should -Be $false
+            }
+            finally {
+                $CachePath = (Get-OnlySessionContext).CookieCacheFilePath
+                if (![string]::IsNullOrWhiteSpace($CachePath)) {
+                    Remove-Item -Path $CachePath -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+    }
+
+    Context 'Responses that are not a 401' {
+        It 'should not re-authenticate on a 502, and should mark the environment for a re-probe' {
+            Reset-ServerState -StatusOverride 502
+
+            # -MaximumRetryCount 0 turns off the transient-failure retry policy, which treats a 502
+            # as worth retrying with backoff. That is a separate mechanism and is not what this
+            # test is about: here the question is only whether a 502 triggers a sign-in.
+            try { Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache -MaximumRetryCount 0 -ErrorAction Stop | Out-Null } catch { }
+
+            InModuleScope 'OmadaWeb.PS' { $Script:RecheckEnvironmentSuspended } | Should -Be $true
+            # One sign-in (there was no cookie) and no second one: a 502 is not an authentication
+            # problem, and signing in again would only delay the real error.
+            Should -Invoke -ModuleName OmadaWeb.PS Get-DataFromWebView2 -Times 1 -Exactly
+            $Script:ServerState.Requests | Should -Be 1
+        }
+
+        It 'should surface a 500 without re-authenticating' {
+            Reset-ServerState -StatusOverride 500
+
+            { Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache -MaximumRetryCount 0 -ErrorAction Stop } | Should -Throw
+            $Script:ServerState.Requests | Should -Be 1
+            Should -Invoke -ModuleName OmadaWeb.PS Get-DataFromWebView2 -Times 1 -Exactly
+        }
+    }
+
+    Context '-NoInteractiveAuthentication' {
+        It 'should refuse to sign in again on a 401 and say so' {
+            Reset-ServerState -Unauthorized -1
+
+            # Seed a cookie so the call gets as far as the request; the switch forbids the sign-in
+            # that would otherwise happen first.
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ UriA = $Script:ServerUri } {
+                $Key = Get-OmadaSessionKey -Uri ([System.Uri]::new($UriA)) -AuthenticationType "WebView2"
+                $Context = Get-OmadaSessionContext -Key $Key -AuthorityHost ([System.Uri]::new($UriA)).Host
+                $Context.AuthCookie = [pscustomobject]@{
+                    name = "oisauthtoken"; value = "seeded"; domain = "localhost"
+                    path = "/"; expires = $null; httpOnly = $true; secure = $false; sameSite = "Lax"
+                }
+            }
+
+            { Invoke-OmadaRestMethod -Uri $Script:ServerUri -AuthenticationType WebView2 -SkipCookieCache -NoInteractiveAuthentication -ErrorAction Stop } |
+                Should -Throw "*no sign-in was attempted*"
+
+            Should -Invoke -ModuleName OmadaWeb.PS Get-DataFromWebView2 -Times 0 -Exactly
+        }
+    }
+}

--- a/Tests/Integration/Invoke-OmadaRequest.ReAuth.Tests.ps1
+++ b/Tests/Integration/Invoke-OmadaRequest.ReAuth.Tests.ps1
@@ -65,11 +65,14 @@ BeforeAll {
 
     # Readiness: poll rather than sleep a fixed amount. Deliberately not the shared harness's probe,
     # which counted a request of its own against the very counters these tests assert on.
+    # No -SkipHttpErrorCheck: it does not exist in Windows PowerShell 5.1, which is one of the two
+    # legs the build runs, and it is not needed - the listener answers 200 until a test tells it
+    # otherwise, and any other answer throws into the catch and is simply retried.
     $Ready = $false
     $Deadline = [System.Diagnostics.Stopwatch]::StartNew()
     while (-not $Ready -and $Deadline.Elapsed.TotalSeconds -lt 30) {
         try {
-            Invoke-WebRequest -Uri $Script:ServerUri -TimeoutSec 2 -SkipHttpErrorCheck | Out-Null
+            Invoke-WebRequest -Uri $Script:ServerUri -TimeoutSec 2 -UseBasicParsing | Out-Null
             $Ready = $true
         }
         catch { Start-Sleep -Milliseconds 250 }
@@ -117,7 +120,9 @@ BeforeAll {
 
 AfterAll {
     if ($null -ne $Script:ServerState) { $Script:ServerState.Stop = $true }
-    try { Invoke-WebRequest -Uri $Script:ServerUri -TimeoutSec 2 -SkipHttpErrorCheck | Out-Null } catch { }
+    # One last request so the listener's blocking GetContext returns and the loop can see Stop.
+    # Its answer is irrelevant, hence the empty catch.
+    try { Invoke-WebRequest -Uri $Script:ServerUri -TimeoutSec 2 -UseBasicParsing | Out-Null } catch { }
     try { $Script:ServerShell.Stop() } catch { }
     try { $Script:ServerRunspace.Dispose() } catch { }
 }

--- a/Tests/Unit/OmadaCookieCache.Tests.ps1
+++ b/Tests/Unit/OmadaCookieCache.Tests.ps1
@@ -1,0 +1,267 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    # Get-OmadaCookieCacheFilePath.Tests.ps1 already covers where the cache file goes and how a
+    # file left behind by an older version is migrated. This file covers what goes *into* it and
+    # what comes back out - the read and write paths themselves, which nothing exercised.
+
+    $Script:SampleCookie = [pscustomobject]@{
+        name     = "oisauthtoken"
+        value    = "a-real-looking-bearer-value-0123456789"
+        domain   = "tenant.omada.cloud"
+        path     = "/"
+        expires  = $null
+        httpOnly = $true
+        secure   = $true
+        sameSite = "Lax"
+    }
+
+    function New-CookieFilePath {
+        Join-Path ([System.IO.Path]::GetTempPath()) ("omadaCookieTest_{0}.cookie" -f ([guid]::NewGuid().ToString("N")))
+    }
+
+    function Get-RawFileText {
+        param([string]$Path)
+        $Bytes = [System.IO.File]::ReadAllBytes($Path)
+        # Both spellings a .NET string could reach a file in, so "the secret is not in there" is
+        # a claim about the bytes rather than about one encoding.
+        @{
+            Utf8  = [System.Text.Encoding]::UTF8.GetString($Bytes)
+            Utf16 = [System.Text.Encoding]::Unicode.GetString($Bytes)
+        }
+    }
+}
+
+Describe 'Omada cookie cache - write path' -Tag 'Unit' {
+
+    It 'should report success and leave a file behind' {
+        $Path = New-CookieFilePath
+        try {
+            $Written = InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA
+            }
+            $Written | Should -Be $true
+            Test-Path -Path $Path | Should -Be $true
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should not leave the cookie value readable in the file' {
+        # The whole point of the protected format (issue #21): the file holds a bearer token, and
+        # a copy of it taken off the machine must be worthless.
+        $Path = New-CookieFilePath
+        try {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA | Out-Null
+            }
+
+            $Raw = Get-RawFileText -Path $Path
+            $Raw.Utf8 | Should -Not -Match "a-real-looking-bearer-value-0123456789"
+            $Raw.Utf16 | Should -Not -Match "a-real-looking-bearer-value-0123456789"
+            $Raw.Utf8 | Should -Not -Match "oisauthtoken"
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should write the single-SecureString document the cache-file test recognises' {
+        $Path = New-CookieFilePath
+        try {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA | Out-Null
+            }
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+                Test-OmadaCookieCacheFile -Path $PathA
+            } | Should -Be $true
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should overwrite a cookie file that is already there' {
+        $Path = New-CookieFilePath
+        try {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA | Out-Null
+                $Second = $CookieA.PSObject.Copy()
+                $Second.value = "second-value"
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $Second | Out-Null
+            }
+
+            (InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } { Import-OmadaCookieFile -Path $PathA }).value |
+                Should -Be "second-value"
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should warn and report failure rather than throw when the folder does not exist' {
+        # A cookie that cannot be cached costs a sign-in, not a failed request, so this must never
+        # take the caller's request down with it.
+        $Path = Join-Path ([System.IO.Path]::GetTempPath()) ("omadaCookieNoSuchFolder_{0}\x.cookie" -f ([guid]::NewGuid().ToString("N")))
+
+        $Result = InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
+            Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA -WarningAction SilentlyContinue
+        }
+        $Result | Should -Be $false
+    }
+
+    It 'should accept a null cookie without throwing' {
+        $Path = New-CookieFilePath
+        try {
+            { InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+                    Export-OmadaCookieFile -Path $PathA -AuthCookie $null | Out-Null
+                } } | Should -Not -Throw
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+Describe 'Omada cookie cache - read path' -Tag 'Unit' {
+
+    It 'should read back exactly what the write path stored' {
+        $Path = New-CookieFilePath
+        try {
+            $ReadBack = InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA | Out-Null
+                Import-OmadaCookieFile -Path $PathA
+            }
+
+            $ReadBack.name | Should -Be "oisauthtoken"
+            $ReadBack.value | Should -Be "a-real-looking-bearer-value-0123456789"
+            $ReadBack.domain | Should -Be "tenant.omada.cloud"
+            $ReadBack.path | Should -Be "/"
+            $ReadBack.httpOnly | Should -Be $true
+            $ReadBack.secure | Should -Be $true
+            $ReadBack.sameSite | Should -Be "Lax"
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should survive a cookie value full of characters XML would otherwise eat' {
+        $Path = New-CookieFilePath
+        try {
+            $Awkward = 'a<b>c&d"e''f/g+h=i%20j'
+            $ReadBack = InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; ValueA = $Awkward } {
+                $Cookie = [pscustomobject]@{
+                    name = "oisauthtoken"; value = $ValueA; domain = "tenant.omada.cloud"
+                    path = "/"; expires = $null; httpOnly = $true; secure = $true; sameSite = "Lax"
+                }
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $Cookie | Out-Null
+                Import-OmadaCookieFile -Path $PathA
+            }
+
+            $ReadBack.value | Should -BeExactly $Awkward
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should answer "no cookie" for a file that is not there' {
+        $Path = New-CookieFilePath
+        InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+            Import-OmadaCookieFile -Path $PathA
+        } | Should -BeNullOrEmpty
+    }
+
+    It 'should answer "no cookie" for a corrupt file rather than throwing' {
+        $Path = New-CookieFilePath
+        try {
+            Set-Content -Path $Path -Value "this is not clixml at all" -Encoding UTF8
+
+            $Result = $null
+            { $Result = InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+                    Import-OmadaCookieFile -Path $PathA
+                } } | Should -Not -Throw
+            $Result | Should -BeNullOrEmpty
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should answer "no cookie" for a truncated protected file' {
+        $Path = New-CookieFilePath
+        try {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA | Out-Null
+            }
+            $Text = Get-Content -Path $Path -Raw
+            Set-Content -Path $Path -Value $Text.Substring(0, [int]($Text.Length / 2)) -NoNewline
+
+            $Result = $null
+            { $Result = InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+                    Import-OmadaCookieFile -Path $PathA
+                } } | Should -Not -Throw
+            $Result | Should -BeNullOrEmpty
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should refuse an unprotected file written by a version that predates issue #21' {
+        # The old -CookiePath format: a bare Clixml of the cookie object, with the token readable.
+        # It is deliberately not migrated - reading it would be reading the very format this
+        # change set out to stop producing.
+        $Path = New-CookieFilePath
+        try {
+            [PSCustomObject]@{ OmadaWebAuthCookie = $Script:SampleCookie } | Export-Clixml -Path $Path -Force
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+                Import-OmadaCookieFile -Path $PathA
+            } | Should -BeNullOrEmpty
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should refuse a same-named file that is some other SecureString entirely' {
+        # Test-OmadaCookieCacheFile accepts the shape, and the payload then fails to deserialize.
+        # Either way the answer has to be "no cookie", not a half-built object.
+        $Path = New-CookieFilePath
+        try {
+            ConvertTo-SecureString -String "not a serialized cookie" -AsPlainText -Force | Export-Clixml -Path $Path -Force
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+                Import-OmadaCookieFile -Path $PathA
+            } | Should -BeNullOrEmpty
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+Describe 'Omada cookie cache - Test-OmadaCookieCacheFile' -Tag 'Unit' {
+
+    It 'should recognise a file the write path produced' {
+        $Path = New-CookieFilePath
+        try {
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
+                Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA | Out-Null
+                Test-OmadaCookieCacheFile -Path $PathA
+            } | Should -Be $true
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should reject an unrelated Clixml file that happens to share the name' {
+        $Path = New-CookieFilePath
+        try {
+            [PSCustomObject]@{ Something = "else" } | Export-Clixml -Path $Path -Force
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+                Test-OmadaCookieCacheFile -Path $PathA
+            } | Should -Be $false
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'should reject a file that is not XML at all' {
+        $Path = New-CookieFilePath
+        try {
+            Set-Content -Path $Path -Value "plain text" -Encoding UTF8
+
+            InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path } {
+                Test-OmadaCookieCacheFile -Path $PathA
+            } | Should -Be $false
+        }
+        finally { Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue }
+    }
+}

--- a/Tests/Unit/OmadaCookieCache.Tests.ps1
+++ b/Tests/Unit/OmadaCookieCache.Tests.ps1
@@ -103,10 +103,16 @@ Describe 'Omada cookie cache - write path' -Tag 'Unit' {
         # take the caller's request down with it.
         $Path = Join-Path ([System.IO.Path]::GetTempPath()) ("omadaCookieNoSuchFolder_{0}\x.cookie" -f ([guid]::NewGuid().ToString("N")))
 
+        $Warnings = $null
         $Result = InModuleScope 'OmadaWeb.PS' -Parameters @{ PathA = $Path; CookieA = $Script:SampleCookie } {
-            Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA -WarningAction SilentlyContinue
-        }
+            Export-OmadaCookieFile -Path $PathA -AuthCookie $CookieA
+        } -WarningVariable Warnings
+
         $Result | Should -Be $false
+        # The warning is half the contract: without it the cookie silently stops being cached and
+        # every later call pays for a sign-in with nothing said about why.
+        $Warnings | Should -Not -BeNullOrEmpty
+        ($Warnings -join " ") | Should -Match "Unable to write the cookie file"
     }
 
     It 'should accept a null cookie without throwing' {


### PR DESCRIPTION
Part 2 of 2 for `Fortigi/OmadaSqlTroubleshooter#46` ("[Roadmap E3] Close the highest-value test gaps"), which is filed against the other repository but names OmadaWeb.PS explicitly in one of its acceptance criteria:

> OmadaWeb.PS: unit tests for 401-retry recursion (including retry-loop termination) and cookie cache read/write

The companion PR is `Fortigi/OmadaSqlTroubleshooter#104`.

## What was missing — and what writing the test found

Neither seam had a test. The 401 retry is the path every expired session takes, and the cookie cache holds a bearer token on disk; they are the two places in this module where a quiet mistake costs the most.

Writing the *termination* test turned up the fact that **there was no termination**. On a 401, `Invoke-OmadaRequest` clears the cookie, re-authenticates and calls itself — and nothing counted those turns. `Get-DataFromWebView2.ps1:29` and `Get-DataFromWebDriver.ps1` each cap the sign-in windows they open, but both reset that counter on entry, so every recursion started it over.

Measured before the fix, against a local listener answering 401 to everything and a sign-in stubbed to succeed:

```
PROBE: re-authentication #1 ... #12
RESULT: terminated with: PROBE ABORT: reached 12 re-authentications, nothing is bounding this recursion
Re-authentications: 12     HTTP requests served: 12
```

Only the probe's own abort stopped it. In production, a server that answers 401 to a cookie the browser keeps handing back recursed until the call stack ran out, opening another sign-in window every turn.

## What changed

| File | Change |
|---|---|
| `OmadaWeb.PS/Private/Invoke-OmadaRequest.ps1` | Count re-authentications on the session, refuse past `$Script:MaxLoginRetries`, clear the count on the first successful response. |
| `OmadaWeb.PS/Private/Get-OmadaSessionContext.ps1` | New `ReAuthenticationCount` field, with a note on why `LoginRetryCount` cannot do this job. |
| `Tests/Integration/Invoke-OmadaRequest.ReAuth.Tests.ps1` | 13 tests (new). |
| `Tests/Unit/OmadaCookieCache.Tests.ps1` | 16 tests (new). |
| `CONTRIBUTING.md` | The regression-test rule, test layout, how to run and validate (new). |

After the fix, the same probe: one initial sign-in, three re-authentications, then

```
Re-authentication for 'http://localhost:21572' was attempted 3 time(s) and the server still answered HTTP 401. Giving up instead of signing in again.
```

## Acceptance criteria (the OmadaWeb.PS half of #46)

- [x] **Unit tests for 401-retry recursion, including retry-loop termination** — `Tests/Integration/Invoke-OmadaRequest.ReAuth.Tests.ps1`: one 401 then success retried exactly once; the rejected cookie cleared *before* the new sign-in starts (observed during the sign-in, not after); the encrypted cache deleted; `-CookiePath` written before the recursive call, so the retry cannot reload the cookie that caused the 401; **termination** after exactly `MaxLoginRetries` attempts, with the message naming the count and the tenant, and the budget restored afterwards so a later call is not refused; a 502 re-probing the environment without signing in again; a 500 surfaced without re-authenticating; `-NoInteractiveAuthentication` refusing rather than prompting.
- [x] **Unit tests for cookie cache read/write** — `Tests/Unit/OmadaCookieCache.Tests.ps1`: the real round trip through `Export-OmadaCookieFile` → `Import-OmadaCookieFile`; the token appearing nowhere in the file's raw bytes in either UTF-8 or UTF-16; a value full of XML metacharacters surviving; an overwrite; a write to a missing folder warning and returning `$false` rather than throwing; and a corrupt, truncated, foreign, or pre-issue-#21 unprotected file each answering "no cookie" rather than throwing or half-decoding.

## Decisions worth reviewing

1. **This PR changes behaviour, which a test-coverage PR normally would not.** The criterion asks for a *termination* test, and there was no termination to test. The options were to write a test that documents unbounded recursion, or to add the bound. I added the bound — an unbounded recursion that opens a browser window per turn is a defect, not a design — but it is the one judgement call here that deserves a second opinion.

2. **`MaxLoginRetries` (3) reused rather than a new setting.** It already means "how many times do we try to sign in before giving up". A second, separate knob for almost the same question seemed worse than reusing this one. It does mean the effective budget is 3 sign-in windows *within* a call and 3 re-authentications *across* the recursion.

3. **The count is cleared on the first successful response, not per call.** The session context is long-lived and keyed by tenant/auth-type/identity. Without the reset, a session that had once needed three re-authentications would eventually refuse a legitimate one. With it, the budget is per run of consecutive failures, which is what it is for.

4. **Giving up raises `New-OmadaSessionExpiredError`**, the same error `-NoInteractiveAuthentication` already raises for a 401 it will not act on, carrying the last 401 as the inner exception so the server's own explanation survives. A new exception type would have given callers a second thing to catch for the same situation.

5. **The retry tests bring their own `HttpListener`** rather than using `Tests/Integration/Start-WebServer.ps1`, which always answers 200 and so cannot express the case under test. It runs in-process on its own runspace, is steered through a synchronized hashtable, and counts the requests that actually arrived. Its readiness probe deliberately resets the counter afterwards, because the shared harness's probe would otherwise count a request of its own against the assertions.

6. **Only the browser is mocked.** `Get-DataFromWebView2` stands in for a completed sign-in; the request, the 401, the catch handler and the recursion are all the real code path. Mocking `Invoke-RestMethod` was not an option — `Invoke-OmadaRequest` resolves it through `Get-Command -FullyQualifiedModule` and invokes the `CommandInfo` directly, which walks straight past a Pester mock.

## Verification

```
Invoke-Pester -Path Tests/Integration/Invoke-OmadaRequest.ReAuth.Tests.ps1
Tests Passed: 13, Failed: 0, Skipped: 0

Invoke-Pester -Path Tests/Unit/OmadaCookieCache.Tests.ps1
Tests Passed: 16, Failed: 0, Skipped: 0

Invoke-Pester -Path Tests/Unit          # the whole unit suite
Passed: 815  Failed: 1  Skipped: 8
```

The single failure is **pre-existing and unrelated**: `Export-OmadaCookieFile / Import-OmadaCookieFile — Should release the unmanaged decryption buffer on both the success and the failure path`. Confirmed by running that file alone in a clean worktree at `origin/main` and on this branch — 11 passed / 1 failed in both. It is not touched by this PR, and I have left it alone rather than widening scope; happy to look at it separately if you want.

**The full `TestBuildOnly` task could not be run locally.** It reaches the Selenium/WebDriver integration tests, which open a real Edge window and wait for a human to sign in — `$env:GITHUB_ACTIONS` only suppresses the WebView2 path, not the WebDriver one. It sat at "Browser opened, please login!" until killed. CI is the evidence for the full suite, so `/validate` is the gate here rather than a local run.
