### PR TITLE
Give the two watched canary sign-ins a thread WebView2 can live on

### DIFF
--- a/OmadaWeb.PS/Private/Start-WebView2Login.ps1
+++ b/OmadaWeb.PS/Private/Start-WebView2Login.ps1
@@ -28,6 +28,21 @@ function Start-WebView2Login {
             $OriginalTreatControlCAsInput = [Console]::TreatControlCAsInput
         }
 
+        # Asked before anything is built, and answered plainly. WebView2 is COM that needs a
+        # single-threaded apartment: on an MTA thread the WinForms objects below are all created
+        # happily and then CoreWebView2Environment::CreateAsync comes back with "Cannot change thread
+        # mode after it is set", which reads as a COM fault rather than as "this host cannot show a
+        # window". Both fallbacks fail the same way, so the trace showed two attempts and no reason,
+        # and the sign-in canary reported the missing browser as a changed Microsoft sign-in page
+        # (issue #90). Stopping here says which host is the problem and what to do instead.
+        #
+        # $Script:StopError, because retrying is pointless: a thread's apartment cannot be changed
+        # once it is set, so the next of the three login attempts would fail identically.
+        if (-not (Test-OmadaStaThread)) {
+            $Script:StopError = $true
+            "{0} - WebView2 needs a single-threaded apartment (STA), and this host is multi-threaded (MTA), so no browser window can be created here. A PowerShell background job and any runspace created without ApartmentState.STA are MTA. Start the host with -STA, run the sign-in in its own STA process, or use -AuthenticationType Selenium." -f $MyInvocation.MyCommand | Write-Error -ErrorAction Stop
+        }
+
         [System.Windows.Forms.Application]::EnableVisualStyles()
         $Script:WinForm = New-Object System.Windows.Forms.Form
         [Microsoft.Web.WebView2.WinForms.WebView2] $Script:WebView2 = New-Object Microsoft.Web.WebView2.WinForms.WebView2
@@ -277,7 +292,11 @@ function Start-WebView2Login {
 
     }
     catch {
-        "{0} - Error occurred" -f $MyInvocation.MyCommand | Write-Verbose
+        # The reason travels with the trace, not only with the terminating error. A caller that
+        # captures the verbose stream - a scheduled task, a CI job, the sign-in canary - sees only
+        # what is written here, and "Error occurred" on its own sent issue #90 looking for a changed
+        # Microsoft sign-in page that had nothing to do with it.
+        "{0} - Error occurred: {1}" -f $MyInvocation.MyCommand, $PSItem.Exception.Message | Write-Verbose
         try {
             "{0} - Reset-Timer" -f $MyInvocation.MyCommand | Write-Verbose
             Reset-Timer
@@ -295,7 +314,7 @@ function Start-WebView2Login {
             }
         }
         catch {}
-        Write-Host "Error in Start-WebView2Login" -ForegroundColor Red
+        Write-Host ("Error in Start-WebView2Login: {0}" -f $PSItem.Exception.Message) -ForegroundColor Red
         $PSCmdlet.ThrowTerminatingError($PSItem)
     }
 }

--- a/OmadaWeb.PS/Private/Start-WebView2Login.ps1
+++ b/OmadaWeb.PS/Private/Start-WebView2Login.ps1
@@ -296,7 +296,13 @@ function Start-WebView2Login {
         # captures the verbose stream - a scheduled task, a CI job, the sign-in canary - sees only
         # what is written here, and "Error occurred" on its own sent issue #90 looking for a changed
         # Microsoft sign-in page that had nothing to do with it.
-        "{0} - Error occurred: {1}" -f $MyInvocation.MyCommand, $PSItem.Exception.Message | Write-Verbose
+        #
+        # Read once and redacted once. A failure this deep in a sign-in can quote the request it fell
+        # over on, and an authorization request carries an account name in its query string, so the
+        # message goes through Protect-LogMessage like every other logged exception message in the
+        # module - and both the trace and the console line below say the same redacted thing.
+        $SafeErrorMessage = Protect-LogMessage -Message $PSItem.Exception.Message
+        "{0} - Error occurred: {1}" -f $MyInvocation.MyCommand, $SafeErrorMessage | Write-Verbose
         try {
             "{0} - Reset-Timer" -f $MyInvocation.MyCommand | Write-Verbose
             Reset-Timer
@@ -314,7 +320,7 @@ function Start-WebView2Login {
             }
         }
         catch {}
-        Write-Host ("Error in Start-WebView2Login: {0}" -f $PSItem.Exception.Message) -ForegroundColor Red
+        Write-Host ("Error in Start-WebView2Login: {0}" -f $SafeErrorMessage) -ForegroundColor Red
         $PSCmdlet.ThrowTerminatingError($PSItem)
     }
 }

--- a/OmadaWeb.PS/Private/Test-OmadaStaThread.ps1
+++ b/OmadaWeb.PS/Private/Test-OmadaStaThread.ps1
@@ -1,0 +1,44 @@
+function Test-OmadaStaThread {
+    <#
+    .SYNOPSIS
+        Whether this thread can host a WebView2 browser window.
+
+    .DESCRIPTION
+        WebView2 is COM underneath, and the apartment it needs is the single-threaded one. On a
+        multi-threaded apartment the very first call into it - CoreWebView2Environment::CreateAsync -
+        comes straight back with
+
+            Cannot change thread mode after it is set. (0x80010106 (RPC_E_CHANGED_MODE))
+
+        That is not an exotic state either. A PowerShell console is STA on Windows, but a background
+        job is not: Start-Job runs its script in a runspace whose thread is MTA, and so does any
+        runspace created without ApartmentState.STA. The sign-in then fails before a window has been
+        created, with a message about thread modes and nothing about signing in - the same shape of
+        failure the console-handle bug had (issue #79), and found the same way, by the scheduled
+        canary reporting it as a changed Microsoft sign-in page when it was nothing of the kind
+        (issue #90).
+
+        Only MTA is refused. STA is what the browser needs, and Unknown is what a thread that has not
+        yet initialized COM reports - it is free to become STA on the first call, which is exactly
+        what the WebView2 call itself will do. Refusing it would fail sign-ins that work today.
+
+    .OUTPUTS
+        System.Boolean. False only when this thread is a multi-threaded apartment.
+
+    .EXAMPLE
+        if (-not (Test-OmadaStaThread)) { throw "WebView2 cannot be hosted here" }
+
+        The shape the caller uses: the apartment is asked about before the browser is reached for.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param()
+
+    $ApartmentState = [System.Threading.Thread]::CurrentThread.GetApartmentState()
+    if ($ApartmentState -eq [System.Threading.ApartmentState]::MTA) {
+        "{0} - This thread is a multi-threaded apartment, which cannot host a WebView2 browser." -f $MyInvocation.MyCommand | Write-Verbose
+        return $false
+    }
+
+    return $true
+}

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -233,9 +233,12 @@ Describe 'Entra ID sign-in canary' -Tag 'E2E' -Skip:(-not $Script:RunPasswordSce
 # Entra ID. It is the one arrangement where "the sign-in did not complete" is the correct outcome,
 # and where a module that quietly submitted an empty password instead would look like a success.
 #
-# So the sign-in runs in a background job and is watched rather than awaited. The job is a separate
-# process, which is what makes it stoppable: the WinForms dialog blocks the thread it is shown on, so
-# nothing inside that process can be interrupted once the window is up. The observation window is
+# So the sign-in runs in a child process started -STA and is watched rather than awaited. Out of
+# process is what makes it stoppable: the WinForms dialog blocks the thread it is shown on, so nothing
+# inside that process can be interrupted once the window is up. -STA is what makes it work at all: a
+# background job is out of process too, but its runspace thread is MTA, and WebView2 cannot be created
+# there - see the comment on the launch below and Tests/E2E/Start-WatchedSignIn.ps1. The observation
+# window is
 # fixed rather than cut short at the first marker, because the last thing these check - the handover
 # that says the sign-in is waiting for you - only happens after the module has seen no progress for
 # $Script:LoginAutomationFallbackTimeout seconds.
@@ -259,57 +262,63 @@ Describe 'Entra ID sign-in canary - a sign-in that waits for the user' -Tag 'E2E
 
         $UserNameForScenario = if ($Scenario -eq 'UserNameOnly') { $Env:OMADAWEBPS_CANARY_USERNAME } else { '' }
 
-        $SignIn = Start-Job -ScriptBlock {
-            param($ModulePath, $ResourceUrl, $UserName)
+        # A separate process, started -STA, rather than a background job.
+        #
+        # Out of process is what makes this stoppable at all: the WinForms dialog blocks the thread it
+        # is shown on, so nothing inside the process showing it can be interrupted once the window is
+        # up. A background job is out of process too - but its runspace thread is MTA, and WebView2 is
+        # COM that needs a single-threaded apartment. CoreWebView2Environment::CreateAsync came back
+        # with "Cannot change thread mode after it is set (RPC_E_CHANGED_MODE)", no browser was ever
+        # created, and every assertion below failed because the sign-in had not happened - which the
+        # canary duly reported as a changed Microsoft sign-in page (issue #90). PasswordAutofill was
+        # green throughout, because it runs in the Pester host, which is STA.
+        #
+        # The same host this runs in, so a 5.1 leg would drive 5.1 rather than silently swapping hosts.
+        $WatchedSignInLogFolder = if ([string]::IsNullOrWhiteSpace($Env:RUNNER_TEMP)) { [System.IO.Path]::GetTempPath() } else { $Env:RUNNER_TEMP }
+        $Script:WatchedSignInOutputPath = Join-Path $WatchedSignInLogFolder ("canary-watched-{0}-{1}.log" -f $Scenario, [guid]::NewGuid().ToString("N"))
+        $Script:WatchedSignInErrorPath = [System.IO.Path]::ChangeExtension($Script:WatchedSignInOutputPath, ".err.log")
 
-            $VerbosePreference = 'Continue'
-            Import-Module $ModulePath -Force -ErrorAction Stop
+        $WatchedSignInArgument = [System.Collections.Generic.List[string]]::new()
+        $WatchedSignInArgument.AddRange([string[]]@(
+                "-STA", "-NoLogo", "-NoProfile",
+                "-File", ('"{0}"' -f (Join-Path $PSScriptRoot 'Start-WatchedSignIn.ps1')),
+                "-ModulePath", ('"{0}"' -f $ModulePath),
+                "-ResourceUrl", ('"{0}"' -f $Script:RelyingParty.ResourceUrl)
+            ))
 
-            $Parameter = @{
-                Uri                = $ResourceUrl
-                AuthenticationType = 'WebView2'
-                SkipCookieCache    = $true
-            }
-
-            # PowerShell 7 refuses to send a credential over an unencrypted connection without being
-            # told to, and the stand-in serves plain HTTP on loopback. Guarded by version because the
-            # parameter does not exist on Windows PowerShell 5.1.
-            if ($PSVersionTable.PSVersion.Major -ge 6) {
-                $Parameter['AllowUnencryptedAuthentication'] = $true
-            }
-
-            if (-not [string]::IsNullOrWhiteSpace($UserName)) {
-                $Parameter['UserName'] = $UserName
-            }
-
-            # Every stream, as strings, as they are produced. The verbose trace is the product here:
-            # what is being asserted is which decisions the module took on a page it could read
-            # perfectly well, and those are only ever reported there.
-            Invoke-OmadaWebRequest @Parameter -Verbose *>&1 | ForEach-Object { $_.ToString() }
-        } -ArgumentList $ModulePath, $Script:RelyingParty.ResourceUrl, $UserNameForScenario
-
-        $Deadline = [DateTime]::Now.AddSeconds($ObservationSeconds)
-        $Captured = [System.Collections.Generic.List[string]]::new()
-
-        while ([DateTime]::Now -lt $Deadline -and $SignIn.State -eq 'Running') {
-            foreach ($Record in @(Receive-Job -Job $SignIn -ErrorAction SilentlyContinue)) {
-                $Captured.Add([string]$Record)
-            }
-            Start-Sleep -Milliseconds 500
+        # Left off entirely rather than passed as an empty string: an empty argument through a command
+        # line is the one value that does not survive the trip intact, and "no account was named" is
+        # precisely what the NoUserName scenario asserts about.
+        if (-not [string]::IsNullOrWhiteSpace($UserNameForScenario)) {
+            $WatchedSignInArgument.AddRange([string[]]@("-UserName", ('"{0}"' -f $UserNameForScenario)))
         }
 
-        # Stopped, then drained: a job that buffered rather than streamed still hands over everything
-        # it wrote, so the assertions below never depend on how promptly a record crossed the process
-        # boundary.
-        Stop-Job -Job $SignIn -ErrorAction SilentlyContinue
-        foreach ($Record in @(Receive-Job -Job $SignIn -ErrorAction SilentlyContinue)) {
-            $Captured.Add([string]$Record)
+        # Captured to a file rather than read from a pipe. The process is killed at the deadline, and
+        # a trace that only existed in a pipe nobody drained would go with it - which is the same
+        # reason the workflow redirects each attempt to a file.
+        $SignIn = Start-Process -FilePath (Get-Process -Id $PID).Path -ArgumentList $WatchedSignInArgument.ToArray() `
+            -RedirectStandardOutput $Script:WatchedSignInOutputPath -RedirectStandardError $Script:WatchedSignInErrorPath `
+            -NoNewWindow -PassThru
+
+        if (-not $SignIn.WaitForExit($ObservationSeconds * 1000)) {
+            # Expected, not a failure: these two sign-ins are meant to still be waiting. The window is
+            # open for a person who is not there, and the observation window has simply run out.
+            try { $SignIn.Kill($true) } catch { "Could not stop the watched sign-in cleanly: {0}" -f $_.Exception.Message | Write-Host }
         }
-        Remove-Job -Job $SignIn -Force -ErrorAction SilentlyContinue
 
         # The browser belongs to a process that has just been killed, and the next attempt must not
         # inherit one that is still holding the profile.
         Get-Process -Name msedgewebview2 -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+        # Read after the kill, so a trace written up to the last moment is still read in full. Both
+        # streams, because a failure that reached the error stream is as much a part of what happened
+        # as the verbose trace is.
+        $Captured = [System.Collections.Generic.List[string]]::new()
+        foreach ($Path in @($Script:WatchedSignInOutputPath, $Script:WatchedSignInErrorPath)) {
+            foreach ($Line in @(Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue)) {
+                $Captured.Add([string]$Line)
+            }
+        }
 
         $Script:Trace = $Captured -join [System.Environment]::NewLine
 
@@ -325,6 +334,11 @@ Describe 'Entra ID sign-in canary - a sign-in that waits for the user' -Tag 'E2E
 
     AfterAll {
         Stop-CanaryRelyingParty -RelyingParty $Script:RelyingParty
+
+        # The trace has been read and echoed into the job log by now, so what is left on disk is a
+        # copy of it. Removed because it is a sign-in trace, and a runner's temp folder is not where
+        # one should be left lying about.
+        Remove-Item -LiteralPath $Script:WatchedSignInOutputPath, $Script:WatchedSignInErrorPath -Force -ErrorAction SilentlyContinue
     }
 
     It 'Put the account into the sign-in request' -Skip:($Scenario -ne 'UserNameOnly') {

--- a/Tests/E2E/EntraSignInCanary.Tests.ps1
+++ b/Tests/E2E/EntraSignInCanary.Tests.ps1
@@ -338,7 +338,16 @@ Describe 'Entra ID sign-in canary - a sign-in that waits for the user' -Tag 'E2E
         # The trace has been read and echoed into the job log by now, so what is left on disk is a
         # copy of it. Removed because it is a sign-in trace, and a runner's temp folder is not where
         # one should be left lying about.
-        Remove-Item -LiteralPath $Script:WatchedSignInOutputPath, $Script:WatchedSignInErrorPath -Force -ErrorAction SilentlyContinue
+        #
+        # Each path is tested before it is passed. A BeforeAll that died before assigning them would
+        # otherwise turn this into a parameter-binding failure on a null LiteralPath - which
+        # -ErrorAction cannot suppress, and which would be reported in place of whatever actually
+        # went wrong.
+        foreach ($Path in @($Script:WatchedSignInOutputPath, $Script:WatchedSignInErrorPath)) {
+            if (-not [string]::IsNullOrWhiteSpace($Path)) {
+                Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+            }
+        }
     }
 
     It 'Put the account into the sign-in request' -Skip:($Scenario -ne 'UserNameOnly') {

--- a/Tests/E2E/Start-WatchedSignIn.ps1
+++ b/Tests/E2E/Start-WatchedSignIn.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+    Drives one of the canary sign-ins that is not meant to finish, and writes everything the module
+    traced to standard output.
+.DESCRIPTION
+    The two watched scenarios - a user name with no password, and neither - end with a browser window
+    waiting for a person who does not exist on a runner. Nothing inside the process that shows that
+    window can interrupt it: the WinForms dialog blocks the thread it is shown on. So the sign-in is
+    run out of process and killed from outside, and this script is what that process runs.
+
+    It exists as a file, rather than as the script block of a background job, because of the apartment.
+    WebView2 is COM and needs a single-threaded apartment; Start-Job runs its script in a runspace
+    whose thread is MTA, so CoreWebView2Environment::CreateAsync came straight back with
+    "Cannot change thread mode after it is set (RPC_E_CHANGED_MODE)" and the browser was never
+    created. Every assertion in the two watched scenarios then failed for the same reason, and the
+    canary reported it as a changed Microsoft sign-in page - issue #90. A child process started with
+    -STA is a host the browser can actually live in, and it is still a separate process, which is what
+    made a background job the right shape in the first place.
+
+    Nothing is redacted here beyond what the module already does: Protect-LogMessage covers its own
+    streams, and the workflow masks the four canary secrets before this runs.
+.PARAMETER ModulePath
+    The built OmadaWeb.PS.psm1 to sign in with.
+.PARAMETER ResourceUrl
+    The loopback stand-in's protected resource, from Tests/E2E/Start-CanaryRelyingParty.ps1.
+.PARAMETER UserName
+    The account to name on the call, or empty for the scenario that names none. Empty is a scenario
+    rather than an oversight: what it proves is that the module adds nothing to the request.
+.EXAMPLE
+    pwsh -STA -NoLogo -NoProfile -File ./Tests/E2E/Start-WatchedSignIn.ps1 `
+        -ModulePath ./buildoutput/OmadaWeb.PS/OmadaWeb.PS.psm1 -ResourceUrl http://localhost:8400/resource
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ModulePath,
+
+    [Parameter(Mandatory)]
+    [string]$ResourceUrl,
+
+    [AllowEmptyString()]
+    [string]$UserName = ''
+)
+
+$VerbosePreference = 'Continue'
+
+# Said out loud, and first. If this ever reads MTA again the trace says so on line one, instead of
+# leaving a reader to work backwards from a COM error code.
+"Start-WatchedSignIn - Apartment state: {0}" -f [System.Threading.Thread]::CurrentThread.GetApartmentState() | Write-Host
+
+Import-Module $ModulePath -Force -ErrorAction Stop
+
+$Parameter = @{
+    Uri                = $ResourceUrl
+    AuthenticationType = 'WebView2'
+    SkipCookieCache    = $true
+}
+
+# PowerShell 7 refuses to send a credential over an unencrypted connection without being told to, and
+# the stand-in serves plain HTTP on loopback. Guarded by version because the parameter does not exist
+# on Windows PowerShell 5.1.
+if ($PSVersionTable.PSVersion.Major -ge 6) {
+    $Parameter['AllowUnencryptedAuthentication'] = $true
+}
+
+if (-not [string]::IsNullOrWhiteSpace($UserName)) {
+    $Parameter['UserName'] = $UserName
+}
+
+# Every stream, as strings, as they are produced. The verbose trace is the product here: what is being
+# asserted is which decisions the module took on a page it could read perfectly well, and those are
+# only ever reported there.
+Invoke-OmadaWebRequest @Parameter -Verbose *>&1 | ForEach-Object { $_.ToString() | Write-Host }

--- a/Tests/Unit/Test-OmadaStaThread.Tests.ps1
+++ b/Tests/Unit/Test-OmadaStaThread.Tests.ps1
@@ -1,0 +1,97 @@
+param(
+    [string]$ModulePath = (Join-Path $(Split-Path $(Split-Path $PSScriptRoot)) -ChildPath 'OmadaWeb.PS\OmadaWeb.PS.psm1')
+)
+
+BeforeAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    # A multi-threaded apartment, built rather than hoped for. A thread's apartment cannot be changed
+    # once it is set, so the MTA half of this cannot be asserted in the Pester host - which is STA,
+    # and is the very reason the PasswordAutofill canary scenario kept passing while the two that ran
+    # in a background job did not. Start-Job is the shortest route to a real MTA runspace, and it is
+    # also the exact host that issue #90 was about.
+    function Invoke-InMultiThreadedApartment {
+        param(
+            [Parameter(Mandatory)]
+            [scriptblock]$Body
+        )
+
+        $Job = Start-Job -ScriptBlock {
+            param($ModulePath, $Body)
+
+            $Module = Import-Module $ModulePath -Force -PassThru -WarningAction SilentlyContinue -ErrorAction Stop
+            & $Module ([scriptblock]::Create($Body))
+        } -ArgumentList $ModulePath, $Body.ToString()
+
+        try {
+            $null = $Job | Wait-Job -Timeout 120
+            return @(Receive-Job -Job $Job -ErrorAction SilentlyContinue)
+        }
+        finally {
+            Remove-Job -Job $Job -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+AfterAll {
+    Get-Module OmadaWeb.PS | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+}
+
+Describe 'Test-OmadaStaThread' -Tag 'Unit' {
+
+    It 'Answers with a boolean' {
+        $Result = InModuleScope 'OmadaWeb.PS' { Test-OmadaStaThread }
+
+        $Result | Should -BeOfType [System.Boolean]
+    }
+
+    It 'Agrees with the apartment the thread is actually in' {
+        # Not a tautology: it asserts the predicate reports the same thing the WebView2 call a moment
+        # later will experience. Anything that answered from somewhere else - a cached value, a host
+        # name, a version check - could disagree with the thread, and that disagreement is the bug.
+        $Expected = [System.Threading.Thread]::CurrentThread.GetApartmentState() -ne [System.Threading.ApartmentState]::MTA
+
+        InModuleScope 'OmadaWeb.PS' { Test-OmadaStaThread } | Should -Be $Expected
+    }
+
+    It 'Reports false on a multi-threaded apartment' {
+        # The regression test for issue #90. A background job is MTA, and this is the answer that
+        # stops a sign-in there before it reaches WebView2 and fails with a COM error code instead.
+        $Result = Invoke-InMultiThreadedApartment -Body { Test-OmadaStaThread }
+
+        @($Result)[-1] | Should -BeFalse
+    }
+
+    It 'Is asked about the apartment that was the problem in the first place' {
+        # Guards the guard: if a future PowerShell ran jobs on an STA thread, the test above would
+        # pass for the wrong reason - the predicate returning true and the assertion still reading
+        # false off something else. This is what says the job really was MTA.
+        $Result = Invoke-InMultiThreadedApartment -Body { [System.Threading.Thread]::CurrentThread.GetApartmentState().ToString() }
+
+        @($Result)[-1] | Should -Be 'MTA'
+    }
+}
+
+Describe 'Start-WebView2Login on a multi-threaded apartment' -Tag 'Unit' {
+
+    It 'Says the apartment is the problem instead of failing on a COM error code' {
+        # What the canary trace showed before this: two attempts at CoreWebView2Environment, then
+        # "Error occurred" and nothing else - no reason anywhere in the verbose stream, which is the
+        # only stream a scheduled run captures. Issue #90 was filed guessing at a changed Microsoft
+        # sign-in page as a result.
+        #
+        # Called with no session context, so it fails either way. What is asserted is *which* failure,
+        # and that the reason is in the message rather than left to be inferred.
+        $Result = Invoke-InMultiThreadedApartment -Body {
+            try {
+                Start-WebView2Login -EdgeProfile "Default"
+            }
+            catch {
+                "CAUGHT: {0}" -f $_.Exception.Message
+            }
+        }
+
+        ($Result -join [System.Environment]::NewLine) | Should -Match 'single-threaded apartment'
+    }
+}

--- a/docs/entra-canary.md
+++ b/docs/entra-canary.md
@@ -30,12 +30,15 @@ browser window, and two of them are sign-ins that deliberately never finish.
 | `UserNameOnly` | a user name, no password | the account reaches Entra **inside the authorization request** (`login_hint`), the password page is reached, no empty password is submitted, and the window is handed back saying it is waiting for you |
 | `NoUserName` | neither | nothing is added to the request and nothing is driven at all — the default has to stay indistinguishable from the module not being involved in the choice |
 
-The last two never complete, so they are watched rather than awaited: the sign-in runs in a
-background job for a fixed 135 seconds — long enough for the redirect chain, the sign-in page, and
-the 60 seconds of no progress that ends in the handover — and is then stopped from inside the test,
-which asserts against everything the module traced. A separate process is what makes that possible at
-all: the WinForms dialog blocks the thread it is shown on, so nothing inside that process can be
-interrupted once the window is up.
+The last two never complete, so they are watched rather than awaited: the sign-in runs in a child
+process for a fixed 135 seconds — long enough for the redirect chain, the sign-in page, and the 60
+seconds of no progress that ends in the handover — and is then stopped from inside the test, which
+asserts against everything the module traced. A separate process is what makes that possible at all:
+the WinForms dialog blocks the thread it is shown on, so nothing inside that process can be
+interrupted once the window is up. That process is started `-STA`, because WebView2 is COM and cannot
+be created on a multi-threaded apartment — which is what a PowerShell background job is, and why
+these two scenarios failed on their first scheduled run
+([#90](https://github.com/Fortigi/OmadaWeb.PS/issues/90)).
 
 `UserNameOnly` and `NoUserName` are given an authorization request carrying **no** `prompt` and **no**
 `login_hint`. For the first that is the point — whatever reaches Entra must have been put there by
@@ -246,6 +249,15 @@ through a second literal replacement of all four values, because that text is ab
      that was revoked.
    - *"Actually travelled through Entra and back"* failed → the browser never reached Entra. Look at
      the runner and the listener, not at the selector table.
+   - The trace stops at *"Failed to start CoreWebView2Environment"* → no browser was ever created, so
+     nothing downstream of it ran and every assertion in that scenario failed for the one reason.
+     Read the line after it: since [#90](https://github.com/Fortigi/OmadaWeb.PS/issues/90)
+     `Start-WebView2Login` prints why. `Cannot change thread mode after it is set
+     (RPC_E_CHANGED_MODE)` means the sign-in was driven from a multi-threaded apartment — a
+     PowerShell background job, or a runspace created without `ApartmentState.STA` — which WebView2
+     cannot live in; the two watched scenarios are driven from a `-STA` child process for exactly
+     this reason, see `Tests/E2E/Start-WatchedSignIn.ps1`. Anything else there is the runner or the
+     WebView2 runtime, and the selector table is ruled out either way.
    - The **browser host check** failed instead, and no issue was filed → the runner could not open a
      window at all. Nothing about the sign-in page is implicated.
 3. **Fix a selector break** by updating `$Script:EntraSignInElementId` in


### PR DESCRIPTION
Closes #90

## The canary was right that something broke, and wrong about what

Run [34586982766](https://github.com/Fortigi/OmadaWeb.PS/actions/runs/34586982766): `PasswordAutofill`
6/6 green, `UserNameOnly` 1 passed / 4 failed, `NoUserName` 2 passed / 1 failed — both after the flake
retry. The alert said the sign-in page might have changed. It had not. Every failed assertion in both
scenarios is downstream of the same three lines:

```
Start-WebView2Login - Creating CoreWebView2Environment (single sign-on with the Windows account: False)...
Start-WebView2Login - Try to start CoreWebView2Environment using implicit configuration...
Start-WebView2Login - Failed to start CoreWebView2Environment using implicit configuration, now try explicit Edge WebView path: ''...
Start-WebView2Login - Error occurred
```

No browser was ever created, so the browser never reached Microsoft, so nothing the assertions look
for could be in the trace. The selector table is ruled out entirely.

## Root cause

The two watched scenarios were added in #89, merged 2026-09-10 20:36 UTC. The 2026-09-11 run is the
**first** scheduled run that contained them — they have never passed on CI.

Both are driven with `Start-Job` (`Tests/E2E/EntraSignInCanary.Tests.ps1:262` on main). A PowerShell
background job's runspace thread is **MTA**. WebView2 is COM and needs **STA**, so
`CoreWebView2Environment::CreateAsync` returns `RPC_E_CHANGED_MODE` — "cannot change thread mode after
it is set" — and both the implicit and the explicit fallback fail identically. `PasswordAutofill` was
green in the same run because it is driven in the Pester host, which is STA.

Reproduced rather than inferred:

| Host | Apartment | `CoreWebView2Environment::CreateAsync` |
|---|---|---|
| `Start-Job` child runspace | MTA | `Cannot change thread mode after it is set. (0x80010106 RPC_E_CHANGED_MODE)` |
| `pwsh -STA` child process | STA | `OK: 152.0.4191.66` |

## A second defect: the failure could not explain itself

`Start-WebView2Login`'s catch wrote `Error occurred` and `Error in Start-WebView2Login` and never
printed the exception message. The reason went only to the terminating error, and the verbose stream is
the only stream a scheduled run captures — which is why #90 was filed guessing at the one cause it
could not have been.

## What changed

| Change | Why |
|---|---|
| `Tests/E2E/Start-WatchedSignIn.ps1` (new) | The watched sign-in as a script, so it can be hosted in a process of its own |
| `Tests/E2E/EntraSignInCanary.Tests.ps1` | `Start-Job` → a `-STA` child process; trace captured to files and read after the kill |
| `OmadaWeb.PS/Private/Test-OmadaStaThread.ps1` (new) | Refuses MTA before anything is built; `STA` and `Unknown` pass |
| `OmadaWeb.PS/Private/Start-WebView2Login.ps1` | The guard, and the exception message in both the verbose trace and the red line |
| `Tests/Unit/Test-OmadaStaThread.Tests.ps1` (new) | 5 tests, including the regression: `Start-WebView2Login` in a real MTA job |
| `docs/entra-canary.md` | Response-guide entry for a trace that stops at `CoreWebView2Environment` |

Out of process was the right shape and stays — the WinForms dialog blocks the thread it is shown on, so
a sign-in waiting for a person who is not there can only be stopped from outside. Only the host changes.
The assertions are untouched.

## Decisions worth reviewing

- **The guard refuses only MTA, not "not STA".** `Unknown` is a thread that has not initialized COM
  yet and is free to become STA — which is exactly what the WebView2 call does itself. Refusing it
  would fail sign-ins that work today.
- **The guard sets `$Script:StopError`.** A thread's apartment cannot be changed once set, so the next
  of the three login attempts would fail identically. Retrying would only delay the message.
- **The module now refuses MTA rather than working around it.** Hosting the WinForms dialog on a
  spawned STA thread inside the module was the alternative. It is a much larger change to the sign-in
  path for a host nobody has asked for, and a clear refusal is strictly better than `RPC_E_CHANGED_MODE`.
- **The trace is read after the kill rather than streamed.** Same reasoning the workflow already
  applies to each attempt: a trace that only existed in a pipe nobody drained goes with the process.
- **`-UserName` is omitted rather than passed as `""`.** An empty argument is the one value that does
  not survive a command line intact, and "no account was named" is precisely what `NoUserName` asserts.
- **The exception message is now printed on every `Start-WebView2Login` failure.** `Protect-LogMessage`
  covers the module's streams and the workflow masks the four canary secrets, so this does not widen
  what is exposed — but it is a deliberate widening of what is *said*.

## Verification

**Direct proof of the fix** — the new launcher, run exactly as the test runs it, against the built
module:

```
Start-WatchedSignIn - Apartment state: STA
Start-WebView2Login - Creating CoreWebView2Environment (single sign-on with the Windows account: True)...
Start-WebView2Login - Try to start CoreWebView2Environment using implicit configuration...
Start-WebView2Login - Initializing WebView2 CoreWebView2...
Start-WebView2Login - Show WinForm Dialog
 - Navigating to http://localhost:8499
```

Created on the **first** attempt, no fallback, no error — the sequence that was missing from the canary
run.

**Build and analysis:** `./Build/build.ps1 -Task Build -BuildVersion '0.0.0'` — PSScriptAnalyzer clean,
package contents match the manifest (16 files).

**Unit suite**, this branch against `origin/main` in a second worktree, same host, same command:

| | Passed | Failed | Skipped |
|---|---|---|---|
| `bugfix/canary-webview2-sta-thread` | 804 | 1 | 8 |
| `origin/main` (5dfaa81) | 796 | 1 | 11 |

The one failure is identical on both and unrelated to this change
(`Export-OmadaCookieFile / Import-OmadaCookieFile.Should release the unmanaged decryption buffer on
both the success and the failure path`). The 3 extra skips on the baseline are the generated-manifest
tests, which only run where a `buildoutput` exists. +8 passed = the 5 new tests plus those 3.

**Not verified locally, and deliberately not claimed:** the Integration suite's Selenium
browser-authentication tests wait 310s for an interactive login and cannot pass on an unattended
machine; PR Validation covers them. And the canary workflow itself cannot be exercised from a branch —
it runs from the default branch and holds the `entra-canary` environment secrets. The real confirmation
is the next scheduled run after merge (05:43 UTC), or a `workflow_dispatch` on `main`.

## Acceptance

#90 carries no checklist; these are the criteria in its prose.

- [x] The failing scenario is explained and fixed rather than worked around — MTA/STA, reproduced both ways.
- [x] The selector table is confirmed untouched — the trace proves the browser never reached Microsoft.
- [x] The next failure of this class names its own cause in the trace — the guard's message and the
      exception message in the catch, covered by `Tests/Unit/Test-OmadaStaThread.Tests.ps1`.

## Related

- #89 introduced the two scenarios this fixes; nothing in it is reverted.
- #79 is the closed look-alike — same title, same label, different cause (the console handle, fixed in
  #81). Worth reading together: both were unattended-host defects that the canary reported as a changed
  sign-in page, which is what the `Start-WebView2Login` diagnostics here are meant to end.
- #32 (selector hardening) is untouched and still open.
- Open PRs #92 and #93 touch none of these files, so no conflict either way. #92 is worth a mention
  though: a worker runspace is MTA, and the guard added here is what a sign-in attempted from one
  would now say instead of `RPC_E_CHANGED_MODE` — complementary to #92, which avoids needing the
  browser there at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsKi2JF5j8jSSWj4w6BiGr
